### PR TITLE
feat: 扩展 SimpleMarket 以支持完整费率规则并改进每日定时器

### DIFF
--- a/docs/en/advanced/llm.md
+++ b/docs/en/advanced/llm.md
@@ -47,6 +47,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
 
 6.  **Configuration**:
     *   **Risk Config**: Use `RiskConfig` to set parameters like `safety_margin` (default 0.0001).
+    *   **Market Config**: `SimpleMarket` (T+0, 7x24) now supports full fee rules (stamp tax, transfer fee). `ChinaMarket` enforces T+1 and trading sessions.
     *   Example:
         ```python
         from akquant.config import RiskConfig, StrategyConfig, BacktestConfig
@@ -55,6 +56,10 @@ Your task is to write trading strategies or backtest scripts based on user requi
         backtest_config = BacktestConfig(strategy_config=strategy_config)
         run_backtest(..., config=backtest_config)
         ```
+
+7.  **Timers**:
+    *   Use `self.add_daily_timer("HH:MM:SS", "payload")` for recurring daily tasks. It works in both Backtest and Live modes.
+    *   Implement logic in `on_timer(self, payload)`.
 
 ### Example Strategy (Reference)
 

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -79,6 +79,7 @@ def on_bar(self, bar):
 In addition to the low-level `schedule` method, AKQuant provides more convenient ways to register timers:
 
 *   **`add_daily_timer(time_str, payload)`**: Triggers daily at a specified time.
+    *   **Live Mode Supported**: Pre-generates triggers in Backtest mode; Automatically schedules the next trigger daily in Live mode.
 *   **`schedule(trigger_time, payload)`**: Triggers once at a specified datetime.
 
 ```python

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -65,11 +65,12 @@ engine = akquant.Engine()
 
 **Market & Fee Configuration:**
 
-*   `use_simple_market(commission_rate: float)`: Enable simple market (T+0, 7x24, no tax).
+*   `use_simple_market(commission_rate: float)`: Enable simple market (T+0, 7x24).
+    *   **Update**: Now supports stamp tax, transfer fee, and min commission configuration (via `set_stock_fee_rules`).
 *   `use_china_market()`: Enable China market (T+1/T+0, trading sessions, taxes).
 *   `use_china_futures_market()`: Enable China futures market (T+0, manual session config required).
 *   `set_t_plus_one(enabled: bool)`: Enable/Disable T+1 rule (ChinaMarket only).
-*   `set_stock_fee_rules(commission_rate, stamp_tax, transfer_fee, min_commission)`: Set stock fee rules.
+*   `set_stock_fee_rules(commission_rate, stamp_tax, transfer_fee, min_commission)`: Set stock fee rules (Applicable to both SimpleMarket and ChinaMarket).
 *   `set_slippage(type: str, value: float)`: Set slippage. `type` can be `"fixed"` (fixed amount) or `"percent"` (percentage).
 
 **Runtime Methods:**

--- a/docs/zh/advanced/llm.md
+++ b/docs/zh/advanced/llm.md
@@ -47,6 +47,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
 
 6.  **Configuration**:
     *   **Risk Config**: Use `RiskConfig` to set parameters like `safety_margin` (default 0.0001).
+    *   **Market Config**: `SimpleMarket` (T+0, 7x24) now supports full fee rules (stamp tax, transfer fee). `ChinaMarket` enforces T+1 and trading sessions.
     *   Example:
         ```python
         from akquant.config import RiskConfig, StrategyConfig, BacktestConfig
@@ -55,6 +56,10 @@ Your task is to write trading strategies or backtest scripts based on user requi
         backtest_config = BacktestConfig(strategy_config=strategy_config)
         run_backtest(..., config=backtest_config)
         ```
+
+7.  **Timers**:
+    *   Use `self.add_daily_timer("HH:MM:SS", "payload")` for recurring daily tasks. It works in both Backtest and Live modes.
+    *   Implement logic in `on_timer(self, payload)`.
 
 ### Example Strategy (Reference)
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -78,6 +78,7 @@ def on_bar(self, bar):
 除了底层的 `schedule` 方法，AKQuant 提供了更便捷的定时任务注册方式：
 
 *   **`add_daily_timer(time_str, payload)`**: 每天在指定时间触发。
+    *   **支持实盘**: 在回测模式下预生成所有触发时间；在实盘模式下，每日自动调度下一次触发。
 *   **`schedule(trigger_time, payload)`**: 在指定时间点（一次性）触发。
 
 ```python

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -67,11 +67,12 @@ engine = akquant.Engine()
 
 **市场与费率配置:**
 
