### PR TITLE
feat(strategy): 添加获取持仓信息的便捷方法

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -114,7 +114,7 @@ class MyStrategy(Strategy):
     def on_bar(self, bar):
         # Simple strategy logic (example)
         # For real backtests, using IndicatorSet for vectorized calculation is recommended
-        position = self.ctx.get_position(bar.symbol)
+        position = self.get_position(bar.symbol)
         if position == 0:
             self.buy(symbol=bar.symbol, quantity=100)
         elif position > 0:

--- a/docs/en/strategy_guide.md
+++ b/docs/en/strategy_guide.md
@@ -274,7 +274,9 @@ class RotationStrategy(Strategy):
         # Assume a daily timer is registered
         # Get current prices of all subscribed symbols
         scores = {}
-        for symbol in self.ctx.portfolio.positions.keys(): # Example only, actually should iterate over watchlist
+        # Actually should iterate over watchlist or subscribed symbols
+        # Note: self.ctx.positions contains current positions, but we might want to check all watched symbols
+        for symbol in self.ctx.positions.keys():
              hist = self.get_history(20, symbol)
              scores[symbol] = hist[-1] / hist[0] # 20-day momentum
 

--- a/docs/zh/strategy_guide.md
+++ b/docs/zh/strategy_guide.md
@@ -274,7 +274,9 @@ class RotationStrategy(Strategy):
         # 假设注册了一个每日定时器
         # 获取所有订阅标的的当前价格
         scores = {}
-        for symbol in self.ctx.portfolio.positions.keys(): # 仅示例，实际应遍历关注列表
+        # 仅示例，实际应遍历关注列表
+        # 注意: self.ctx.positions 仅包含当前持仓，可能需要遍历所有订阅的代码
+        for symbol in self.ctx.positions.keys():
              hist = self.get_history(20, symbol)
              scores[symbol] = hist[-1] / hist[0] # 20日动量
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.16"
+version = "0.1.17"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -546,6 +546,33 @@ class Strategy:
                 raise ValueError("Symbol must be provided")
         return symbol
 
+    def get_position(self, symbol: Optional[str] = None) -> float:
+        """
+        获取指定标的的持仓数量.
+
+        Args:
+            symbol: 标的代码 (如果不填, 默认使用当前 Bar/Tick 的 symbol)
+
+        Returns:
+            float: 持仓数量 (正数为多头, 负数为空头)
+        """
+        if self.ctx is None:
+            raise RuntimeError("Context not ready")
+
+        symbol = self._resolve_symbol(symbol)
+        return self.ctx.get_position(symbol)
+
+    def get_positions(self) -> Dict[str, float]:
+        """
+        获取所有持仓信息.
+
+        Returns:
+            Dict[str, float]: 持仓字典 {symbol: quantity}
+        """
+        if self.ctx is None:
+            raise RuntimeError("Context not ready")
+        return self.ctx.positions
+
     def get_open_orders(self, symbol: Optional[str] = None) -> list[Any]:
         """
         获取当前未完成的订单.
@@ -972,20 +999,6 @@ class Strategy:
         if self.ctx is None:
             raise RuntimeError("Context not ready")
         self.ctx.schedule(timestamp, payload)
-
-    def get_position(self, symbol: Optional[str] = None) -> float:
-        """获取当前持仓数量."""
-        if self.ctx is None:
-            return 0.0
-
-        if symbol is None:
-            if self.current_bar:
-                symbol = self.current_bar.symbol
-            elif self.current_tick:
-                symbol = self.current_tick.symbol
-            else:
-                return 0.0
-        return self.ctx.get_position(symbol)
 
     def get_cash(self) -> float:
         """获取现金."""


### PR DESCRIPTION
在 Strategy 类中添加 `get_position` 和 `get_positions` 方法，提供更直观的持仓查询接口。 更新文档示例以使用新方法，并修正相关文档中的错误引用。
同时将项目版本号更新至 0.1.17。