### PR TITLE
docs: 更新示例代码和文档以使用AKShare真实数据

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ print(result)
 **运行结果示例:**
 
 ```text
+=== Backtest Result ===
 BacktestResult:
                                             Value
-name
 start_time              2025-02-12 00:00:00+08:00
 end_time                2026-02-12 00:00:00+08:00
 duration                        365 days, 0:00:00
@@ -143,6 +143,8 @@ cvar_95                                 -0.000405
 cvar_99                                  -0.00069
 sqn                                     -0.743693
 kelly_criterion                         -0.080763
+max_leverage                              0.01458
+min_margin_level                        68.587671
 ```
 
 ## 可视化 (Visualization)
@@ -151,11 +153,7 @@ AKQuant 内置了基于 **Plotly** 的强大可视化模块，仅需一行代码
 
 ```python
 # 生成交互式 HTML 报告，自动在浏览器中打开
-result.report(title="我的策略报告", show=True)
-
-# 或者单独绘制仪表盘
-import akquant.plot as aqp
-aqp.plot_dashboard(result)
+result.report(show=True)
 ```
 
 <p align="center">

--- a/examples/13_adj_returns_signal.py
+++ b/examples/13_adj_returns_signal.py
@@ -1,61 +1,90 @@
-import akquant as aq
-import numpy as np
+import akshare as ak
 import pandas as pd
-from akquant import Bar, Strategy
-
-dates = pd.date_range("2025-01-01", periods=60, freq="D", tz="Asia/Shanghai")
-close = np.linspace(10, 12, len(dates)) + np.sin(np.linspace(0, 6, len(dates)))
-factor = np.ones(len(dates))
-factor[30:] = 0.5
-adj_close = close * factor
-high = close * 1.01
-low = close * 0.99
-open_ = close * 0.995
-vol = np.random.randint(1000, 2000, size=len(dates))
-df = pd.DataFrame(
-    {
-        "date": dates,
-        "open": open_,
-        "high": high,
-        "low": low,
-        "close": close,
-        "volume": vol,
-        "adj_close": adj_close,
-    }
-)
-df["symbol"] = "TEST"
+from akquant import Bar, Strategy, run_backtest
 
 
 class AdjSignal(Strategy):
     """
-    使用后复权价格计算信号的策略示例.
+    使用前复权收盘价作为信号、默认次日开盘撮合（NextOpen）的示例策略.
 
-    Demonstrate using adjusted close for signals while executing with real prices.
+    :ivar warmup_period: 暖启动所需的 Bar 数；在此期间仅更新历史，不执行交易
     """
 
     warmup_period = 5
 
     def on_bar(self, bar: Bar) -> None:
         """
-        K线闭合回调.
+        每根 Bar 到来时触发，基于最近两根前复权收盘价计算信号.
 
-        :param bar: 当前K线数据
+        :param bar: 当前的行情 Bar（估值使用真实收盘价 close；撮合采用默认 NextOpen）
+        :type bar: Bar
         """
-        x = self.get_history(2, bar.symbol, "adj_close")
+        try:
+            # 从历史中取最近 2 根“前复权收盘价”序列（不包含当前 Bar，避免前视偏差）
+            adj_val = bar.extra.get("adj_close", None)
+            self.log(f"{bar.timestamp_str}, {bar.close}, {adj_val}")
+            x = self.get_history(2, bar.symbol, "adj_close")
+        except Exception:
+            # 如果数据字段不存在或不足，直接跳过
+            return
+
         if x is None or len(x) < 2:
             return
+
+        # 以“前复权收盘价”计算最新一天的简单收益率
+        # r_t = adj_close_t / adj_close_{t-1} - 1
         r = x[-1] / x[-2] - 1.0
+
+        # 查询当前持仓
         pos = self.get_position(bar.symbol)
+
+        # 简单信号：r > 0 且空仓 -> 开多；r < 0 且有多头 -> 平仓
         if pos == 0 and r > 0:
             self.buy(bar.symbol, 100)
         elif pos > 0 and r < 0:
             self.close_position(bar.symbol)
 
 
