### PR TITLE
fix: 修正股票代码映射中的笔误并调整策略持仓周期

### DIFF
--- a/examples/check_multi.py
+++ b/examples/check_multi.py
@@ -16,14 +16,14 @@ df_3 = ak.stock_zh_a_daily(
     symbol="sh600006", start_date="20000101", end_date="20261231"
 )
 df_3["symbol"] = "600006"
-df = {"600000": df_1, "6000004": df_2, "600006": df_3}
+df = {"600000": df_1, "600004": df_2, "600006": df_3}
 
 
 class MyStrategy(Strategy):
     """
     Example strategy for testing broker execution.
 
-    This strategy buys on the first bar and holds for 100 bars or until 10% profit.
+    This strategy buys on the first bar and holds for 5 bars or until 10% profit.
     """
 
     def __init__(self) -> None:
@@ -75,7 +75,7 @@ class MyStrategy(Strategy):
                     f"Current={bar.close}, PnL={pnl_pct:.2%}"
                 )
 
-            # 持仓时间条件：持有满 100 个 Bar
+            # 持仓时间条件：持有满 5 个 Bar
             elif current_bars_held >= 5:
                 self.sell(symbol, pos)
 


### PR DESCRIPTION
将股票代码映射字典中的错误键 "6000004" 更正为正确的 "600004"。
同时将策略示例中的持仓周期描述从 "100 bars" 更新为实际的 "5 bars"，确保文档与实际代码逻辑一致。