### PR TITLE
chore: 移除pyo3依赖中的auto-initialize特性

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "akquant"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.28.2", features = ["abi3-py310", "chrono", "auto-initialize"] }
+pyo3 = { version = "0.28.2", features = ["abi3-py310", "chrono"] }
 numpy = "0.28"
 pyo3-stub-gen = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
该特性可能导致在嵌入式Python环境中的初始化问题。
移除后可避免潜在的冲突，使库更通用。