### PR TITLE
docs: 更新文档首页样式并添加国际化支持

### DIFF
--- a/docs/assets/akquant-logo.svg
+++ b/docs/assets/akquant-logo.svg
@@ -1,0 +1,32 @@
+<svg width="400" height="120" viewBox="0 0 400 120" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#CE412B;stop-opacity:1" /> <!-- Rust Orange -->
+      <stop offset="100%" style="stop-color:#3776AB;stop-opacity:1" /> <!-- Python Blue -->
+    </linearGradient>
+  </defs>
+
+  <!-- Graphic: Quant Signal Bars (Ascending Data Spectrum) -->
+  <!-- Represents: Data Analysis -> Model Building -> Alpha Generation -->
+  <g transform="translate(30, 25)">
+    <!-- Bar 1: Low (Foundation/Data - Rust Color) -->
+    <rect x="0" y="40" width="15" height="30" rx="4" fill="#CE412B" />
+
+    <!-- Bar 2: Mid (Processing/Strategy - Blend) -->
+    <rect x="25" y="20" width="15" height="50" rx="4" fill="#BE5C60" />
+
+    <!-- Bar 3: High (Alpha/Profit - Python Color) -->
+    <rect x="50" y="0" width="15" height="70" rx="4" fill="#3776AB" />
+
+    <!-- Abstract Data Dots (floating above, implying quantitative precision) -->
+    <circle cx="7" cy="30" r="2" fill="#CE412B" />
+    <circle cx="32" cy="10" r="2" fill="#BE5C60" />
+    <circle cx="57" cy="-10" r="2" fill="#3776AB" />
+  </g>
+
+  <!-- Text -->
+  <text x="110" y="75" font-family="'Segoe UI', Helvetica, Arial, sans-serif" font-size="60" font-weight="bold" fill="url(#textGradient)">AKQuant</text>
+
+  <!-- Subtitle -->
+  <text x="115" y="100" font-family="'Segoe UI', Helvetica, Arial, sans-serif" font-size="14" fill="#666">High-Performance Quant Framework</text>
+</svg>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,4 +1,8 @@
-# AKQuant
+<p align="center">
+  <img src="../assets/akquant-logo.svg" alt="AKQuant Logo" width="800" />
+</p>
+
+---
 
 **AKQuant** is a high-performance quantitative research framework built on **Rust** and **Python**. It combines the extreme performance of Rust with the ease of use of Python, providing powerful backtesting and research tools for quantitative traders.
 

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -1,8 +1,8 @@
-<div align="center">
-  <img src="../../assets/logo.svg" width="400" alt="AKQuant Logo" />
-</div>
+<p align="center">
+  <img src="../assets/akquant-logo.svg" alt="AKQuant Logo" width="800" />
+</p>
 
-# AKQuant
+---
 
 **AKQuant** 是一个基于 **Rust** 和 **Python** 构建的高性能量化投研框架。它旨在结合 Rust 的极致性能和 Python 的易用性，为量化交易者提供强大的回测和研究工具。
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,5 @@ pandas-stubs>=2.3.3.260113
 types-pytz>=2025.2.0.20251108
 mkdocs>=1.5.0
 mkdocs-material>=9.5.0
+mkdocs-static-i18n>=1.2.0
 scikit-learn>=1.8.0


### PR DESCRIPTION
- 将中英文文档首页的标题样式从 `<div align="center">` 更新为 `<p align="center">`，使 logo 居中显示更规范
- 为文档首页添加分隔线 (`---`) 以改善视觉层次
- 新增 `akquant-logo.svg` 矢量 logo 文件，采用 Rust 橙色到 Python 蓝色的渐变设计，并包含量化信号柱的图形元素
- 在开发依赖中新增 `mkdocs-static-i18n>=1.2.0` 以支持文档的静态国际化