### PR TITLE
docs: 修正文档中绩效指标表的打印示例

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -132,8 +132,8 @@ print(f"Sharpe Ratio: {result.metrics.sharpe_ratio:.2f}")
 print(f"Max Drawdown: {result.metrics.max_drawdown_pct:.2f}%")
 
 # 5. Get Detailed Data (DataFrame)
-# Performance metrics table (transposed for readability)
-print(result.metrics_df.T)
+# Performance metrics table
+print(result.metrics_df)
 # Trade record table
 print(result.trades_df)
 # Daily position table

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -132,8 +132,8 @@ print(f"Sharpe Ratio: {result.metrics.sharpe_ratio:.2f}")
 print(f"Max Drawdown: {result.metrics.max_drawdown_pct:.2f}%")
 
 # 5. 获取详细数据 (DataFrame)
-# 绩效指标表 (使用 .T 转置为竖排显示，方便阅读)
-print(result.metrics_df.T)
+# 绩效指标表
+print(result.metrics_df)
 # 交易记录表
 print(result.trades_df)
 # 每日持仓表


### PR DESCRIPTION
移除对 metrics_df 的转置操作，直接打印原始 DataFrame，使其与库的实际行为保持一致。