### PR TITLE
feat(回测): 为交易记录添加MAE/MFE和持仓分析字段

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/backtest_result.md
+++ b/docs/en/backtest_result.md
@@ -98,6 +98,12 @@ This document details the performance metrics in AKQuant backtest results (`metr
 | `commission` | Commission | Float | Commission paid. |
 | `duration_bars` | Duration (Bars) | Int | Number of bars held. |
 | `duration` | Duration | Timedelta | `exit_time - entry_time`. |
+| `mae` | MAE | **%** | Maximum Adverse Excursion (max loss during trade). |
+| `mfe` | MFE | **%** | Maximum Favorable Excursion (max profit during trade). |
+| `entry_tag` | Entry Tag | String | Tag of the entry order. |
+| `exit_tag` | Exit Tag | String | Tag of the exit order. |
+| `entry_portfolio_value` | Entry Portfolio Value | Float | Total account equity at entry. |
+| `max_drawdown_pct` | Max Drawdown % | **%** | Max drawdown percentage during the trade. |
 
 ## Orders
 

--- a/docs/zh/backtest_result.md
+++ b/docs/zh/backtest_result.md
@@ -99,6 +99,12 @@
 | `commission` | 手续费 | Float | 交易产生的佣金。 |
 | `duration_bars` | 持仓 K 线数 | Int | 持仓期间经历的 Bar 数量。 |
 | `duration` | 持仓时长 | Timedelta | `exit_time - entry_time`。 |
+| `mae` | 最大不利偏移 | **% (百分比)** | 持仓期间最大亏损幅度 (相对于开仓价)。 |
+| `mfe` | 最大有利偏移 | **% (百分比)** | 持仓期间最大盈利幅度 (相对于开仓价)。 |
+| `entry_tag` | 开仓标签 | String | 开仓订单的标签。 |
+| `exit_tag` | 平仓标签 | String | 平仓订单的标签。 |
+| `entry_portfolio_value` | 开仓总资产 | Float | 开仓时刻的账户总权益 (Equity)。用于计算仓位占比。 |
+| `max_drawdown_pct` | 单笔最大回撤 | **% (百分比)** | 持仓期间从最高点回落的最大幅度。 |
 
 ## 订单记录 (Orders)
 

--- a/examples/pybroker_strategy.py
+++ b/examples/pybroker_strategy.py
@@ -1,10 +1,52 @@
 import akquant as aq
-import akshare as ak
+import numpy as np
 import pandas as pd
 from akquant import Bar, Strategy
 from akquant.config import BacktestConfig, RiskConfig, StrategyConfig
 
-df = ak.stock_zh_a_daily(symbol="sh600000", start_date="20200131", end_date="20230228")
+# df = ak.stock_zh_a_daily(
+#     symbol="sh600000", start_date="20200131", end_date="20230228"
+# )
+
+
+def generate_data() -> pd.DataFrame:
+    """Generate dummy data for backtesting."""
+    n = 1000000  # 精确生成1000万根K线
+
+    # 1. 生成日期序列（使用periods确保数量精确）
+    dates = pd.date_range(start="2020-01-01", periods=n, freq="1min")
+
+    # 2. 生成合理价格序列（关键优化）
+    # - 收益率均值设为0（避免1000万次累积后价格爆炸/归零）
+    # - 标准差0.0001（约0.01%波动，符合5分钟K线特征）
+    # - 使用np.exp避免cumprod数值溢出，更稳定
+    np.random.seed(42)  # 可复现性（生产环境可移除）
+    log_returns = np.random.normal(0, 0.0001, n)
+    price = 100 * np.exp(np.cumsum(log_returns))
+
+    # 3. 构建DataFrame（内存优化关键）
+    df = pd.DataFrame(
+        {
+            "date": dates,
+            "open": price.astype(np.float32),  # float32节省50%内存
+            "high": (price * 1.005).astype(np.float32),  # 缩小振幅至±0.5%更合理
+            "low": (price * 0.995).astype(np.float32),
+            "close": price.astype(np.float32),
+            "volume": np.full(n, 10000, dtype=np.int32),  # int32替代默认int64
+            "symbol": pd.Categorical(["600000"] * n),  # category类型节省90%+内存
+        }
+    )
+
+    # 4. 强制修正：确保high >= max(open,close) 且 low <= min(open,close)
+    # （解决原逻辑中open=close导致K线形态失真的问题）
+    df["high"] = np.maximum(df["high"], np.maximum(df["open"], df["close"]))
+    df["low"] = np.minimum(df["low"], np.minimum(df["open"], df["close"]))
+
+    return df
+
+
+# 生成数据（注意：需8-12GB可用内存）
+df = generate_data()
 
 
 class MyStrategy(Strategy):
@@ -43,6 +85,10 @@ class MyStrategy(Strategy):
         # 交易逻辑
         if pos == 0:
             # 简单示例：无条件买入
+            print(
+                f"Buy Signal for {symbol}: Open={bar.open}, High={bar.high}, "
+                f"Low={bar.low}, Close={bar.close}"
+            )
             self.order_target_percent(target_percent=1.0, symbol=symbol)
             # 初始化计数器 (虽然会在下个 bar 的 pos>0 分支中自增，但这里先占位)
             self.bars_held[symbol] = 0
@@ -69,9 +115,12 @@ class MyStrategy(Strategy):
 
 
 # 配置风险参数：safety_margin
-risk_config = RiskConfig(safety_margin=0.00000001)
+risk_config = RiskConfig(safety_margin=0.0001)
 strategy_config = StrategyConfig(risk=risk_config)
 backtest_config = BacktestConfig(strategy_config=strategy_config)
+
+engine = aq.Engine()
+engine.set_force_session_continuous(True)
 
 result = aq.run_backtest(
     strategy=MyStrategy,
@@ -88,4 +137,5 @@ result = aq.run_backtest(
 
 pd.set_option("display.max_columns", None)
 print(result)
+print(result.trades_df)
 print(result.orders_df)

--- a/examples/test_hold_bar.py
+++ b/examples/test_hold_bar.py
@@ -1,0 +1,55 @@
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+pd.set_option("display.max_columns", None)
+
+
+class TestHoldBarStrategy(Strategy):
+    """Test strategy for hold_bar functionality."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Handle bar event."""
+        symbol = bar.symbol
+        pos = self.get_position(symbol)
+
+        # 1. 第2个Bar买入
+        if pos == 0:
+            print(f"[{self.format_time(bar.timestamp)}] Buying...")
+            self.buy(symbol, 100)
+
+        # 2. 打印持有天数
+        hold_bars = self.hold_bar(symbol)
+        if pos != 0:
+            ts_str = self.format_time(bar.timestamp)
+            print(f"[{ts_str}] Holding {symbol}, hold_bar={hold_bars}")
+
+        # 3. 持有 5 个 Bar 后卖出
+        if hold_bars >= 5:
+            print(f"[{self.format_time(bar.timestamp)}] Selling after 5 bars...")
+            self.close_position(symbol)
+
+
+def generate_data() -> pd.DataFrame:
+    """Generate synthetic data for testing."""
+    dates = pd.date_range(start="2023-01-01", periods=20, freq="D")
+    df = pd.DataFrame(
+        {
+            "datetime": dates,
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 101.0,
+            "volume": 10000,
+        }
+    )
+    return df
+
+
+if __name__ == "__main__":
+    df = generate_data()
+    print("Starting backtest...")
+    result = aq.run_backtest(
+        df, TestHoldBarStrategy, symbol="TEST", cash=10000, show_progress=False
+    )
+    print(result.trades_df)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.24"
+version = "0.1.25"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -217,6 +217,12 @@ class ClosedTrade:
     commission: float
     duration_bars: int
     duration: int
+    mae: float
+    mfe: float
+    entry_tag: str
+    exit_tag: str
+    entry_portfolio_value: float
+    max_drawdown_pct: float
 
 class EMA:
     r"""Exponential Moving Average."""

--- a/python/akquant/backtest.py
+++ b/python/akquant/backtest.py
@@ -298,6 +298,12 @@ class BacktestResult:
             - commission (float): Commission paid.
             - duration_bars (int): Number of bars held.
             - duration (timedelta): Duration of trade.
+            - mae (float): Maximum Adverse Excursion (%).
+            - mfe (float): Maximum Favorable Excursion (%).
+            - entry_tag (str): Tag of the entry order.
+            - exit_tag (str): Tag of the exit order.
+            - entry_portfolio_value (float): Portfolio value at entry.
+            - max_drawdown_pct (float): Max drawdown % during trade.
         """
         if not self._raw.trades:
             return pd.DataFrame()
@@ -325,6 +331,14 @@ class BacktestResult:
                         "commission": t.commission,
                         "duration_bars": t.duration_bars,
                         "duration": t.duration,
+                        "mae": t.mae,
+                        "mfe": t.mfe,
+                        "entry_tag": t.entry_tag,
+                        "exit_tag": t.exit_tag,
+                        "entry_portfolio_value": getattr(
+                            t, "entry_portfolio_value", 0.0
+                        ),
+                        "max_drawdown_pct": getattr(t, "max_drawdown_pct", 0.0),
                     }
                 )
             df = pd.DataFrame(data_list)

--- a/python/akquant/utils/__init__.py
+++ b/python/akquant/utils/__init__.py
@@ -385,7 +385,7 @@ def prepare_dataframe(
         if dt.dt.tz is None:
             # Ensure ns for naive before localizing
             dt = dt.astype("datetime64[ns]")
-            dt = dt.dt.tz_localize(tz)
+            dt = dt.dt.tz_localize(tz, ambiguous="NaT", nonexistent="shift_forward")
 
         # 4. Convert to UTC
         dt = dt.dt.tz_convert("UTC")
@@ -399,7 +399,9 @@ def prepare_dataframe(
 
         if dt_idx.tz is None:
             dt_idx = cast(pd.DatetimeIndex, dt_idx.astype("datetime64[ns]"))
-            dt_idx = dt_idx.tz_localize(tz)
+            dt_idx = dt_idx.tz_localize(
+                tz, ambiguous="NaT", nonexistent="shift_forward"
+            )
 
         dt_idx = dt_idx.tz_convert("UTC")
         df.index = dt_idx

--- a/src/data.rs
+++ b/src/data.rs
@@ -361,7 +361,9 @@ pub fn from_arrays(
         };
 
         let ts = timestamps[i];
-        let normalized_ts = normalize_timestamp(ts);
+        // Timestamps from Python/Pandas are already in nanoseconds (int64)
+        // No normalization needed (and normalization can be buggy for dates near 1970)
+        let normalized_ts = ts;
 
         let mut bar_extra = HashMap::new();
         for (k, arr) in &extra_arrays {

--- a/src/history.rs
+++ b/src/history.rs
@@ -28,6 +28,11 @@ impl SymbolHistory {
 
     pub fn push(&mut self, bar: &Bar) {
         if self.capacity == 0 {
+            // If capacity is 0, we can still store unbounded history?
+            // Or should we interpret 0 as "unlimited" or "none"?
+            // Usually 0 means None.
+            // But if we want MAE/MFE, we need history.
+            // Let's assume 0 means disabled.
             return;
         }
 


### PR DESCRIPTION
- 在ClosedTrade结构中新增mae、mfe、entry_tag、exit_tag、entry_portfolio_value和max_drawdown_pct字段
- 修改TradeTracker以计算每笔交易的最大不利偏移、最大有利偏移和最大回撤百分比
- 为策略类添加hold_bar方法，用于追踪持仓的Bar数量
- 更新历史缓冲区默认容量以支持MAE/MFE计算
- 同步更新Python接口、文档和示例代码