### PR TITLE
feat(strategy): 新增get_order和get_account方法并更新API文档

### DIFF
--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -13,24 +13,78 @@ def run_backtest(
     data: Optional[Union[pd.DataFrame, Dict[str, pd.DataFrame], List[Bar]]] = None,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = None,
     symbol: Union[str, List[str]] = "BENCHMARK",
-    cash: float = 1_000_000.0,
-    commission: float = 0.0003,
+    initial_cash: Optional[float] = None,
+    commission_rate: Optional[float] = None,
+    stamp_tax_rate: float = 0.0,
+    transfer_fee_rate: float = 0.0,
+    min_commission: float = 0.0,
+    execution_mode: Union[ExecutionMode, str] = ExecutionMode.NextOpen,
+    timezone: Optional[str] = None,
     t_plus_one: bool = False,
-    instruments_config: Optional[Union[List[InstrumentConfig], Dict[str, InstrumentConfig]]] = None,
-    instruments: Optional[List[Instrument]] = None,
+    initialize: Optional[Callable[[Any], None]] = None,
+    context: Optional[Dict[str, Any]] = None,
+    history_depth: Optional[int] = None,
     warmup_period: int = 0,
-    # ... 其他参数
+    lot_size: Union[int, Dict[str, int], None] = None,
+    show_progress: Optional[bool] = None,
+    start_time: Optional[Union[str, Any]] = None,
+    end_time: Optional[Union[str, Any]] = None,
+    config: Optional[BacktestConfig] = None,
+    instruments_config: Optional[Union[List[InstrumentConfig], Dict[str, InstrumentConfig]]] = None,
+    custom_matchers: Optional[Dict[AssetType, Any]] = None,
+    **kwargs: Any,
 ) -> BacktestResult
 ```
 
 **关键参数:**
 
 *   `data`: 回测数据。支持单个 DataFrame，或 `{symbol: DataFrame}` 字典。
-*   `t_plus_one`: **(新增)** 是否启用 T+1 交易规则 (默认 False)。如果启用，将强制使用中国市场模型。
-*   `warmup_period`: **(新增)** 策略预热期。指定需要预加载的历史数据长度（Bar 数量），用于计算指标。
-*   `instruments_config`: **(新增)** 标的配置。用于设置期货/期权等非股票资产的参数（如乘数、保证金）。
+*   `strategy`: 策略类或实例。也支持传入 `on_bar` 函数（函数式编程风格）。
+*   `symbol`: 标的代码或代码列表。
+*   `initial_cash`: 初始资金 (默认 1,000,000.0)。
+*   `execution_mode`: 执行模式。
+    *   `ExecutionMode.NextOpen`: 下一 Bar 开盘价成交 (默认)。
+    *   `ExecutionMode.CurrentClose`: 当前 Bar 收盘价成交。
+*   `t_plus_one`: 是否启用 T+1 交易规则 (默认 False)。如果启用，将强制使用中国市场模型。
+*   `warmup_period`: 策略预热期。指定需要预加载的历史数据长度（Bar 数量），用于计算指标。
+*   `start_time` / `end_time`: 回测开始/结束时间。
+*   `config`: `BacktestConfig` 配置对象，用于集中管理配置。
+*   `instruments_config`: 标的配置。用于设置期货/期权等非股票资产的参数（如乘数、保证金）。
     *   接收 `List[InstrumentConfig]` 或 `{symbol: InstrumentConfig}`。
-*   `instruments`: **(新增)** 显式 `Instrument` 对象列表。用于 `InstrumentConfig` 无法满足的高级配置场景（如需指定期权行权价/到期日/结算方式）。
+
+### `akquant.BacktestConfig`
+
+用于集中配置回测参数的数据类。
+
+```python
+@dataclass
+class BacktestConfig:
+    strategy_config: StrategyConfig
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
+    instruments: Optional[List[str]] = None
+    instruments_config: Optional[Union[List[InstrumentConfig], Dict[str, InstrumentConfig]]] = None
+    benchmark: Optional[str] = None
+    timezone: str = "Asia/Shanghai"
+    show_progress: bool = True
+    history_depth: int = 0
+```
+
+### `akquant.StrategyConfig`
+
+策略层面的配置，包含资金、费率和风控。
+
+```python
+@dataclass
+class StrategyConfig:
+    initial_cash: float = 100000.0
+    commission_rate: float = 0.0
+    stamp_tax_rate: float = 0.0
+    transfer_fee_rate: float = 0.0
+    min_commission: float = 0.0
+    enable_fractional_shares: bool = False
+    risk: Optional[RiskConfig] = None
+```
 
 ### `akquant.InstrumentConfig`
 
@@ -51,64 +105,6 @@ class InstrumentConfig:
     expiry_date: Optional[str] = None  # YYYY-MM-DD
 ```
 