-*   `use_simple_market(commission_rate: float)`: 启用简单市场 (T+0, 7x24, 无税)。
+*   `use_simple_market(commission_rate: float)`: 启用简单市场 (T+0, 7x24)。
+    *   **更新**: 现已支持印花税、过户费和最低佣金配置 (通过 `set_stock_fee_rules`)。
 *   `use_china_market()`: 启用中国市场 (T+1/T+0, 交易时段, 税费)。
 *   `use_china_futures_market()`: 启用中国期货市场 (T+0, 需手动配置时段)。
 *   `set_t_plus_one(enabled: bool)`: 开启/关闭 T+1 规则 (仅限 ChinaMarket)。
-*   `set_stock_fee_rules(commission_rate, stamp_tax, transfer_fee, min_commission)`: 设置股票费率。
+*   `set_stock_fee_rules(commission_rate, stamp_tax, transfer_fee, min_commission)`: 设置股票费率 (适用于 SimpleMarket 和 ChinaMarket)。
 *   `set_slippage(type: str, value: float)`: 设置滑点。`type` 可为 `"fixed"` (固定金额) 或 `"percent"` (百分比)。
 
 **运行方法:**

--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -31,7 +31,7 @@ class MyStrategy(Strategy):
 
 # 运行回测
 result = aq.run_backtest(
-    data=df, strategy=MyStrategy, symbol="sh600000", initial_cash=100
+    data=df, strategy=MyStrategy, symbol="sh600000", initial_cash=100000
 )
 
 

--- a/python/akquant/backtest.py
+++ b/python/akquant/backtest.py
@@ -1119,26 +1119,9 @@ def run_backtest(
         engine.use_china_market()
         engine.set_t_plus_one(True)
     else:
-        # 即使是 T+0，如果配置了印花税等费率，建议使用 ChinaMarket 或 SimpleMarket
-        # 这里为了保持一致性，默认 SimpleMarket (T+0, 无税)，除非用户显式设置了费率
-        # 如果设置了费率，set_stock_fee_rules 会生效，但 SimpleMarket 不支持印花税
-        # 所以如果印花税 > 0，应该自动切换到 ChinaMarket?
-        # 目前 Engine 的 use_simple_market 只接受 commission_rate
-        # 为了支持印花税，我们统一使用 ChinaMarket 但关闭 T+1?
-        # 现有的逻辑是：engine 默认初始化时是 SimpleMarket
-        # 下面调用 set_t_plus_one(False) 实际上只对 ChinaMarket 有效
-
-        # 简单起见，如果 t_plus_one=False (默认)，我们保持原有逻辑
-        # 但为了支持印花税，最好总是使用 ChinaMarket 并根据 t_plus_one 开关
-        # 不过为了兼容性，我们只在 t_plus_one=True 时强制 ChinaMarket
-        # 或者如果用户传入了 stamp_tax_rate > 0
-        if stamp_tax_rate > 0 or transfer_fee_rate > 0:
-            engine.use_china_market()
-            engine.set_t_plus_one(False)
-        else:
-            # 使用 SimpleMarket (更轻量)
-            # 但 set_stock_fee_rules 可能在 SimpleMarket 下部分参数无效
-            engine.use_simple_market(commission_rate)
+        # T+0 模式
+        # 使用 SimpleMarket (已支持印花税等费率)
+        engine.use_simple_market(commission_rate)
 
     engine.set_force_session_continuous(True)
     engine.set_stock_fee_rules(


### PR DESCRIPTION
- 修改 SimpleMarket 配置以支持印花税、过户费和最低佣金
- 更新 backtest.py 中的逻辑，在 T+0 模式下默认使用 SimpleMarket
- 改进 add_daily_timer 方法，在实盘模式下自动调度下一次触发
- 更新相关文档以反映 SimpleMarket 的完整费率支持
- 将示例中的初始资金从 100 调整为 100000