### PR TITLE
feat: 新增订单标签、风险安全边际和多种执行模式

### DIFF
--- a/docs/en/llm_guide.md
+++ b/docs/en/llm_guide.md
@@ -30,8 +30,8 @@ Your task is to write trading strategies or backtest scripts based on user requi
     *   **Check Data Sufficiency**: Always check `if len(history) < N: return` before calculating indicators.
 
 3.  **Trading API**:
-    *   Buy: `self.buy(symbol, quantity, price=None)`. `price=None` means Market Order.
-    *   Sell: `self.sell(symbol, quantity, price=None)`.
+    *   Buy: `self.buy(symbol, quantity, price=None, tag=None)`. `price=None` means Market Order.
+    *   Sell: `self.sell(symbol, quantity, price=None, tag=None)`.
     *   Position: `self.get_position(symbol)` returns float (0 if no position).
     *   Target: `self.order_target_percent(target, symbol)` or `self.order_target_value(target, symbol)`.
 
@@ -44,6 +44,17 @@ Your task is to write trading strategies or backtest scripts based on user requi
     *   Example: `run_backtest(data=df, strategy=MyStrat, cash=100_000.0, warmup_period=50)`.
     *   **Execution Mode**: Default is `ExecutionMode.NextOpen` (trade on next bar open). Set `execution_mode=ExecutionMode.CurrentClose` to trade on current bar close.
     *   Timezone: Default is "Asia/Shanghai".
+
+6.  **Configuration**:
+    *   **Risk Config**: Use `RiskConfig` to set parameters like `safety_margin` (default 0.0001).
+    *   Example:
+        ```python
+        from akquant.config import RiskConfig, StrategyConfig, BacktestConfig
+        risk_config = RiskConfig(safety_margin=0.001)
+        strategy_config = StrategyConfig(risk=risk_config)
+        backtest_config = BacktestConfig(strategy_config=strategy_config)
+        run_backtest(..., config=backtest_config)
+        ```
 
 ### Example Strategy (Reference)
 

--- a/docs/zh/llm_guide.md
+++ b/docs/zh/llm_guide.md
@@ -30,8 +30,8 @@ Your task is to write trading strategies or backtest scripts based on user requi
     *   **Check Data Sufficiency**: Always check `if len(history) < N: return` before calculating indicators.
 
 3.  **Trading API**:
-    *   Buy: `self.buy(symbol, quantity, price=None)`. `price=None` means Market Order.
-    *   Sell: `self.sell(symbol, quantity, price=None)`.
+    *   Buy: `self.buy(symbol, quantity, price=None, tag=None)`. `price=None` means Market Order.
+    *   Sell: `self.sell(symbol, quantity, price=None, tag=None)`.
     *   Position: `self.get_position(symbol)` returns float (0 if no position).
     *   Target: `self.order_target_percent(target, symbol)` or `self.order_target_value(target, symbol)`.
 
@@ -42,8 +42,19 @@ Your task is to write trading strategies or backtest scripts based on user requi
 5.  **Backtest Execution**:
     *   Use `akquant.run_backtest` with direct arguments for simplicity.
     *   Example: `run_backtest(data=df, strategy=MyStrat, cash=100_000.0, warmup_period=50)`.
-    *   **Execution Mode**: Default is `ExecutionMode.NextOpen` (trade on next bar open). Set `execution_mode=ExecutionMode.CurrentClose` to trade on current bar close.
+    *   **Execution Mode**: Default is `ExecutionMode.NextOpen` (trade on next bar open). Options: `ExecutionMode.CurrentClose` (trade on current bar close), `ExecutionMode.NextAverage` (trade on next bar average price (OHLC/4)).
     *   Timezone: Default is "Asia/Shanghai".