-## 2. 核心引擎 (Core)
-
-### `akquant.Engine`
-
-回测引擎的主入口。
-
-```python
-engine = akquant.Engine()
-```
-
-**配置方法:**
-
-*   `set_timezone(offset: int)`: 设置时区偏移 (秒)。例如 UTC+8 为 28800。
-*   `use_simulated_execution()`: (默认) 启用内存撮合模拟执行。
-*   `use_realtime_execution()`: 启用实盘/仿真执行 (订单发送至外部 Broker)。
-*   `set_execution_mode(mode: ExecutionMode)`: 设置撮合模式。
-    *   `ExecutionMode.NextOpen`: 下一 Bar 开盘价撮合 (默认)。
-    *   `ExecutionMode.CurrentClose`: 当前 Bar 收盘价撮合。
-*   `set_history_depth(depth: int)`: 设置引擎层面的历史数据缓存长度。
-
-**市场与费率配置:**
-
-*   `use_simple_market(commission_rate: float)`: 启用简单市场 (T+0, 7x24)。
-    *   **更新**: 现已支持印花税、过户费和最低佣金配置 (通过 `set_stock_fee_rules`)。
-*   `use_china_market()`: 启用中国市场 (T+1/T+0, 交易时段, 税费)。
-*   `use_china_futures_market()`: 启用中国期货市场 (T+0, 需手动配置时段)。
-*   `set_t_plus_one(enabled: bool)`: 开启/关闭 T+1 规则 (仅限 ChinaMarket)。
-*   `set_stock_fee_rules(commission_rate, stamp_tax, transfer_fee, min_commission)`: 设置股票费率 (适用于 SimpleMarket 和 ChinaMarket)。
-*   `set_slippage(type: str, value: float)`: 设置滑点。`type` 可为 `"fixed"` (固定金额) 或 `"percent"` (百分比)。
-
-**运行方法:**
-
-*   `add_instrument(instrument: Instrument)`: 添加合约定义。
-*   `add_data(feed: DataFeed)`: 添加数据源。
-*   `add_bars(bars: List[Bar])`: 批量添加 Bar 数据。
-*   `run(strategy: Strategy, show_progress: bool) -> str`: 运行回测。
-*   `get_results() -> BacktestResult`: 获取详细回测结果。
-
-### `akquant.DataFeed`
-
-数据容器。
-
-*   `add_bars(bars: List[Bar])`: 添加数据。
-*   `sort()`: 按时间戳排序数据。
-
-### `akquant.BarAggregator`
-
-实时 Tick 聚合器，用于将 Tick 流转换为 Bar 数据并自动注入 DataFeed。
-
-```python
-aggregator = akquant.BarAggregator(feed: DataFeed, interval_min: int = 1)
-```
-
-**方法:**
-
-*   `on_tick(symbol: str, price: float, volume: float, timestamp_ns: int)`: 处理新的 Tick 数据。
-    *   `volume`: 这里的 volume 应该是累计成交量 (TotalVolume)，聚合器会自动计算增量。
-
 ## 2. 策略开发 (Strategy)
 
 ### `akquant.Strategy`
@@ -121,6 +117,15 @@ aggregator = akquant.BarAggregator(feed: DataFeed, interval_min: int = 1)
 *   `on_bar(bar: Bar)`: K 线闭合时触发。
 *   `on_tick(tick: Tick)`: Tick 到达时触发。
 *   `on_timer(payload: str)`: 定时器触发。
+*   `on_stop()`: 策略停止时触发。
+*   `on_train_signal(context)`: 滚动训练信号触发 (ML 模式)。
+
+**属性与快捷访问:**
+
+*   `self.symbol`: 当前正在处理的标的代码。
+*   `self.close`, `self.open`, `self.high`, `self.low`, `self.volume`: 当前 Bar/Tick 的价格和成交量。
+*   `self.position`: 当前标的持仓对象 (`Position`)，包含 `size` 和 `available` 属性。
+*   `self.now`: 当前回测时间 (`pd.Timestamp`)。
 
 **交易方法:**
 
@@ -128,19 +133,33 @@ aggregator = akquant.BarAggregator(feed: DataFeed, interval_min: int = 1)
 *   `sell(symbol, quantity, price=None, ...)`: 卖出。
 *   `short(symbol, quantity, price=None, ...)`: 卖空。
 *   `cover(symbol, quantity, price=None, ...)`: 平空。
