### PR TITLE
refactor(engine): 引入 EngineContext 重构组件间状态传递

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.37"
+version = "0.1.38"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,8 +1,13 @@
 use crate::analysis::ClosedTrade;
 use crate::event::Event;
 use crate::history::HistoryBuffer;
+use crate::market::MarketModel;
 use crate::model::market_data::extract_decimal;
-use crate::model::{Order, OrderSide, OrderType, TimeInForce, Timer, Trade, TradingSession};
+use crate::model::{
+    ExecutionMode, Instrument, Order, OrderSide, OrderType, TimeInForce, Timer, Trade,
+    TradingSession,
+};
+use crate::portfolio::Portfolio;
 use crate::risk::RiskConfig;
 use numpy::PyArray1;
 use pyo3::prelude::*;
@@ -10,8 +15,21 @@ use pyo3_stub_gen::derive::*;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use std::collections::HashMap;
-use std::sync::{Arc, RwLock, mpsc::Sender};
+use std::sync::{mpsc::Sender, Arc, RwLock};
 use uuid::Uuid;
+
+/// 引擎上下文 (Engine Context)
+/// 用于在 Rust 内部组件之间传递共享状态
+pub struct EngineContext<'a> {
+    pub instruments: &'a HashMap<String, Instrument>,
+    pub portfolio: &'a Portfolio,
+    pub last_prices: &'a HashMap<String, Decimal>,
+    pub market_model: &'a dyn MarketModel,
+    pub execution_mode: ExecutionMode,
+    pub bar_index: usize,
+    pub session: TradingSession,
+    pub active_orders: &'a [Order],
+}
 
 #[gen_stub_pyclass]
 #[pyclass]

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -13,8 +13,9 @@ pub use realtime::RealtimeExecutionClient;
 pub use simulated::SimulatedExecutionClient;
 pub use slippage::{SlippageModel, FixedSlippage, PercentSlippage, ZeroSlippage};
 
+use crate::context::EngineContext;
 use crate::event::Event;