+
+6.  **Configuration**:
+    *   **Risk Config**: Use `RiskConfig` to set parameters like `safety_margin` (default 0.0001).
+    *   Example:
+        ```python
+        from akquant.config import RiskConfig, StrategyConfig, BacktestConfig
+        risk_config = RiskConfig(safety_margin=0.001)
+        strategy_config = StrategyConfig(risk=risk_config)
+        backtest_config = BacktestConfig(strategy_config=strategy_config)
+        run_backtest(..., config=backtest_config)
+        ```
 
 ### Example Strategy (Reference)
 

--- a/examples/plot_demo.py
+++ b/examples/plot_demo.py
@@ -8,6 +8,8 @@ Demonstrates a complete workflow:
 4. Visualizing results with a professional-grade interactive dashboard using Plotly.
 """
 
+from typing import cast
+
 import numpy as np
 import pandas as pd
 import plotly.graph_objects as go  # type: ignore
@@ -67,7 +69,7 @@ class TrendMomentumStrategy(Strategy):
         gain = (delta.where(delta > 0, 0)).rolling(window=self.rsi_period).mean()
         loss = (-delta.where(delta < 0, 0)).rolling(window=self.rsi_period).mean()
         rs = gain / loss
-        return 100 - (100 / (1 + rs))
+        return cast(pd.Series, 100 - (100 / (1 + rs)))
 
     def on_bar(self, bar: Bar) -> None:
         """Handle new bar event."""

--- a/examples/pybroker_strategy.py
+++ b/examples/pybroker_strategy.py
@@ -1,0 +1,91 @@
+import akquant as aq
+import akshare as ak
+import pandas as pd
+from akquant import Bar, Strategy
+from akquant.config import BacktestConfig, RiskConfig, StrategyConfig
+
+df = ak.stock_zh_a_daily(symbol="sh600000", start_date="20200131", end_date="20230228")
+
+
+class MyStrategy(Strategy):
+    """
+    Example strategy for testing broker execution.
+
+    This strategy buys on the first bar and holds for 100 bars or until 10% profit.
+    """
+
+    def __init__(self) -> None:
+        """Initialize strategy state."""
+        self.bars_held: dict[str, int] = {}
+        self.entry_prices: dict[str, float] = {}
+
+    def on_bar(self, bar: Bar) -> None:
+        """
+        Handle bar data event.
+
+        :param bar: The current bar data
+        """
+        symbol = bar.symbol
+        pos = self.get_position(symbol)
+
+        # 维护持仓计数
+        if pos > 0:
+            if symbol not in self.bars_held:
+                self.bars_held[symbol] = 0
+            self.bars_held[symbol] += 1
+        else:
+            # 如果没有持仓，清理状态
+            if symbol in self.bars_held:
+                del self.bars_held[symbol]
+            if symbol in self.entry_prices:
+                del self.entry_prices[symbol]
+
+        # 交易逻辑
+        if pos == 0:
+            # 简单示例：无条件买入
+            self.order_target_percent(target_percent=1.0, symbol=symbol)
+            # 初始化计数器 (虽然会在下个 bar 的 pos>0 分支中自增，但这里先占位)
+            self.bars_held[symbol] = 0
+            self.entry_prices[symbol] = bar.close
+
+        elif pos > 0:
+            entry_price = self.entry_prices.get(symbol, bar.close)
+            current_bars_held = self.bars_held.get(symbol, 0)
+
+            # 计算收益率
+            pnl_pct = (bar.close - entry_price) / entry_price
+
+            # 止盈条件：收益率 >= 10%
+            if pnl_pct >= 0.10:
+                self.sell(symbol, pos)
+                print(
+                    f"Take Profit Triggered for {symbol}: Entry={entry_price}, "
+                    f"Current={bar.close}, PnL={pnl_pct:.2%}"
+                )
+
+            # 持仓时间条件：持有满 100 个 Bar
+            elif current_bars_held >= 100:
+                self.sell(symbol, pos)
+
+
+# 配置风险参数：safety_margin
+risk_config = RiskConfig(safety_margin=0.00000001)
+strategy_config = StrategyConfig(risk=risk_config)
+backtest_config = BacktestConfig(strategy_config=strategy_config)
+
+result = aq.run_backtest(
+    strategy=MyStrategy,
+    data=df,
+    initial_cash=500_000,
+    commission_rate=0.0,
+    stamp_tax_rate=0.0,
+    transfer_fee_rate=0.0,
+    min_commission=0.0,
+    lot_size=1,
+    execution_mode=aq.ExecutionMode.NextHighLowMid,  # type: ignore
+    config=backtest_config,
+)
+
+pd.set_option("display.max_columns", None)
+print(result)
+print(result.orders_df)

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -44,6 +44,49 @@ class TimeInForce:
 class ExecutionMode:
     CurrentClose: "ExecutionMode"
     NextOpen: "ExecutionMode"
+    NextAverage: "ExecutionMode"
+    NextHighLowMid: "ExecutionMode"
+
+class Instrument:
+    r"""
+    交易标的.
+
+    :ivar symbol: 代码
+    :ivar asset_type: 资产类型
+    :ivar multiplier: 合约乘数
+    :ivar margin_ratio: 保证金比率
+    :ivar tick_size: 最小变动价位
+    """
+
+    symbol: str
+    asset_type: "AssetType"
+    multiplier: typing.Any
+    margin_ratio: typing.Any
+    tick_size: typing.Any
+    option_type: typing.Optional["OptionType"]
+    strike_price: typing.Optional[typing.Any]
+    expiry_date: typing.Optional[int]
+    lot_size: typing.Any
+    def __new__(
+        cls,
+        symbol: str,
+        asset_type: "AssetType",
+        multiplier: typing.Optional[typing.Any] = ...,
+        margin_ratio: typing.Optional[typing.Any] = ...,
+        tick_size: typing.Optional[typing.Any] = ...,
+        option_type: typing.Optional["OptionType"] = ...,
+        strike_price: typing.Optional[typing.Any] = ...,
+        expiry_date: typing.Optional[int] = ...,
+        lot_size: typing.Optional[typing.Any] = ...,
+    ) -> "Instrument": ...
+
+class DataFeed:
+    r"""数据源."""
+
+    def __new__(cls) -> "DataFeed": ...
+    def add_bar(self, bar: "Bar") -> None: ...
+    def add_bars(self, bars: list["Bar"]) -> None: ...
+    def sort(self) -> None: ...
 
 class TradingSession:
     PreOpen: "TradingSession"
@@ -74,6 +117,8 @@ class BacktestResult:
     snapshots: list[tuple[int, list["PositionSnapshot"]]]
     def get_trades_dict(self) -> dict[str, list[typing.Any]]: ...
     def get_positions_dict(self) -> dict[str, list[typing.Any]]: ...
+    @property
+    def executions(self) -> list["Trade"]: ...
 
 class PositionSnapshot:
     r"""每日持仓快照."""
@@ -172,10 +217,6 @@ class ClosedTrade:
     commission: float
     duration_bars: int
     duration: int
-
-class DataFeed:
-    def sort(self) -> None: ...
-    def add_bars(self, bars: typing.Sequence[Bar]) -> None: ...
 
 class EMA:
     r"""Exponential Moving Average."""
@@ -369,35 +410,6 @@ class Engine:
         self, active_orders: typing.Sequence["Order"]
     ) -> "StrategyContext": ...
 
-class Instrument:
-    r"""
-    交易标的.
-
-    :ivar symbol: 代码
-    :ivar asset_type: 资产类型
-    :ivar multiplier: 合约乘数
-    :ivar margin_ratio: 保证金比率
-    :ivar tick_size: 最小变动价位
-    """
-
-    symbol: str
-    asset_type: "AssetType"
-    multiplier: float
-    margin_ratio: float
-    tick_size: float
-    def __new__(
-        cls,
-        symbol: str,
-        asset_type: "AssetType",
-        multiplier: typing.Any,
-        margin_ratio: typing.Any,
-        tick_size: typing.Any,
-        option_type: typing.Optional["OptionType"],
-        strike_price: typing.Optional[typing.Any],
-        expiry_date: typing.Optional[int],
-        lot_size: typing.Optional[typing.Any],
-    ) -> "Instrument": ...
-
 class MACD:
     r"""Moving Average Convergence Divergence."""
 
@@ -424,6 +436,10 @@ class Order:
     :ivar status: 订单状态
     :ivar filled_quantity: 已成交数量
     :ivar average_filled_price: 成交均价
+    :ivar created_at: 创建时间戳
+    :ivar updated_at: 更新时间戳
+    :ivar tag: 订单标签
+    :ivar reject_reason: 拒绝原因
     """
 
     id: str
