### PR TITLE
ci(release): 优化构建配置并启用发布缓存

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_RELEASE_LTO: ${{ startsWith(github.ref, 'refs/tags/') && 'thin' || 'false' }}
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: ${{ startsWith(github.ref, 'refs/tags/') && '1' || '16' }}
+
 jobs:
   linux:
     runs-on: ubuntu-latest
@@ -23,6 +28,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: linux-${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -47,6 +56,10 @@ jobs:
         with:
           python-version: '3.13'
           architecture: ${{ matrix.target }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -69,6 +82,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: macos-${{ matrix.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -102,12 +119,8 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     permissions:
-      # Use to sign the release artifacts
       id-token: write
-      # Used to upload release artifacts
       contents: write
-      # Used to publish to PyPI
-      # attestations: write
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -117,6 +130,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        # with:
-          # password: ${{ secrets.PYPI_API_TOKEN }}
-          # repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
- 添加环境变量以在标签构建时启用LTO和优化代码生成单元
- 为所有平台作业添加Rust工具链和缓存步骤以加速构建
- 清理发布作业中已注释的配置并移除多余的空格