### PR TITLE
feat: 统一时间参数命名并增强回测日期过滤

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/examples.md
+++ b/docs/en/examples.md
@@ -196,8 +196,8 @@ import pandas as pd
 import numpy as np
 
 # 1. Prepare data (Mock data)
-def create_dummy_data(symbol, start_date, n_bars, price=100.0):
-    dates = pd.date_range(start_date, periods=n_bars, freq="B")
+def create_dummy_data(symbol, start_time, n_bars, price=100.0):
+    dates = pd.date_range(start_time, periods=n_bars, freq="B")
     np.random.seed(42)
     changes = np.random.randn(n_bars)
     prices = price + np.cumsum(changes)

--- a/docs/zh/examples.md
+++ b/docs/zh/examples.md
@@ -196,8 +196,8 @@ import pandas as pd
 import numpy as np
 
 # 1. 准备数据 (模拟数据)
-def create_dummy_data(symbol, start_date, n_bars, price=100.0):
-    dates = pd.date_range(start_date, periods=n_bars, freq="B")
+def create_dummy_data(symbol, start_time, n_bars, price=100.0):
+    dates = pd.date_range(start_time, periods=n_bars, freq="B")
     np.random.seed(42)
     changes = np.random.randn(n_bars)
     prices = price + np.cumsum(changes)

--- a/examples/benchmark_akquant_multi.py
+++ b/examples/benchmark_akquant_multi.py
@@ -43,7 +43,7 @@ for i, symbol in enumerate(SYMBOLS):
     # 生成数据 (使用 'B' 代表工作日频率，从 1990 年开始)
     # 固定种子以确保结果可复现
     df = get_benchmark_data(
-        DATA_SIZE, symbol, freq="B", start_date="1990-01-01", seed=42 + i
+        DATA_SIZE, symbol, freq="B", start_time="1990-01-01", seed=42 + i
     )
 
     # 重命名列

--- a/examples/benchmark_utils.py
+++ b/examples/benchmark_utils.py
@@ -10,7 +10,7 @@ def get_benchmark_data(
     n: int = 200_000,
     symbol: str = "BENCHMARK",
     freq: str = "min",
-    start_date: str = "2020-01-01",
+    start_time: str = "2020-01-01",
     seed: Optional[int] = None,
 ) -> pd.DataFrame:
     """
@@ -21,7 +21,7 @@ def get_benchmark_data(
     print(f"Generating {n} rows of dummy data...")
     t0 = time.time()
 
-    dates = pd.date_range(start=start_date, periods=n, freq=freq, tz="UTC")
+    dates = pd.date_range(start=start_time, periods=n, freq=freq, tz="UTC")
     # Add 15 hours to simulate market close time (15:00:00 UTC)
     dates = dates + pd.Timedelta(hours=15)
 

--- a/examples/plot_demo.py
+++ b/examples/plot_demo.py
@@ -49,11 +49,21 @@ if __name__ == "__main__":
     # Configuration
     SYMBOL = "sh600000"
     START_DATE = "20120101"
-    END_DATE = "20231231"
+    END_DATE = "20261231"
     INITIAL_CASH = 100_000.0
 
     df = ak.stock_zh_a_daily(symbol=SYMBOL, start_date=START_DATE, end_date=END_DATE)
     df["symbol"] = SYMBOL
+
+    # from akquant.config import BacktestConfig, StrategyConfig, RiskConfig
+    # # 配置风险参数：safety_margin
+    # risk_config = RiskConfig(safety_margin=0.0001)
+    # strategy_config = StrategyConfig(risk=risk_config)
+    # backtest_config = BacktestConfig(
+    #     strategy_config=strategy_config,
+    #     # start_time="20200131",
+    #     # end_time="20260210"
+    # )
 
     # 2. Run Backtest
     print("\nRunning Backtest...")
@@ -63,6 +73,9 @@ if __name__ == "__main__":
         symbol=SYMBOL,
         initial_cash=INITIAL_CASH,
         show_progress=True,
+        # config=backtest_config,
+        start_time="20160101",
+        end_time="20201231",
     )
 
     # 3. Print Metrics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.30"
+version = "0.1.31"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -42,8 +42,10 @@ class StrategyConfig:
     initial_cash: float = 100000.0
 
     # Fees & Commission
-    fee_mode: str = "per_order"  # 'per_order', 'per_share', 'percent'
-    fee_amount: float = 0.0  # Fixed amount or percentage
+    commission_rate: float = 0.0  # Commission rate (e.g. 0.0003 for 0.03%)
+    stamp_tax_rate: float = 0.0  # Stamp tax rate (e.g. 0.001, sell only)
+    transfer_fee_rate: float = 0.0  # Transfer fee rate
+    min_commission: float = 0.0  # Minimum commission per order (e.g. 5.0)
 
     # Execution
     enable_fractional_shares: bool = False
@@ -69,8 +71,8 @@ class BacktestConfig:
     """Configuration specifically for running backtests."""
 
     strategy_config: StrategyConfig
-    start_date: Optional[str] = None
-    end_date: Optional[str] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
     instruments: Optional[List[str]] = None
     instruments_config: Optional[
         Union[List[InstrumentConfig], Dict[str, InstrumentConfig]]

--- a/python/akquant/data.py
+++ b/python/akquant/data.py
@@ -1,7 +1,7 @@
 import hashlib
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
@@ -62,16 +62,16 @@ class ParquetDataCatalog:
     def read(
         self,
         symbol: str,
-        start_date: Optional[str] = None,
-        end_date: Optional[str] = None,
+        start_time: Optional[Union[str, pd.Timestamp]] = None,
+        end_time: Optional[Union[str, pd.Timestamp]] = None,
         columns: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """
         Read DataFrame from Parquet catalog.
 
         :param symbol: Instrument symbol.
