### PR TITLE
feat(history): 支持数值型扩展字段并修复时间戳精度问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.42"
+version = "0.1.43"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -21,6 +21,31 @@
 
 Here are some common quantitative strategy implementations that you can use directly in your projects. We provide detailed logic explanations for each strategy to help you understand the core concepts.
 
+### Use Adjusted Series for Signals, Real Prices for Execution
+
+When your data provides `adj_close` or `adj_factor`, you can fetch adjusted series directly via `get_history(symbol=..., field="adj_close", n)` for signal computation, while matching and valuation still use real `close`. See `examples/13_adj_returns_signal.py`.
+
+```python
+import akquant as aq
+from akquant import Strategy
+
+class AdjSignal(Strategy):
+    warmup_period = 5
+    def on_bar(self, bar):
+        try:
+            x = self.get_history(2, bar.symbol, "adj_close")
+        except Exception:
+            return
+        if x is None or len(x) < 2:
+            return
+        r = x[-1] / x[-2] - 1.0
+        pos = self.get_position(bar.symbol)
+        if pos == 0 and r > 0:
+            self.buy(bar.symbol, 100)
+        elif pos > 0 and r < 0:
+            self.close_position(bar.symbol)
+```
+
 ### 3.1 Dual Moving Average Strategy
 
 **Core Concept**:

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -143,7 +143,7 @@ Strategy base class. Users should inherit from this class and override callback 
 
 **Data & Utilities:**
 
-*   `get_history(count, symbol, field="close") -> np.ndarray`: Get history data array (Zero-Copy).
+*   `get_history(count, symbol, field="close") -> np.ndarray`: Get history data array (Zero-Copy). Supports `open/high/low/close/volume` and any numeric extra fields (e.g., `adj_close`, `adj_factor`).
 *   `get_history_df(count, symbol) -> pd.DataFrame`: Get history data DataFrame (OHLCV).
 *   `get_position(symbol) -> float`: Get current position size.
 *   `get_cash() -> float`: Get current available cash.

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -143,7 +143,7 @@ class InstrumentConfig:
 
 **数据与工具:**
 
-*   `get_history(count, symbol, field="close") -> np.ndarray`: 获取历史数据数组 (Zero-Copy)。
+*   `get_history(count, symbol, field="close") -> np.ndarray`: 获取历史数据数组 (Zero-Copy)。支持 `open/high/low/close/volume` 以及任何数值型扩展字段（例如 `adj_close`, `adj_factor`）。
 *   `get_history_df(count, symbol) -> pd.DataFrame`: 获取历史数据 DataFrame (OHLCV)。
 *   `get_position(symbol) -> float`: 获取当前持仓量。
 *   `get_cash() -> float`: 获取当前可用资金。

--- a/examples/13_adj_returns_signal.py
+++ b/examples/13_adj_returns_signal.py
@@ -1,0 +1,61 @@
+import akquant as aq
+import numpy as np
+import pandas as pd
+from akquant import Bar, Strategy
+
+dates = pd.date_range("2025-01-01", periods=60, freq="D", tz="Asia/Shanghai")
+close = np.linspace(10, 12, len(dates)) + np.sin(np.linspace(0, 6, len(dates)))
+factor = np.ones(len(dates))
+factor[30:] = 0.5
+adj_close = close * factor
+high = close * 1.01
+low = close * 0.99
+open_ = close * 0.995
+vol = np.random.randint(1000, 2000, size=len(dates))
+df = pd.DataFrame(
+    {
+        "date": dates,
+        "open": open_,
+        "high": high,
+        "low": low,
+        "close": close,
+        "volume": vol,
+        "adj_close": adj_close,
+    }
+)
+df["symbol"] = "TEST"
+
+
+class AdjSignal(Strategy):
+    """
+    使用后复权价格计算信号的策略示例.
+
+    Demonstrate using adjusted close for signals while executing with real prices.
+    """
+
+    warmup_period = 5
+
+    def on_bar(self, bar: Bar) -> None:
+        """
+        K线闭合回调.
+
+        :param bar: 当前K线数据
+        """
+        x = self.get_history(2, bar.symbol, "adj_close")
+        if x is None or len(x) < 2:
+            return
+        r = x[-1] / x[-2] - 1.0
+        pos = self.get_position(bar.symbol)
+        if pos == 0 and r > 0:
+            self.buy(bar.symbol, 100)
+        elif pos > 0 and r < 0:
+            self.close_position(bar.symbol)
+
+
+result = aq.run_backtest(
+    data=df,
+    strategy=AdjSignal,
+    initial_cash=100000.0,
+    symbol="TEST",
+)
+print(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.42"
+version = "0.1.43"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/utils/__init__.py
+++ b/python/akquant/utils/__init__.py
@@ -299,6 +299,14 @@ def df_to_arrays(
         dt_series_s = dt_series_s.dt.tz_localize("Asia/Shanghai")
     dt_series_s = dt_series_s.dt.tz_convert("UTC")
 
+    # Force nanosecond resolution before converting to int64
+    if not str(dt_series_s.dtype).startswith("datetime64[ns"):
+        try:
+            dt_series_s = dt_series_s.astype("datetime64[ns, UTC]")
+        except Exception:
+            # Fallback for older pandas or incompatible types
+            pass
+
     timestamps = cast(np.ndarray, dt_series_s.astype("int64").values)
 
     # 2. Extract numeric columns

--- a/src/context.rs
+++ b/src/context.rs
@@ -255,7 +255,17 @@ impl StrategyContext {
                     "low" => PyArray1::from_iter(py, history.lows.iter().skip(start).cloned()),
                     "close" => PyArray1::from_iter(py, history.closes.iter().skip(start).cloned()),
                     "volume" => PyArray1::from_iter(py, history.volumes.iter().skip(start).cloned()),
-                    _ => return Err(pyo3::exceptions::PyValueError::new_err("Invalid field")),
+                    _ => {
+                        if let Some(series) = history.extras.get(&field) {
+                            PyArray1::from_iter(py, series.iter().skip(start).cloned())
+                        } else {
+                            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                                "Invalid field: '{}'. Available extra fields: {:?}",
+                                field,
+                                history.extras.keys()
+                            )));
+                        }
+                    }
                 };
 
                 return Ok(Some(py_array));


### PR DESCRIPTION
- 在 `get_history` 方法中增加对任意数值型扩展字段（如 `adj_close`, `adj_factor`）的支持
- 修复 `df_to_arrays` 中时间戳强制转换为纳秒精度，避免精度丢失
- 在文档中添加使用后复权序列计算信号的示例策略
- 更新中英文 API 文档以说明扩展字段支持