-use crate::model::{Order, TradingSession};
+use crate::model::Order;
 
 /// 交易执行接口 (Execution Client Trait)
 pub trait ExecutionClient: Send + Sync {
@@ -25,18 +26,7 @@ pub trait ExecutionClient: Send + Sync {
     fn on_cancel(&mut self, order_id: &str);
 
     /// 处理市场事件并返回执行报告
-    fn on_event(
-        &mut self,
-        event: &Event,
-        instruments: &std::collections::HashMap<String, crate::model::Instrument>,
-        portfolio: &crate::portfolio::Portfolio,
-        last_prices: &std::collections::HashMap<String, rust_decimal::Decimal>,
-        // risk_manager: &crate::risk::RiskManager, // Removed: Risk checks are done before Execution
-        market_model: &dyn crate::market::MarketModel,
-        execution_mode: crate::model::ExecutionMode,
-        bar_index: usize,
-        session: TradingSession,
-    ) -> Vec<Event>;
+    fn on_event(&mut self, event: &Event, ctx: &EngineContext) -> Vec<Event>;
 
     /// 设置滑点模型 (仅回测有效)
     fn set_slippage_model(&mut self, _model: Box<dyn SlippageModel>) {}

--- a/src/execution/realtime.rs
+++ b/src/execution/realtime.rs
@@ -1,6 +1,6 @@
 use crate::event::Event;
 use crate::execution::ExecutionClient;
-use crate::model::{Order, TradingSession};
+use crate::model::Order;
 
 /// 实盘执行器 (Realtime Execution Client)
 /// 对接外部交易接口 (如 CTP/Broker API)
@@ -31,18 +31,7 @@ impl ExecutionClient for RealtimeExecutionClient {
         // In real impl, send cancel to broker API
     }
 
-    fn on_event(
-        &mut self,
-        _event: &Event,
-        _instruments: &std::collections::HashMap<String, crate::model::Instrument>,
-        _portfolio: &crate::portfolio::Portfolio,
-        _last_prices: &std::collections::HashMap<String, rust_decimal::Decimal>,
-        // _risk_manager: &crate::risk::RiskManager,
-        _market_model: &dyn crate::market::MarketModel,
-        _execution_mode: crate::model::ExecutionMode,
-        _bar_index: usize,
-        _session: TradingSession,
-    ) -> Vec<Event> {
+    fn on_event(&mut self, _event: &Event, _ctx: &crate::context::EngineContext) -> Vec<Event> {
         // In realtime, this might check for interaction with broker
         Vec::new()
     }

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -64,7 +64,7 @@ impl pyo3_stub_gen::PyStubType for SettlementType {
 }
 
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 资产类型
 pub enum AssetType {
     Stock,

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -1,3 +1,4 @@
+use crate::context::EngineContext;
 use crate::data::FeedAction;
 use crate::engine::Engine;
 use crate::event::Event;
@@ -14,13 +15,19 @@ impl Processor for ChannelProcessor {
             match event {
                 Event::OrderRequest(mut order) => {
                     // 1. Risk Check & Adjustment
-                    if let Err(err) = engine.risk_manager.check_and_adjust(
-                        &mut order,
-                        &engine.portfolio,
-                        &engine.instruments,
-                        &engine.order_manager.active_orders,
-                        &engine.last_prices,
-                    ) {
+                    // Create Context
+                    let ctx = EngineContext {
+                        instruments: &engine.instruments,
+                        portfolio: &engine.state.portfolio,
+                        last_prices: &engine.last_prices,
+                        market_model: engine.market_manager.model.as_ref(),
+                        execution_mode: engine.execution_mode,
+                        bar_index: engine.bar_count,
+                        session: engine.clock.session,
+                        active_orders: &engine.state.order_manager.active_orders,
+                    };
+
+                    if let Err(err) = engine.risk_manager.check_and_adjust(&mut order, &ctx) {
                         // Rejected
                         order.status = OrderStatus::Rejected;
                         order.reject_reason = err.to_string();
@@ -37,11 +44,11 @@ impl Processor for ChannelProcessor {
                     // 2. Send to Execution Client
                     engine.execution_model.on_order(order.clone());
                     // Add to local active (Strategy View)
-                    engine.order_manager.add_active_order(order);
+                    engine.state.order_manager.add_active_order(order);
                 }
                 Event::ExecutionReport(order, trade) => {
                     // 3. Update Order State
-                    engine.order_manager.on_execution_report(order);
+                    engine.state.order_manager.on_execution_report(order);
 
                     // 4. Process Trade (if any)
                     if let Some(t) = trade {
@@ -53,9 +60,9 @@ impl Processor for ChannelProcessor {
         }
 
         if !trades_to_process.is_empty() {
-            engine.order_manager.process_trades(
+            engine.state.order_manager.process_trades(
                 trades_to_process,
-                &mut engine.portfolio,
+                &mut engine.state.portfolio,
                 &engine.instruments,
                 engine.market_manager.model.as_ref(),
                 &engine.history_buffer,
@@ -80,7 +87,7 @@ impl DataProcessor {
 impl Processor for DataProcessor {
     fn process(&mut self, engine: &mut Engine, py: Python<'_>, _strategy: &Bound<'_, PyAny>) -> PyResult<ProcessorResult> {
         let next_timer_time = engine.timers.peek().map(|t| t.timestamp);
-        let action = engine.feed.next_action(next_timer_time, py);
+        let action = engine.state.feed.next_action(next_timer_time, py);
 
         match action {
             FeedAction::Wait => Ok(ProcessorResult::Loop),
@@ -128,10 +135,10 @@ impl Processor for DataProcessor {
                     if engine.current_date.is_some() {
                         engine.statistics_manager.record_snapshot(
                             timestamp,
-                            &engine.portfolio,
+                            &engine.state.portfolio,
                             &engine.instruments,
                             &engine.last_prices,
-                            &engine.order_manager.trade_tracker,
+                            &engine.state.order_manager.trade_tracker,
                         );
                     }
                     engine.current_date = Some(local_date);
@@ -140,20 +147,24 @@ impl Processor for DataProcessor {
                     let mut expired_orders = Vec::new();
                     engine.settlement_manager.process_daily_settlement(
                         local_date,
-                        &mut engine.portfolio,
+                        &mut engine.state.portfolio,
                         &engine.instruments,
                         &engine.last_prices,
                         &engine.market_manager,
-                        &mut engine.order_manager.active_orders,
+                        &mut engine.state.order_manager.active_orders,
                         &mut expired_orders,
                     );
 
                     for o in expired_orders {
-                        engine.order_manager.orders.push(o);
+                        engine.state.order_manager.orders.push(o);
                     }
                 }
 
-                if let Event::Bar(ref _b) = event {
+                if let Event::Bar(ref b) = event {
+                    // Update History Buffer
+                    if let Ok(mut buffer) = engine.history_buffer.write() {
+                        buffer.update(b);
+                    }
                     // println!("DataProcessor: Bar Symbol={}, TS={}", b.symbol, b.timestamp);
                 }
 
@@ -221,16 +232,19 @@ impl Processor for ExecutionProcessor {
         if let Some(event) = engine.current_event.clone() {
             match event {
                 Event::Bar(_) | Event::Tick(_) => {
-                    let reports = engine.execution_model.on_event(
-                        &event,
-                        &engine.instruments,
-                        &engine.portfolio,
-                        &engine.last_prices,
-                        engine.market_manager.model.as_ref(),
-                        engine.execution_mode,
-                        engine.bar_count,
-                        engine.clock.session,
-                    );
+                    // Create Context
+                    let ctx = EngineContext {
+                        instruments: &engine.instruments,
+                        portfolio: &engine.state.portfolio,
+                        last_prices: &engine.last_prices,
+                        market_model: engine.market_manager.model.as_ref(),
+                        execution_mode: engine.execution_mode,
+                        bar_index: engine.bar_count,
+                        session: engine.clock.session,
+                        active_orders: &engine.state.order_manager.active_orders,
+                    };
+
+                    let reports = engine.execution_model.on_event(&event, &ctx);
                     for report in reports {
                         let _ = engine.event_manager.send(report);
                     }
@@ -246,7 +260,7 @@ pub struct CleanupProcessor;
 
 impl Processor for CleanupProcessor {
     fn process(&mut self, engine: &mut Engine, _py: Python<'_>, _strategy: &Bound<'_, PyAny>) -> PyResult<ProcessorResult> {
-        engine.order_manager.cleanup_finished_orders();
+        engine.state.order_manager.cleanup_finished_orders();
         Ok(ProcessorResult::Next)
     }
 }
@@ -259,8 +273,8 @@ impl Processor for StatisticsProcessor {
             match event {
                  Event::Bar(_) | Event::Tick(_) => {
                     if let Some(timestamp) = engine.clock.timestamp() {
-                         let equity = engine.portfolio.calculate_equity(&engine.last_prices, &engine.instruments);
-                         engine.statistics_manager.update(timestamp, equity, engine.portfolio.cash);
+                         let equity = engine.state.portfolio.calculate_equity(&engine.last_prices, &engine.instruments);
+                         engine.statistics_manager.update(timestamp, equity, engine.state.portfolio.cash);
                     }
                  }
                  _ => {}


### PR DESCRIPTION
- 新增 EngineContext 结构体，统一传递引擎状态至执行器、风控等组件
- 重构 ExecutionClient trait 的 on_event 方法，使用 EngineContext 替代多个独立参数
- 重构 RiskManager 的风控检查接口，支持 EngineContext 参数
- 调整市场管理器初始化逻辑，确保各资产类型配置默认启用
- 优化回测引擎内部状态管理，提取 SharedState 结构体
- 修复 ML 策略特征处理中的 NaN 填充问题，避免训练数据污染