-        :param start_date: Filter start date (YYYYMMDD or YYYY-MM-DD).
-        :param end_date: Filter end date.
+        :param start_time: Filter start date/time.
+        :param end_time: Filter end date/time.
         :param columns: Specific columns to read.
         :return: DataFrame.
         """
@@ -83,10 +83,10 @@ class ParquetDataCatalog:
 
         # Read with projection (columns) and push-down filters
         filters = []
-        if start_date:
-            filters.append(("index", ">=", pd.to_datetime(start_date)))
-        if end_date:
-            filters.append(("index", "<=", pd.to_datetime(end_date)))
+        if start_time:
+            filters.append(("index", ">=", pd.to_datetime(start_time)))
+        if end_time:
+            filters.append(("index", "<=", pd.to_datetime(end_time)))
 
         # If filters is empty, pass None to read_parquet
         kwargs: Dict[str, Any] = {"columns": columns}
@@ -98,10 +98,10 @@ class ParquetDataCatalog:
         except Exception:
             # Fallback for engines that don't support filters or if index name mismatch
             df = pd.read_parquet(file_path, columns=columns)
-            if start_date:
-                df = df[df.index >= pd.to_datetime(start_date)]
-            if end_date:
-                df = df[df.index <= pd.to_datetime(end_date)]
+            if start_time:
+                df = df[df.index >= pd.to_datetime(start_time)]
+            if end_time:
+                df = df[df.index <= pd.to_datetime(end_time)]
 
         return df
 


### PR DESCRIPTION
- 将 `start_date`/`end_date` 统一重命名为 `start_time`/`end_time`，提高参数一致性
- 在回测函数中增加 `start_time` 和 `end_time` 参数，支持直接过滤数据
- 重构费用配置结构，将 `fee_mode` 和 `fee_amount` 拆分为更详细的佣金、印花税等字段
- 增强 `BacktestResult.metrics` 返回的时间字段，自动转换为带时区的 datetime 对象
- 改进数据读取和过滤逻辑，支持多种日期时间格式和类型