### PR TITLE
build: 更新版本号至 0.1.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.28"
+version = "0.1.29"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.28"
+version = "0.1.29"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/plot/analysis.py
+++ b/python/akquant/plot/analysis.py
@@ -130,7 +130,7 @@ def plot_pnl_vs_duration(
             text=symbols,
             hovertemplate=(
                 f"<b>%{{text}}</b><br>持仓: %{{x:.1f}} {unit_label}<br>"
-                "盈亏: %{{y:.2f}}<extra></extra>"
+                "盈亏: %{y:.2f}<extra></extra>"
             ),
         )
     )


### PR DESCRIPTION
为发布新版本准备，同步更新 Cargo.toml、Cargo.lock 和 pyproject.toml 中的版本号。 修复 Python 绘图模块中 hovertemplate 的格式字符串转义问题。