@@ -437,6 +453,10 @@ class Order:
     trigger_price: typing.Optional[float]
     filled_quantity: float
     average_filled_price: typing.Optional[float]
+    created_at: int
+    updated_at: int
+    tag: str
+    reject_reason: str
     def __new__(
         cls,
         id: str,
@@ -447,6 +467,8 @@ class Order:
         price: typing.Optional[float] = ...,
         time_in_force: "TimeInForce" = ...,
         trigger_price: typing.Optional[float] = ...,
+        created_at: typing.Optional[int] = ...,
+        tag: typing.Optional[str] = ...,
     ) -> "Order": ...
     def __repr__(self) -> str: ...
 
@@ -513,6 +535,7 @@ class RiskConfig:
     max_position_size: typing.Optional[float]
     restricted_list: list[str]
     active: bool
+    safety_margin: float
     def __new__(cls) -> "RiskConfig": ...
 
 class RiskManager:
@@ -560,6 +583,7 @@ class StrategyContext:
     cash: float
     positions: dict[str, float]
     available_positions: dict[str, float]
+    risk_config: RiskConfig
     def __new__(
         cls,
         cash: typing.Any,
@@ -569,6 +593,7 @@ class StrategyContext:
         active_orders: typing.Optional[typing.Sequence[Order]],
         closed_trades: typing.Optional[typing.Sequence[ClosedTrade]],
         recent_trades: typing.Optional[typing.Sequence[Trade]],
+        risk_config: typing.Optional[RiskConfig],
     ) -> "StrategyContext": ...
     def history(
         self, symbol: str, field: str, count: int
@@ -607,6 +632,7 @@ class StrategyContext:
         price: typing.Optional[float] = ...,
         time_in_force: typing.Optional["TimeInForce"] = ...,
         trigger_price: typing.Optional[float] = ...,
+        tag: typing.Optional[str] = ...,
     ) -> str: ...
     def sell(
         self,
@@ -615,6 +641,7 @@ class StrategyContext:
         price: typing.Optional[float] = ...,
         time_in_force: typing.Optional["TimeInForce"] = ...,
         trigger_price: typing.Optional[float] = ...,
+        tag: typing.Optional[str] = ...,
     ) -> str: ...
     def get_position(self, symbol: str) -> float: ...
     def get_available_position(self, symbol: str) -> float: ...

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -27,6 +27,7 @@ class RiskConfig:
     """Configuration for Risk Management."""
 
     active: bool = True