-*   `stop_buy(symbol, trigger_price, quantity, ...)`: 止损买入。
-*   `stop_sell(symbol, trigger_price, quantity, ...)`: 止损卖出。
+*   `stop_buy(symbol, trigger_price, quantity, ...)`: 止损买入 (Stop Market)。当价格突破 `trigger_price` 时触发市价买单。
+*   `stop_sell(symbol, trigger_price, quantity, ...)`: 止损卖出 (Stop Market)。当价格跌破 `trigger_price` 时触发市价卖单。
 *   `order_target_value(target_value, symbol, price=None)`: 调整至目标持仓市值。
 *   `order_target_percent(target_percent, symbol, price=None)`: 调整至目标账户占比。
 *   `close_position(symbol)`: 平仓指定标的。
-*   `cancel_all_orders(symbol)`: 取消指定标的的所有挂单。
+*   `cancel_order(order_id: str)`: 撤销指定订单。
+*   `cancel_all_orders(symbol)`: 取消指定标的的所有挂单。如果不指定 `symbol`，则取消所有挂单。
 
-**数据访问:**
+**数据与工具:**
 
 *   `get_history(count, symbol, field="close") -> np.ndarray`: 获取历史数据数组 (Zero-Copy)。
+*   `get_history_df(count, symbol) -> pd.DataFrame`: 获取历史数据 DataFrame (OHLCV)。
 *   `get_position(symbol) -> float`: 获取当前持仓量。
 *   `get_cash() -> float`: 获取当前可用资金。
-*   `subscribe(instrument_id: str)`: 订阅行情。
+*   `get_account() -> Dict[str, float]`: 获取账户详情快照。包含 `cash` (可用资金), `equity` (总权益), `market_value` (持仓市值), 以及 `frozen_cash` 和 `margin` (预留字段，暂为0)。
+*   `get_order(order_id) -> Order`: 获取指定订单详情。
+*   `get_open_orders(symbol) -> List[Order]`: 获取当前未完成订单列表。
+*   `subscribe(instrument_id: str)`: 订阅行情。对于多标的回测或实盘，必须显式订阅才能接收 `on_tick`/`on_bar` 回调。
+*   `log(msg: str, level: int)`: 输出带时间戳的日志。
+*   `schedule(trigger_time, payload)`: 注册单次定时任务。
+*   `add_daily_timer(time_str, payload)`: 注册每日定时任务。
+
+**机器学习支持:**
+
+*   `set_rolling_window(train_window, step)`: 设置滚动训练窗口。
+*   `get_rolling_data(length, symbol)`: 获取滚动训练数据 (X, y)。
+*   `prepare_features(df, mode)`: (需重写) 特征工程与标签生成。
 
 ### `akquant.Bar`
 
@@ -150,19 +169,35 @@ K 线数据对象。
 *   `open`, `high`, `low`, `close`, `volume`: OHLCV 数据。
 *   `symbol`: 标的代码。
 
-## 3. 交易对象 (Trading Objects)
+## 3. 核心引擎 (Core)
+
+### `akquant.Engine`
+
+回测引擎的主入口 (通常通过 `run_backtest` 隐式使用)。
+
+**配置方法:**
+
+*   `set_timezone(offset: int)`: 设置时区偏移。
+*   `use_simulated_execution()` / `use_realtime_execution()`: 设置执行环境。
+*   `set_execution_mode(mode)`: 设置撮合模式。
+*   `set_history_depth(depth)`: 设置历史数据缓存长度。
+
+**市场与费率配置:**
+
+*   `use_simple_market()`: 启用简单市场。
+*   `use_china_market()`: 启用中国市场。
+*   `set_stock_fee_rules(commission, stamp_tax, transfer_fee, min_commission)`: 设置费率。
+
+## 4. 交易对象 (Trading Objects)
 
 ### `akquant.Order`
 
-订单对象。
-
 *   `id`: 订单 ID。
 *   `symbol`: 标的代码。
-*   `side`: `OrderSide.Buy` 或 `OrderSide.Sell`。
-*   `order_type`: `OrderType.Market`, `OrderType.Limit`, `OrderType.StopMarket` 等。
-*   `status`: `OrderStatus.New`, `Submitted`, `Filled`, `Cancelled`, `Rejected` 等。
-*   `quantity`: 委托数量。
-*   `filled_quantity`: 已成交数量。
+*   `side`: `OrderSide.Buy` / `OrderSide.Sell`。
+*   `order_type`: `OrderType.Market` / `OrderType.Limit` 等。
+*   `status`: `OrderStatus.New` / `Filled` / `Cancelled` 等。
+*   `quantity` / `filled_quantity`: 委托/成交数量。
 *   `average_filled_price`: 成交均价。
 
 ### `akquant.Instrument`
