### PR TITLE
feat: 添加高分辨率权益曲线记录

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.18"
+version = "0.1.19"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}


### PR DESCRIPTION
在引擎中添加 equity_curve 字段，用于记录每个时间步长的权益值，提供更精细的回测结果分析。同时将 BacktestResult 的计算从 daily_equity 切换到 equity_curve，确保结果包含所有时间点的权益数据。