-result = aq.run_backtest(
+# ----------------------- 数据准备：AKShare -----------------------
+
+# 1) 未复权日线（真实 close），用于撮合和估值
+df_raw = ak.stock_zh_a_daily(symbol="sz000001", start_date="20200101")
+if "date" not in df_raw.columns:
+    # 部分接口会把日期放在索引上，这里统一还原为列
+    df_raw = df_raw.reset_index().rename(columns={"index": "date"})
+# 列名统一为小写，便于后续标准化
+df_raw.columns = [c.lower() for c in df_raw.columns]
+# 若存在 time 列但无 date 列，统一改名为 date
+if "time" in df_raw.columns and "date" not in df_raw.columns:
+    df_raw = df_raw.rename(columns={"time": "date"})
+# 时区本地化为 Asia/Shanghai（AKQuant 规范）
+df_raw["date"] = pd.to_datetime(df_raw["date"]).dt.tz_localize("Asia/Shanghai")
+# 必须包含 symbol 列（即使只有单标的）
+df_raw["symbol"] = "000001"
+# 只保留 AKQuant 需要的标准列
+df_raw = df_raw[["date", "open", "high", "low", "close", "volume", "symbol"]]
+
+# 2) 前复权日线（用于信号），重命名为 adj_close
+df_adj = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq", start_date="20200101")
+if "date" not in df_adj.columns:
+    df_adj = df_adj.reset_index().rename(columns={"index": "date"})
+df_adj.columns = [c.lower() for c in df_adj.columns]
+if "time" in df_adj.columns and "date" not in df_adj.columns:
+    df_adj = df_adj.rename(columns={"time": "date"})
+df_adj["date"] = pd.to_datetime(df_adj["date"]).dt.tz_localize("Asia/Shanghai")
+df_adj = df_adj[["date", "close"]].rename(columns={"close": "adj_close"})
+
+# 3) 合并两者：既包含真实 close（撮合/估值），又包含 adj_close（信号计算）
+df = (
+    pd.merge(df_raw, df_adj, on="date", how="inner")
+    .sort_values("date")
+    .reset_index(drop=True)
+)
+
+# ----------------------- 运行回测 -----------------------
+result = run_backtest(
     data=df,
-    strategy=AdjSignal,
-    initial_cash=100000.0,
-    symbol="TEST",
+    strategy=AdjSignal,  # 传类或实例均可
+    lot_size=100,  # A 股常见 1 手 = 100 股
 )
 print(result)

--- a/examples/14_readme.py
+++ b/examples/14_readme.py
@@ -1,0 +1,49 @@
+import akquant as aq
+import akshare as ak
+from akquant import Strategy
+
+# 1. 准备数据
+# 使用 akshare 获取 A 股历史数据 (需安装: pip install akshare)
+df = ak.stock_zh_a_daily(symbol="sh600000", start_date="20250212", end_date="20260212")
+
+
+class MyStrategy(Strategy):
+    """简单的阳线买入、阴线卖出示例策略.
+
+    本策略在每个 Bar 到来时进行判断：
+    - 当收盘价大于开盘价（阳线）且当前无持仓，则买入固定数量；
+    - 当收盘价小于开盘价（阴线）且当前有持仓，则平仓。
+    """
+
+    def on_bar(self, bar: aq.Bar) -> None:
+        """处理每个到来的 Bar，并根据 K 线形态进行交易决策。.
+
+        :param bar: 当前 Bar 数据，包含 open/close/high/low/volume/timestamp 等字段。
+        :type bar: akquant.Bar
+        :return: 无返回值
+        :rtype: None
+        """
+        # 简单策略示例:
+        # 当收盘价 > 开盘价 (阳线) -> 买入
+        # 当收盘价 < 开盘价 (阴线) -> 卖出
+
+        # 获取当前持仓
+        current_pos = self.get_position(bar.symbol)
+
+        if current_pos == 0 and bar.close > bar.open:
+            self.buy(symbol=bar.symbol, quantity=100)
+            print(f"[{bar.timestamp_str}] Buy 100 at {bar.close:.2f}")
+
+        elif current_pos > 0 and bar.close < bar.open:
+            self.close_position(symbol=bar.symbol)
+            print(f"[{bar.timestamp_str}] Sell 100 at {bar.close:.2f}")
+
+
+# 运行回测
+result = aq.run_backtest(
+    data=df, strategy=MyStrategy, initial_cash=100000.0, symbol="sh600000"
+)
+
+# 打印回测结果
+print("\n=== Backtest Result ===")
+print(result)


### PR DESCRIPTION
- 将13_adj_returns_signal.py示例从模拟数据改为AKShare真实数据
- 在示例文档中添加AKShare数据获取的标准代码片段
- 为所有策略示例补充使用AKShare数据运行回测的完整代码
- 更新文档说明，明确除特殊标注外均使用真实市场数据