+    safety_margin: float = 0.0001
     max_order_size: Optional[float] = None
     max_order_value: Optional[float] = None
     max_position_size: Optional[float] = None

--- a/python/akquant/risk.py
+++ b/python/akquant/risk.py
@@ -34,7 +34,17 @@ def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
     if config.restricted_list is not None:
         rust_config.restricted_list = config.restricted_list
 
-    rust_config.active = config.active
+    if config.active is not None:
+        rust_config.active = config.active
 
-    # Re-assign to ensure it updates (in case it was a copy)
-    engine.risk_manager.config = rust_config
+    if config.safety_margin is not None:
+        rust_config.safety_margin = config.safety_margin
+
+    # Use the dedicated setter method to ensure the update propagates to the Engine
+    # Direct attribute assignment (engine.risk_manager.config = ...) might only
+    # update a copy
+    if hasattr(engine, "set_risk_config"):
+        engine.set_risk_config(rust_config)
+    else:
+        # Fallback for older versions or if method is missing
+        engine.risk_manager.config = rust_config

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -848,6 +848,7 @@ impl BacktestResult {
         let mut order_types = Vec::with_capacity(n); // market/limit/stop
         let mut symbols = Vec::with_capacity(n);
         let mut dates = Vec::with_capacity(n);
+        let mut updated_dates = Vec::with_capacity(n);
         let mut quantities = Vec::with_capacity(n);
         let mut filled_quantities = Vec::with_capacity(n);
         let mut limit_prices = Vec::with_capacity(n);
@@ -856,6 +857,8 @@ impl BacktestResult {
         let mut commissions = Vec::with_capacity(n);
         let mut status = Vec::with_capacity(n);
         let mut time_in_force = Vec::with_capacity(n);
+        let mut tags = Vec::with_capacity(n);
+        let mut reject_reasons = Vec::with_capacity(n);
 
         for o in &self.orders {
             ids.push(o.id.clone());
@@ -863,6 +866,7 @@ impl BacktestResult {
             order_types.push(format!("{:?}", o.order_type).to_lowercase());
             symbols.push(o.symbol.clone());
             dates.push(o.created_at); // i64 timestamp (ns)
+            updated_dates.push(o.updated_at);
             quantities.push(o.quantity.to_f64().unwrap_or(0.0));
             filled_quantities.push(o.filled_quantity.to_f64().unwrap_or(0.0));
             limit_prices.push(
@@ -883,6 +887,8 @@ impl BacktestResult {
             commissions.push(o.commission.to_f64().unwrap_or(0.0));
             status.push(format!("{:?}", o.status).to_lowercase());
             time_in_force.push(format!("{:?}", o.time_in_force).to_lowercase());
+            tags.push(o.tag.clone());
+            reject_reasons.push(o.reject_reason.clone());
         }
 
         let dict = pyo3::types::PyDict::new(py);
@@ -899,6 +905,9 @@ impl BacktestResult {
         dict.set_item("status", status)?;
         dict.set_item("time_in_force", time_in_force)?;
         dict.set_item("created_at", dates)?; // Renamed date -> created_at for consistency
+        dict.set_item("updated_at", updated_dates)?;
+        dict.set_item("tag", tags)?;
+        dict.set_item("reject_reason", reject_reasons)?;
 
         Ok(dict.into())
     }

--- a/src/model/instrument.rs
+++ b/src/model/instrument.rs
@@ -115,4 +115,15 @@ impl Instrument {
     fn get_tick_size(&self) -> f64 {
         self.tick_size.to_f64().unwrap_or_default()
     }
+
+    #[getter]
+    fn get_lot_size(&self) -> f64 {
+        self.lot_size.to_f64().unwrap_or_default()
+    }
+
+    #[setter]
+    fn set_lot_size(&mut self, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.lot_size = extract_decimal(value)?;
+        Ok(())
+    }
 }

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -42,7 +42,13 @@ pub struct Order {
     pub average_filled_price: Option<Decimal>,
     #[pyo3(get)]
     pub created_at: i64,
+    #[pyo3(get)]
+    pub updated_at: i64,
     pub commission: Decimal,
+    #[pyo3(get, set)]
+    pub tag: String,
+    #[pyo3(get)]
+    pub reject_reason: String,
 }
 
 #[gen_stub_pymethods]
@@ -59,8 +65,9 @@ impl Order {
     /// :param time_in_force: 订单有效期 (可选，默认 Day)
     /// :param trigger_price: 触发价格 (可选)
     /// :param created_at: 创建时间戳 (可选，默认 0)
+    /// :param tag: 订单标签 (可选，默认 "")
     #[new]
-    #[pyo3(signature = (id, symbol, side, order_type, quantity, price=None, time_in_force=None, trigger_price=None, created_at=None))]
+    #[pyo3(signature = (id, symbol, side, order_type, quantity, price=None, time_in_force=None, trigger_price=None, created_at=None, tag=None))]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
@@ -72,7 +79,9 @@ impl Order {
         time_in_force: Option<TimeInForce>,
         trigger_price: Option<&Bound<'_, PyAny>>,
         created_at: Option<i64>,
+        tag: Option<String>,
     ) -> PyResult<Self> {
+        let created_at_ts = created_at.unwrap_or(0);
         Ok(Order {
             id,
             symbol,
@@ -91,8 +100,11 @@ impl Order {
             status: OrderStatus::New,
             filled_quantity: Decimal::ZERO,
             average_filled_price: None,
-            created_at: created_at.unwrap_or(0),
+            created_at: created_at_ts,
+            updated_at: created_at_ts,
             commission: Decimal::ZERO,
+            tag: tag.unwrap_or_default(),
+            reject_reason: String::new(),
         })
     }
 
@@ -129,7 +141,7 @@ impl Order {
 
     pub fn __repr__(&self) -> String {
         format!(
-            "Order(id={}, symbol={}, side={:?}, type={:?}, qty={}, price={:?}, tif={:?}, status={:?})",
+            "Order(id={}, symbol={}, side={:?}, type={:?}, qty={}, price={:?}, tif={:?}, status={:?}, tag={}, reject_reason={})",
             self.id,
             self.symbol,
             self.side,
@@ -137,7 +149,9 @@ impl Order {
             self.quantity,
             self.price,
             self.time_in_force,
-            self.status
+            self.status,
+            self.tag,
+            self.reject_reason
         )
     }
 }

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -114,6 +114,8 @@ pub enum TimeInForce {
 pub enum ExecutionMode {
     CurrentClose, // 当前Bar收盘价成交 (Cheat-on-Close)
     NextOpen,     // 下一根Bar开盘价成交 (Real-world)
+    NextAverage,  // 下一根Bar均价成交 (TWAP/VWAP 模拟)
+    NextHighLowMid, // 下一根Bar最高价和最低价的中间价成交
 }
 
 #[pyclass(eq, eq_int)]

--- a/src/risk.rs
+++ b/src/risk.rs
@@ -27,6 +27,8 @@ pub struct RiskConfig {
     pub active: bool,
     #[pyo3(get, set)]
     pub check_cash: bool,
+    #[pyo3(get, set)]
+    pub safety_margin: f64,
 }
 
 #[pymethods]
@@ -40,6 +42,7 @@ impl RiskConfig {
             restricted_list: Vec::new(),
             active: true,
             check_cash: true,
+            safety_margin: 0.0001,
         }
     }
 
@@ -286,10 +289,11 @@ mod tests {
     use super::*;
     use crate::model::OrderType;
     use std::collections::HashMap;
+    use uuid::Uuid;
 
     fn create_dummy_order(symbol: &str, quantity: Decimal, price: Option<Decimal>) -> Order {
         Order {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: Uuid::new_v4().to_string(),
             symbol: symbol.to_string(),
             side: OrderSide::Buy,
             order_type: OrderType::Limit,
@@ -301,7 +305,10 @@ mod tests {
             filled_quantity: Decimal::ZERO,
             average_filled_price: None,
             created_at: 0,
+            updated_at: 0,
             commission: Decimal::ZERO,
+            tag: String::new(),
+            reject_reason: String::new(),
         }
     }
 


### PR DESCRIPTION
- 在 Order 类中增加 tag、reject_reason、updated_at 字段，支持订单标签和拒绝原因
- 新增 ExecutionMode.NextAverage（下一根Bar均价成交）和 NextHighLowMid（最高最低价中间价成交）执行模式
- 为 RiskConfig 增加 safety_margin 参数，用于资金检查时的安全缓冲
- 扩展订单DataFrame，新增 updated_at、tag、reject_reason、filled_value、duration 等字段
- 改进 Strategy.order_target_value 方法，自动计算考虑费率后的最大可买数量
- 更新文档和示例，展示新功能和配置方式