@@ -176,77 +211,40 @@ Instrument(
     multiplier=1.0,
     margin_ratio=1.0,
     tick_size=0.01,
-    # 期权相关
-    option_type=None,        # OptionType.Call / OptionType.Put
-    strike_price=None,       # float
-    expiry_date=None,        # int (ns timestamp)
-    underlying_symbol=None,  # str
-    settlement_type=None     # SettlementType.Physical / SettlementType.Cash
+    option_type=None,
+    strike_price=None,
+    expiry_date=None
 )
 ```
 
-## 4. 投资组合与风控 (Portfolio & Risk)
-
-### `akquant.Portfolio`
-
-*   `cash`: 当前现金。
-*   `positions`: 持仓字典 `{symbol: quantity}`。
-*   `available_positions`: 可用持仓 (考虑 T+1 和冻结)。
+## 5. 投资组合与风控 (Portfolio & Risk)
 
 ### `akquant.RiskConfig`
 
 风控配置。
 
-*   `active`: 是否启用。
-*   `max_order_size`: 单笔最大数量。
-*   `max_order_value`: 单笔最大金额。
-*   `max_position_size`: 最大持仓数量。
-*   `restricted_list`: 限制交易名单 (List[str])。
+```python
+@dataclass
+class RiskConfig:
+    active: bool = True
+    safety_margin: float = 0.0001
+    max_order_size: Optional[float] = None
+    max_order_value: Optional[float] = None
+    max_position_size: Optional[float] = None
+    restricted_list: Optional[List[str]] = None
+```
 
-## 5. 结果分析 (Analysis)
+## 6. 结果分析 (Analysis)
 
 ### `akquant.BacktestResult`
 
-回测运行后返回的结果对象，包含账户权益曲线、交易记录和详细的绩效指标。
+回测结果对象。
 
-**主要属性:**
+**属性:**
 
-*   `metrics_df`: (pd.DataFrame) 包含所有绩效指标的表格，以指标名称为索引。
-*   `trades_df`: (pd.DataFrame) 包含所有平仓交易记录的表格。
-*   `orders_df`: (pd.DataFrame) 包含所有委托记录的表格。
-*   `positions_df`: (pd.DataFrame) 包含每日持仓详情，包括持仓数量、市值、浮动盈亏、**持仓均价 (entry_price)** 等。
-*   `equity_curve`: (pd.Series) 权益曲线，索引为时间，值为账户总权益。
-*   `cash_curve`: (pd.Series) 现金曲线，索引为时间，值为账户可用现金。
-
-**绩效指标详解 (Performance Metrics):**
-
-详细的绩效指标说明、单位及计算公式，请参考 **[绩效指标详解](backtest_result.md)**。
-
-
-## 6. 内置指标 (Indicators)
-
-位于 `akquant.indicators` 模块。
-
-*   `SMA(period)`
-*   `EMA(period)`
-*   `MACD(fast, slow, signal)`
-*   `RSI(period)`
-*   `BollingerBands(period, multiplier)`
-*   `ATR(period)`
-
-所有指标均有 `value` 属性获取当前值，且在注册到 Strategy 后会自动更新。
-
-## 7. 机器学习 (Machine Learning)
-
-AKQuant 提供了专门的机器学习支持模块 `akquant.ml`。详细使用说明请参考 [机器学习指南](ml_guide.md)。
-
-### 核心类
-
-*   `akquant.ml.QuantModel`: 所有 ML 模型的统一接口。
-*   `akquant.ml.SklearnAdapter`: 用于适配 Scikit-learn 风格的模型 (如 XGBoost, LightGBM)。
-*   `akquant.ml.PyTorchAdapter`: 用于适配 PyTorch 深度学习模型。
-
-主要方法:
-
-*   `set_validation(method='walk_forward', verbose=False, ...)`: 配置滚动验证/训练参数。
-*   `predict(X)`: 执行预测。
+*   `metrics_df`: 绩效指标表格。
+*   `trades_df`: 交易记录表格。
+*   `orders_df`: 委托记录表格。
+*   `positions_df`: 每日持仓详情。
+*   `equity_curve`: 权益曲线。
+*   `cash_curve`: 现金曲线。


### PR DESCRIPTION
- 在Strategy类中添加get_order方法，支持通过订单ID查询订单详情
- 添加get_account方法，返回包含现金、权益、市值等信息的账户快照
- 更新get_open_orders和get_trades方法的返回类型注解为List[Any]
- 全面更新中英文API文档，重构run_backtest参数，新增BacktestConfig、StrategyConfig和RiskConfig配置类
- 重新组织文档结构，详细说明Strategy类的属性、方法和交易功能