### PR TITLE
ci(docs): 添加 mkdocs-static-i18n 依赖以支持文档国际化

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,5 +28,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-static-i18n
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
更新文档部署工作流，在安装 mkdocs-material 的同时安装 mkdocs-static-i18n 插件。此插件将为文档站点提供静态内容国际化支持，使多语言文档部署成为可能。