### PR TITLE
feat(execution): 支持Python自定义撮合器并优化回测性能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,13 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "anyhow",
  "chrono",
  "csv",
  "indicatif",
+ "log",
  "numpy",
  "polars",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"
@@ -29,6 +29,7 @@ indicatif = "0.18"
 csv = "1.3"
 thiserror = "2.0.18"
 rust_decimal_macros = "1.40"
+log = "0.4"
 
 [features]
 default = ["extension-module"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.39"
+version = "0.1.40"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/data.rs
+++ b/src/data.rs
@@ -140,11 +140,26 @@ impl CsvDataClient {
 
             let bar = Bar {
                 timestamp: normalize_timestamp(row.timestamp),
-                open: Decimal::from_f64(row.open).unwrap_or(Decimal::ZERO),
-                high: Decimal::from_f64(row.high).unwrap_or(Decimal::ZERO),
-                low: Decimal::from_f64(row.low).unwrap_or(Decimal::ZERO),
-                close: Decimal::from_f64(row.close).unwrap_or(Decimal::ZERO),
-                volume: Decimal::from_f64(row.volume).unwrap_or(Decimal::ZERO),
+                open: Decimal::from_f64(row.open).unwrap_or_else(|| {
+                    log::warn!("Invalid open price {}, defaulting to 0.0", row.open);
+                    Decimal::ZERO
+                }),
+                high: Decimal::from_f64(row.high).unwrap_or_else(|| {
+                    log::warn!("Invalid high price {}, defaulting to 0.0", row.high);
+                    Decimal::ZERO
+                }),
+                low: Decimal::from_f64(row.low).unwrap_or_else(|| {
+                    log::warn!("Invalid low price {}, defaulting to 0.0", row.low);
+                    Decimal::ZERO
+                }),
+                close: Decimal::from_f64(row.close).unwrap_or_else(|| {
+                    log::warn!("Invalid close price {}, defaulting to 0.0", row.close);
+                    Decimal::ZERO
+                }),
+                volume: Decimal::from_f64(row.volume).unwrap_or_else(|| {
+                    log::warn!("Invalid volume {}, defaulting to 0.0", row.volume);
+                    Decimal::ZERO
+                }),
                 symbol: self.symbol.clone(),
                 extra: HashMap::new(),
             };
@@ -384,11 +399,26 @@ pub fn from_arrays(
 
         bars.push(Bar {
             timestamp: normalized_ts,
-            open: Decimal::from_f64(opens[i]).unwrap_or(Decimal::ZERO),
-            high: Decimal::from_f64(highs[i]).unwrap_or(Decimal::ZERO),
-            low: Decimal::from_f64(lows[i]).unwrap_or(Decimal::ZERO),
-            close: Decimal::from_f64(closes[i]).unwrap_or(Decimal::ZERO),
-            volume: Decimal::from_f64(volumes[i]).unwrap_or(Decimal::ZERO),
+            open: Decimal::from_f64(opens[i]).unwrap_or_else(|| {
+                log::warn!("Invalid open price {}, defaulting to 0.0", opens[i]);
+                Decimal::ZERO
+            }),
+            high: Decimal::from_f64(highs[i]).unwrap_or_else(|| {
+                log::warn!("Invalid high price {}, defaulting to 0.0", highs[i]);
+                Decimal::ZERO
+            }),
+            low: Decimal::from_f64(lows[i]).unwrap_or_else(|| {
+                log::warn!("Invalid low price {}, defaulting to 0.0", lows[i]);
+                Decimal::ZERO
+            }),
+            close: Decimal::from_f64(closes[i]).unwrap_or_else(|| {
+                log::warn!("Invalid close price {}, defaulting to 0.0", closes[i]);
+                Decimal::ZERO
+            }),
+            volume: Decimal::from_f64(volumes[i]).unwrap_or_else(|| {
+                log::warn!("Invalid volume {}, defaulting to 0.0", volumes[i]);
+                Decimal::ZERO
+            }),
             symbol: sym,
             extra: bar_extra,
         });
@@ -584,7 +614,10 @@ impl DataFeed {
 
         // Calculate timeout
         let timeout = if let Some(timer_ts) = next_timer_timestamp {
-            let now = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+            let now = Utc::now().timestamp_nanos_opt().unwrap_or_else(|| {
+                log::warn!("Failed to get current timestamp, defaulting to 0");
+                0
+            });
             if timer_ts > now {
                 let diff_ms = (timer_ts - now) / 1_000_000;
                 if diff_ms > 0 {
@@ -630,7 +663,10 @@ impl DataFeed {
         } else {
             // Live logic
             // Calculate timeout
-            let now = Utc::now().timestamp_nanos_opt().unwrap_or(0);
+            let now = Utc::now().timestamp_nanos_opt().unwrap_or_else(|| {
+                log::warn!("Failed to get current timestamp, defaulting to 0");
+                0
+            });
             let timeout = if let Some(tt) = next_timer_ts {
                 if tt > now {
                     let diff_ms = (tt - now) / 1_000_000;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -187,6 +187,16 @@ impl Engine {
         self.execution_model = Box::new(RealtimeExecutionClient::new());
     }
 
+    /// 注册自定义撮合器 (Python)
+    ///
+    /// :param asset_type: 资产类型
+    /// :param matcher: Python 撮合器对象 (需实现 match 方法)
+    fn register_custom_matcher(&mut self, asset_type: crate::model::AssetType, matcher: Py<PyAny>) {
+        use crate::execution::PyExecutionMatcher;
+        let py_matcher = Box::new(PyExecutionMatcher::new(matcher));
+        self.execution_model.register_matcher(asset_type, py_matcher);
+    }
+
     /// 设置撮合模式
     ///
     /// :param mode: 撮合模式 (ExecutionMode.CurrentClose 或 ExecutionMode.NextOpen)

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -2,6 +2,7 @@ pub mod common;
 pub mod futures;
 pub mod matcher;
 pub mod option;
+pub mod python;
 pub mod realtime;
 pub mod simulated;
 pub mod slippage;
@@ -9,6 +10,7 @@ pub mod stock;
 
 pub use common::CommonMatcher;
 pub use matcher::ExecutionMatcher;
+pub use python::PyExecutionMatcher;
 pub use realtime::RealtimeExecutionClient;
 pub use simulated::SimulatedExecutionClient;
 pub use slippage::{SlippageModel, FixedSlippage, PercentSlippage, ZeroSlippage};
@@ -33,6 +35,9 @@ pub trait ExecutionClient: Send + Sync {
 
     /// 设置成交量限制 (仅回测有效)
     fn set_volume_limit(&mut self, _limit: f64) {}
+
+    /// 注册自定义撮合器 (仅回测有效)
+    fn register_matcher(&mut self, _asset_type: crate::model::AssetType, _matcher: Box<dyn ExecutionMatcher>) {}
 
     /// 是否为实盘模式
     #[allow(dead_code)]

--- a/src/execution/python.rs
+++ b/src/execution/python.rs
@@ -1,0 +1,85 @@
+use crate::event::Event;
+use crate::execution::matcher::ExecutionMatcher;
+use crate::execution::slippage::SlippageModel;
+use crate::model::{ExecutionMode, Instrument, Order, Trade};
+use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
+use rust_decimal::Decimal;
+
+/// Python 自定义撮合器包装器
+///
+/// 将 Rust 的 ExecutionMatcher trait 转发给 Python 对象。
+/// Python 对象需要实现 `match` 方法:
+/// `def match(self, order: Order, event: Union[Bar, Tick], instrument: Instrument) -> Optional[Trade]: ...`
+pub struct PyExecutionMatcher {
+    inner: Py<PyAny>,
+}
+
+impl PyExecutionMatcher {
+    pub fn new(obj: Py<PyAny>) -> Self {
+        Self { inner: obj }
+    }
+}
+
+impl ExecutionMatcher for PyExecutionMatcher {
+    fn match_order(
+        &self,
+        order: &mut Order,
+        event: &Event,
+        instrument: &Instrument,
+        _execution_mode: ExecutionMode,
+        _slippage: &dyn SlippageModel,
+        _volume_limit_pct: Decimal,
+        bar_index: usize,
+    ) -> Option<Event> {
+        Python::attach(|py| {
+            // 1. Convert arguments to Python objects
+            // Use clone() to create a copy for Python
+            let py_order = order.clone().into_py_any(py).ok()?;
+
+            let py_event = match event {
+                Event::Bar(b) => b.clone().into_py_any(py).ok()?,
+                Event::Tick(t) => t.clone().into_py_any(py).ok()?,
+                _ => return None, // Only support matching on Bar/Tick
+            };
+
+            let py_instrument = instrument.clone().into_py_any(py).ok()?;
+
+            // 2. Call Python `match` method
+            // Signature: match(self, order, event, instrument) -> Optional[Trade]
+            // Note: The Python method is expected to modify `order` in-place if needed,
+            // and return a Trade if a trade occurred.
+            let args = (py_order.clone_ref(py), py_event, py_instrument, bar_index);
+
+            match self.inner.call_method1(py, "match", args) {
+                Ok(result) => {
+                    // 3. Check result
+                    if result.is_none(py) {
+                        return None;
+                    }
+
+                    // 4. If result is a Trade, extract it
+                    if let Ok(trade) = result.extract::<Trade>(py) {
+                        // 5. Sync back modified Order state from Python object
+                        if let Ok(updated_order) = py_order.extract::<Order>(py) {
+                            *order = updated_order;
+                        } else {
+                            // Log warning? Failed to extract updated order
+                            // eprintln!("PyExecutionMatcher: Failed to extract updated Order from Python");
+                        }
+
+                        // 6. Return ExecutionReport
+                        return Some(Event::ExecutionReport(order.clone(), Some(trade)));
+                    } else {
+                        // eprintln!("PyExecutionMatcher: Python match method returned something that is not a Trade or None");
+                        return None;
+                    }
+                }
+                Err(e) => {
+                    e.print_and_set_sys_last_vars(py);
+                    return None;
+                }
+            }
+        })
+    }
+}

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -143,12 +143,28 @@ impl Order {
         self.filled_quantity.to_f64().unwrap_or_default()
     }
 
+    #[setter]
+    fn set_filled_quantity(&mut self, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.filled_quantity = extract_decimal(value)?;
+        Ok(())
+    }
+
     #[getter]
     /// 获取成交均价.
     /// :return: 成交均价 (如果未成交则返回 None)
     fn get_average_filled_price(&self) -> Option<f64> {
         self.average_filled_price
             .map(|d| d.to_f64().unwrap_or_default())
+    }
+
+    #[setter]
+    fn set_average_filled_price(&mut self, value: Option<&Bound<'_, PyAny>>) -> PyResult<()> {
+        if let Some(v) = value {
+             self.average_filled_price = Some(extract_decimal(v)?);
+        } else {
+             self.average_filled_price = None;
+        }
+        Ok(())
     }
 
     pub fn __repr__(&self) -> String {

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -50,11 +50,18 @@ impl pyo3_stub_gen::PyStubType for TradingSession {
 }
 
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 结算方式
 pub enum SettlementType {
     Physical, // 实物交割
     Cash,     // 现金交割
+}
+
+#[pymethods]
+impl SettlementType {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
 }
 
 impl pyo3_stub_gen::PyStubType for SettlementType {
@@ -73,16 +80,30 @@ pub enum AssetType {
     Option,
 }
 
+#[pymethods]
+impl AssetType {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 期权类型
 pub enum OptionType {
     Call,
     Put,
 }
 
+#[pymethods]
+impl OptionType {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 订单类型
 pub enum OrderType {
     Market,
@@ -91,16 +112,30 @@ pub enum OrderType {
     StopLimit,
 }
 
+#[pymethods]
+impl OrderType {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 交易方向
 pub enum OrderSide {
     Buy,
     Sell,
 }
 
+#[pymethods]
+impl OrderSide {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 订单状态
 pub enum OrderStatus {
     New,
@@ -111,8 +146,15 @@ pub enum OrderStatus {
     Expired,
 }
 
+#[pymethods]
+impl OrderStatus {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 订单有效期
 #[allow(clippy::upper_case_acronyms)]
 pub enum TimeInForce {
@@ -122,8 +164,15 @@ pub enum TimeInForce {
     Day, // Good for Day
 }
 
+#[pymethods]
+impl TimeInForce {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 撮合执行模式
 pub enum ExecutionMode {
     CurrentClose, // 当前Bar收盘价成交 (Cheat-on-Close)
@@ -132,8 +181,15 @@ pub enum ExecutionMode {
     NextHighLowMid, // 下一根Bar最高价和最低价的中间价成交
 }
 
+#[pymethods]
+impl ExecutionMode {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
+}
+
 #[pyclass(eq, eq_int)]
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// 交易时段状态
 pub enum TradingSession {
     PreOpen,     // 盘前 (如集合竞价)
@@ -142,4 +198,11 @@ pub enum TradingSession {
     Break,       // 休市 (如午休)
     Closed,      // 闭市
     PostClose,   // 盘后
+}
+
+#[pymethods]
+impl TradingSession {
+    fn __hash__(&self) -> isize {
+        *self as isize
+    }
 }

--- a/tests/test_custom_matcher.py
+++ b/tests/test_custom_matcher.py
@@ -1,0 +1,120 @@
+"""Test custom matcher functionality."""
+
+from typing import Optional
+
+import akquant as aq
+import pandas as pd
+from akquant import AssetType, Bar, Instrument, Order, OrderStatus, Strategy, Trade
+
+
+class CustomStockMatcher:
+    """Custom stock matcher for testing."""
+
+    def match(
+        self,
+        order: Order,
+        event: Bar,
+        instrument: Instrument,
+        bar_index: int,
+    ) -> Optional[Trade]:
+        """Match order at the event close price and return a Trade or None."""
+        if not hasattr(event, "close"):
+            return None
+
+        # Simple match logic: fill at close price
+        fill_price = event.close
+
+        # Update order status
+        order.status = OrderStatus.Filled
+        order.filled_quantity = order.quantity
+        order.average_filled_price = fill_price
+
+        # Create trade
+        trade = Trade(
+            id=f"trade_{order.id}",
+            order_id=order.id,
+            symbol=order.symbol,
+            price=fill_price,
+            quantity=order.quantity,
+            side=order.side,
+            timestamp=event.timestamp,
+            commission=0.0,
+            bar_index=bar_index,
+        )
+        print(
+            f"[CustomMatcher] Filled order {order.id} at {fill_price}, "
+            f"bar_index={bar_index}"
+        )
+        return trade
+
+
+# 2. Setup Data
+dates = pd.date_range("2024-01-01", periods=10, freq="D")
+data = pd.DataFrame(
+    {
+        "open": 100.0,
+        "high": 105.0,
+        "low": 95.0,
+        "close": 100.0,
+        "volume": 1000,
+        "symbol": "TEST",
+    },
+    index=dates,
+)
+
+
+# 3. Setup Strategy
+class TestStrategy(Strategy):
+    """Minimal strategy to trigger buy/sell for matcher testing."""
+
+    def on_start(self) -> None:
+        """Initialize internal counter."""
+        self.count = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        """Place orders on specific bars to exercise the matcher."""
+        # Buy on first bar, Sell on second bar (bar index 0 and 1)
+        # Note: on_bar is called for each bar.
+        # Bar 0: Buy. Match on Bar 1.
+        # Bar 1: Position is 100. Sell. Match on Bar 2.
+
+        if self.count == 0:
+            print(f"Sending Buy Order at {bar.timestamp}")
+            self.buy(self.symbol, 100)
+        elif self.count == 2:
+            print(f"Sending Sell Order at {bar.timestamp}")
+            self.sell(self.symbol, 100)
+
+        self.count += 1
+
+
+# 4. Run Backtest with custom matcher
+print("Running backtest with custom matcher...")
+custom_matchers = {AssetType.Stock: CustomStockMatcher()}
+
+result = aq.run_backtest(
+    strategy=TestStrategy,
+    data=data,
+    symbol="TEST",
+    initial_cash=100000,
+    custom_matchers=custom_matchers,
+    asset_type=AssetType.Stock,  # Ensure instrument is stock
+)
+
+print("-" * 20)
+print("Trades DF (Closed Trades):")
+print(result.trades_df)
+
+# Also check executions/orders
+print("-" * 20)
+print("Executions:")
+if hasattr(result, "executions"):
+    for exec in result.executions:
+        print(exec)
+
+if not result.trades_df.empty or (
+    hasattr(result, "executions") and len(result.executions) > 0
+):
+    print("SUCCESS: Trades/Executions generated.")
+else:
+    print("FAILURE: No trades generated.")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -18,8 +18,6 @@ def test_engine_initialization() -> None:
 class DummyStrategy(akquant.Strategy):
     """A dummy strategy for testing purposes."""
 
-    pass
-
 
 class RegressionStrategy(akquant.Strategy):
     """Regression strategy for baseline checks."""
@@ -47,10 +45,22 @@ class NoopStrategy(akquant.Strategy):
 
 
 def _ns(dt: datetime) -> int:
+    """
+    Convert a datetime to nanoseconds since epoch.
+
+    :param dt: Datetime object.
+    :return: Nanoseconds since epoch.
+    """
     return int(dt.timestamp() * 1e9)
 
 
 def _build_regression_bars(symbol: str) -> list[akquant.Bar]:
+    """
+    Build a deterministic 3-bar series for regression verification.
+
+    :param symbol: Symbol for bars.
+    :return: List of Bar objects.
+    """
     day1 = _ns(datetime(2023, 1, 2, 15, 0, tzinfo=timezone.utc))
     day2 = _ns(datetime(2023, 1, 3, 15, 0, tzinfo=timezone.utc))
     day3 = _ns(datetime(2023, 1, 4, 15, 0, tzinfo=timezone.utc))
@@ -62,6 +72,13 @@ def _build_regression_bars(symbol: str) -> list[akquant.Bar]:
 
 
 def _build_benchmark_data(n: int, symbol: str) -> pd.DataFrame:
+    """
+    Build a synthetic minute-level dataset for throughput tests.
+
+    :param n: Number of rows.
+    :param symbol: Symbol name.
+    :return: DataFrame with OHLCV and symbol columns.
+    """
     rng = np.random.default_rng(7)
     dates = pd.date_range("2020-01-01", periods=n, freq="min", tz="UTC")
     returns = rng.normal(0, 0.001, n)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,3 +1,16 @@
+"""Version sanity check tests."""
+
+from typing import Any
+
 import akquant as aq
 
-print(aq.__version__)
+
+def test_version_present() -> None:
+    """
+    Ensure package exposes a non-empty __version__ string.
+
+    :return: None
+    """
+    v: Any = aq.__version__
+    assert isinstance(v, str)
+    assert len(v) > 0


### PR DESCRIPTION
- 新增PyExecutionMatcher包装器，允许在Python中实现自定义撮合逻辑
- 为BacktestResult添加get_trades_ipc和get_positions_ipc方法，通过Arrow IPC实现零拷贝数据传输
- 优化模拟执行器订单存储结构，使用HashMap提高订单查找效率
- 为所有枚举类型添加__hash__方法以支持字典键使用
- 在Order类中添加filled_quantity和average_filled_price的setter方法
- 在run_backtest函数中增加custom_matchers参数以注册自定义撮合器
- 添加日志依赖并完善错误处理，当价格转换失败时记录警告
- 更新版本至0.1.40，添加相关测试用例