### PR TITLE
docs(zh): 更新策略接口参数名称以保持一致性

### DIFF
--- a/docs/zh/guide/data.md
+++ b/docs/zh/guide/data.md
@@ -159,8 +159,8 @@ data_map = {
 
 在策略中，你可以随时获取过去 N 天的行情数据。
 
-*   `self.get_history(n, symbol, field)`: 返回 `numpy.ndarray`，性能极高（零拷贝）。
-*   `self.get_history_df(n, symbol)`: 返回 `pd.DataFrame`，方便使用 Pandas 计算。
+*   `self.get_history(count, symbol, field)`: 返回 `numpy.ndarray`，性能极高（零拷贝）。
+*   `self.get_history_df(count, symbol)`: 返回 `pd.DataFrame`，方便使用 Pandas 计算。
 
 **注意**：`get_history` 获取的是**当前时刻之前**的数据，不包含当前 Bar（为了避免未来函数）。如果需要包含当前 Bar 的数据参与计算，可以手动 append。
 

--- a/docs/zh/guide/python_basics.md
+++ b/docs/zh/guide/python_basics.md
@@ -269,7 +269,7 @@ strategy.on_bar(9)          # 价格跌到9，触发买入
 
 | 场景 | Python 代码 | 含义 |
 | :--- | :--- | :--- |
-| **获取数据** | `hist = self.history_data(n=20)` | 拿过去20根K线数据 (DataFrame) |
+| **获取数据** | `hist = self.get_history_df(count=20)` | 拿过去20根K线数据 (DataFrame) |
 | **计算均线** | `ma = hist['close'].mean()` | 计算收盘价平均值 |
 | **取最新价** | `current_price = bar.close` | 获取当前K线的收盘价 |
 | **判断信号** | `if ma_short > ma_long:` | 如果短期均线大于长期均线 |

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -190,8 +190,9 @@ class MyStrategy(Strategy):
     *   只有当市场价格 <= 10.5 时才买入。
 
 *   **目标仓位 (Target Order)**:
-    *   `self.order_target_percent(target=0.5, symbol="AAPL")`: 调整持仓至总资产的 50%。
-    *   `self.order_target_value(target=10000, symbol="AAPL")`: 调整持仓至 10000 元市值。
+    *   `self.order_target(target=100, symbol="AAPL")`: 调整持仓数量至 100 股。
+    *   `self.order_target_percent(target_percent=0.5, symbol="AAPL")`: 调整持仓至总资产的 50%。
+    *   `self.order_target_value(target_value=10000, symbol="AAPL")`: 调整持仓至 10000 元市值。
 
 *   **撤单 (Cancel Order)**:
     *   `self.cancel_order(order_id)`: 撤销指定订单。


### PR DESCRIPTION
将 `get_history` 和 `get_history_df` 方法的参数从 `n` 统一为 `count`，使其与代码库中的实际参数名一致。同时补充并规范了目标仓位下单方法的参数命名，将 `target` 明确为 `target_percent` 和 `target_value`，以提升文档准确性。