### PR TITLE
docs: 添加 PyPI 下载量徽章到 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
     <a href="https://github.com/akfamily/akshare">
         <img src="https://img.shields.io/badge/Data%20Science-AKShare-green?style=flat-square" alt="AKShare">
     </a>
+    <a href="https://pepy.tech/projects/akquant">
+        <img src="https://static.pepy.tech/personalized-badge/akquant?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads" alt="Downloads">
+    </a>
 </p>
 
 # AKQuant


### PR DESCRIPTION
在 README 文件顶部添加了来自 pepy.tech 的下载量统计徽章，以展示项目的流行度和使用情况。