### PR TITLE
refactor: 统一将 initial_capital 重命名为 initial_cash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.45"
+version = "0.1.46"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/quant_basics.md
+++ b/docs/en/guide/quant_basics.md
@@ -180,7 +180,7 @@ if __name__ == "__main__":
     result = run_backtest(
         strategy_class=DualMovingAverageStrategy,
         data=df,
-        initial_capital=10000.0 # Initial capital 10k
+        initial_cash=10000.0 # Initial capital 10k
     )
 
     # Print summary
@@ -213,7 +213,7 @@ df['symbol'] = "AAPL" # Add symbol column
 result = run_backtest(
     strategy_class=DualMovingAverageStrategy,
     data=df,
-    initial_capital=10000.0
+    initial_cash=10000.0
 )
 ```
 

--- a/examples/06_complex_orders.py
+++ b/examples/06_complex_orders.py
@@ -157,7 +157,7 @@ def run_example() -> None:
     # 2. 运行回测
     print("开始 Bracket Order 策略回测...")
     run_backtest(
-        data={"TEST_STOCK": df}, strategy=BracketStrategy, initial_capital=100000.0
+        data={"TEST_STOCK": df}, strategy=BracketStrategy, initial_cash=100000.0
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.45"
+version = "0.1.46"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/analysis/calculator.rs
+++ b/src/analysis/calculator.rs
@@ -12,7 +12,7 @@ impl BacktestResult {
         snapshots: Vec<(i64, Vec<PositionSnapshot>)>,
         trade_pnl: TradePnL,
         trades: Vec<ClosedTrade>,
-        initial_capital: Decimal,
+        initial_cash: Decimal,
         orders: Vec<Order>,
         executions: Vec<Trade>,
     ) -> Self {
@@ -45,8 +45,8 @@ impl BacktestResult {
                     equity_r2: 0.0,
                     std_error: 0.0,
                     win_rate: 0.0,
-                    initial_market_value: initial_capital.to_f64().unwrap_or_default(),
-                    end_market_value: initial_capital.to_f64().unwrap_or_default(),
+                    initial_market_value: initial_cash.to_f64().unwrap_or_default(),
+                    end_market_value: initial_cash.to_f64().unwrap_or_default(),
                     total_return_pct: 0.0,
                     start_time: 0,
                     end_time: 0,
@@ -66,7 +66,7 @@ impl BacktestResult {
             };
         }
 
-        let initial_equity = initial_capital;
+        let initial_equity = initial_cash;
         let final_equity = equity_curve_decimal.last().unwrap().1;
 
         // 1. Total Return (Decimal)

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -52,7 +52,7 @@ pub struct Engine {
     pub risk_manager: RiskManager,
     pub(crate) timezone_offset: i32,
     pub(crate) history_buffer: Arc<RwLock<HistoryBuffer>>,
-    pub(crate) initial_capital: Decimal,
+    pub(crate) initial_cash: Decimal,
     // Components
     pub(crate) event_manager: EventManager,
     pub(crate) statistics_manager: StatisticsManager,

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -73,9 +73,9 @@ impl Engine {
     /// :return: Engine 实例
     #[new]
     pub fn new() -> Self {
-        let initial_capital = Decimal::from(100_000);
+        let initial_cash = Decimal::from(100_000);
         Engine {
-            state: SharedState::new(initial_capital),
+            state: SharedState::new(initial_cash),
             last_prices: HashMap::new(),
             instruments: HashMap::new(),
             current_date: None,
@@ -88,7 +88,7 @@ impl Engine {
             risk_manager: RiskManager::new(),
             timezone_offset: 28800, // Default UTC+8
             history_buffer: Arc::new(RwLock::new(HistoryBuffer::new(10000))), // Default large capacity for MAE/MFE
-            initial_capital,
+            initial_cash,
             event_manager: EventManager::new(),
             statistics_manager: StatisticsManager::new(),
             settlement_manager: SettlementManager::new(),
@@ -307,7 +307,7 @@ impl Engine {
     pub fn set_cash(&mut self, cash: f64) {
         let val = Decimal::from_f64(cash).unwrap_or(Decimal::ZERO);
         self.state.portfolio.cash = val;
-        self.initial_capital = val;
+        self.initial_cash = val;
     }
 
     /// 添加数据源
@@ -439,7 +439,7 @@ impl Engine {
             &self.instruments,
             &self.last_prices,
             &self.state.order_manager,
-            self.initial_capital,
+            self.initial_cash,
             self.clock.timestamp(),
         )
     }

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -14,10 +14,10 @@ pub struct SharedState {
 }
 
 impl SharedState {
-    pub fn new(initial_capital: Decimal) -> Self {
+    pub fn new(initial_cash: Decimal) -> Self {
         Self {
             portfolio: Portfolio {
-                cash: initial_capital,
+                cash: initial_cash,
                 positions: Arc::new(HashMap::new()),
                 available_positions: Arc::new(HashMap::new()),
             },

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -119,7 +119,7 @@ impl StatisticsManager {
         instruments: &HashMap<String, Instrument>,
         last_prices: &HashMap<String, Decimal>,
         order_manager: &crate::order_manager::OrderManager,
-        initial_capital: Decimal,
+        initial_cash: Decimal,
         now_ns: Option<i64>,
     ) -> BacktestResult {
         // Calculate final PnL
@@ -162,7 +162,7 @@ impl StatisticsManager {
             snapshots,
             trade_pnl,
             order_manager.trade_tracker.closed_trades.to_vec(),
-            initial_capital,
+            initial_cash,
             order_manager.get_all_orders(),
             order_manager.trades.clone(),
         )


### PR DESCRIPTION
为了保持术语一致性，将代码库中表示初始资金的变量名从 "initial_capital" 统一改为 "initial_cash"。这更符合金融领域常用术语，并使代码和文档中的命名保持一致。