### PR TITLE
docs: 重构并新增策略示例文档和代码

### DIFF
--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -5,6 +5,8 @@
 *   [Quick Start](../start/quickstart.md): Complete workflow covering manual data backtesting and AKShare data backtesting.
 *   [Simple SMA Strategy](strategy.md#class-based): Demonstrates how to write a strategy in class style and perform simple trading logic in `on_bar`.
 
+> Data Source Convention: Unless otherwise specified (e.g. simulated data), examples on this page default to using AKShare to fetch real market data.
+
 ## 2. Advanced Examples
 
 *   **Zipline Style Strategy**: Demonstrates how to write strategies using functional API (`initialize`, `on_bar`), suitable for users migrating from Zipline.
@@ -17,18 +19,220 @@
 *   **Vectorized Indicators**:
     *   Demonstrates how to use `IndicatorSet` to pre-calculate indicators to improve backtest speed. Refer to [Strategy Guide](strategy.md#indicatorset).
 
+### Fetching A-Share Daily Data with AKShare (stock_zh_a_daily)
+
+```python
+import akshare as ak
+import pandas as pd
+from akquant import run_backtest
+
+df = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
+if "date" not in df.columns:
+    df = df.reset_index().rename(columns={"index": "date"})
+df.columns = [c.lower() for c in df.columns]
+if "time" in df.columns and "date" not in df.columns:
+    df = df.rename(columns={"time": "date"})
+df["date"] = pd.to_datetime(df["date"]).dt.tz_localize("Asia/Shanghai")
+df["symbol"] = "000001"
+cols = ["date", "open", "high", "low", "close", "volume", "symbol"]
+df = df[cols].sort_values("date").reset_index(drop=True)
+
+# result = run_backtest(data=df, strategy=DualSMAStrategy, lot_size=100)
+```
+
 ## 3. Common Strategies
 
 Here are some common quantitative strategy implementations that you can use directly in your projects. We provide detailed logic explanations for each strategy to help you understand the core concepts.
 
-### Use Adjusted Series for Signals, Real Prices for Execution
+### 3.1 Dual Moving Average Strategy
 
-When your data provides `adj_close` or `adj_factor`, you can fetch adjusted series directly via `get_history(symbol=..., field="adj_close", n)` for signal computation, while matching and valuation still use real `close`. See `examples/13_adj_returns_signal.py`.
+[View Full Source](https://github.com/akfamily/akquant/blob/main/examples/strategies/01_stock_dual_moving_average.py)
+
+**Core Concept**:
+The Dual Moving Average strategy uses two moving averages (SMA) with different periods to determine market trends.
+- **Golden Cross**: Short-term SMA crosses above Long-term SMA -> Buy.
+- **Death Cross**: Short-term SMA crosses below Long-term SMA -> Sell.
+
+**AKQuant Features**:
+- Using `get_history` to fetch historical data (including current Bar).
+- A-Share trading rules (1 lot = 100 shares).
 
 ```python
-import akquant as aq
-from akquant import Strategy
+class DualMovingAverageStrategy(Strategy):
+    def __init__(self, short_window=5, long_window=20):
+        self.short_window = short_window
+        self.long_window = long_window
+        # Warmup period setting
+        self.warmup_period = long_window
 
+    def on_bar(self, bar):
+        # Fetch historical data including current Bar
+        closes = self.get_history(count=self.long_window, symbol=bar.symbol, field="close")
+
+        if len(closes) < self.long_window:
+            return
+
+        # Calculate MAs
+        short_ma = np.mean(closes[-self.short_window:])
+        long_ma = np.mean(closes[-self.long_window:])
+
+        current_pos = self.get_position(bar.symbol)
+
+        # Golden Cross -> Buy
+        if short_ma > long_ma and current_pos == 0:
+            self.order_target_percent(symbol=bar.symbol, target_percent=0.95)
+
+        # Death Cross -> Sell
+        elif short_ma < long_ma and current_pos > 0:
+            self.close_position(symbol=bar.symbol)
+```
+
+### 3.2 Grid Trading Strategy
+
+[View Full Source](https://github.com/akfamily/akquant/blob/main/examples/strategies/02_stock_grid_trading.py)
+
+**Core Concept**:
+A mechanical trading strategy based on price fluctuations.
+- **Buy Dip**: Buy a portion for every X% price drop.
+- **Sell Rally**: Sell a portion for every X% price rise.
+- **Suitable for**: Oscillating markets.
+
+**AKQuant Features**:
+- Managing custom state variables (`self.last_trade_price`) inside `on_bar`.
+- Complex position management.
+
+```python
+class GridTradingStrategy(Strategy):
+    def __init__(self, grid_pct=0.03, lot_size=100):
+        self.grid_pct = grid_pct
+        self.trade_lot = lot_size
+        self.last_trade_price = {}
+
+    def on_bar(self, bar):
+        symbol = bar.symbol
+        close = bar.close
+
+        # Initial Position
+        if symbol not in self.last_trade_price:
+            self.buy(symbol=symbol, quantity=10 * self.trade_lot)
+            self.last_trade_price[symbol] = close
+            return
+
+        last_price = self.last_trade_price[symbol]
+        change_pct = (close - last_price) / last_price
+
+        # Buy Dip
+        if change_pct <= -self.grid_pct:
+            self.buy(symbol=symbol, quantity=self.trade_lot)
+            self.last_trade_price[symbol] = close
+
+        # Sell Rally
+        elif change_pct >= self.grid_pct:
+            current_pos = self.get_position(symbol)
+            if current_pos >= self.trade_lot:
+                self.sell(symbol=symbol, quantity=self.trade_lot)
+                self.last_trade_price[symbol] = close
+```
+
+### 3.3 ATR Breakout Strategy
+
+[View Full Source](https://github.com/akfamily/akquant/blob/main/examples/strategies/03_stock_atr_breakout.py)
+
+**Core Concept**:
+Uses ATR (Average True Range) to build price channels and capture trend breakouts.
+- **Upper Band**: Previous Close + k * ATR
+- **Lower Band**: Previous Close - k * ATR
+- **Breakout**: Price > Upper Band -> Buy.
+- **Breakdown**: Price < Lower Band -> Sell.
+
+**AKQuant Features**:
+- **Avoiding Look-ahead Bias**: Use `get_history` and slice with `[:-1]` to exclude the current Bar, using strictly historical data to calculate today's breakout thresholds.
+
+```python
+class AtrBreakoutStrategy(Strategy):
+    def __init__(self, period=20, k=2.0):
+        self.period = period
+        self.k = k
+        self.warmup_period = period + 1
+
+    def on_bar(self, bar):
+        # Fetch N+1 data points
+        req_count = self.period + 1
+        h_closes = self.get_history(count=req_count, field="close")
+
+        if len(h_closes) < req_count:
+            return
+
+        # Exclude current Bar (last element)
+        closes = h_closes[:-1]
+
+        # ... (ATR calculation logic) ...
+        atr = calculate_atr(closes) # Pseudo-code
+
+        # Calculate bands based on YESTERDAY's close
+        prev_close = closes[-1]
+        upper_band = prev_close + self.k * atr
+        lower_band = prev_close - self.k * atr
+
+        # Trading Logic
+        if bar.close > upper_band:
+            self.buy(quantity=500)
+        elif bar.close < lower_band:
+            self.close_position()
+```
+
+### 3.4 Momentum Rotation Strategy
+
+[View Full Source](https://github.com/akfamily/akquant/blob/main/examples/strategies/04_stock_momentum_rotation.py)
+
+**Core Concept**:
+Hold the asset with the strongest recent momentum (return) among a pool of assets.
+- Calculate momentum for candidates periodically (e.g., daily).
+- Sell weak assets and buy the strongest one.
+
+**AKQuant Features**:
+- **Multi-Asset Data**: Passing `Dict[str, DataFrame]` to the engine.
+- **Cross-Asset Comparison**: Iterating `self.symbols` and calling `get_history` for each.
+- **Target Position**: Using `order_target_percent` for easy rotation.
+
+```python
+class MomentumRotationStrategy(Strategy):
+    def __init__(self, lookback_period=20):
+        self.lookback_period = lookback_period
+        self.symbols = ["sh600519", "sz000858"] # Maotai vs Wuliangye
+        self.warmup_period = lookback_period + 1
+
+    def on_bar(self, bar):
+        # Run rotation logic only once per day (on the last symbol)
+        if bar.symbol != self.symbols[-1]:
+            return
+
+        # 1. Calculate Momentum
+        momentums = {}
+        for s in self.symbols:
+            closes = self.get_history(count=self.lookback_period, symbol=s, field="close")
+            # Momentum = (Current - Previous) / Previous
+            mom = (closes[-1] - closes[0]) / closes[0]
+            momentums[s] = mom
+
+        # 2. Select Best
+        best_symbol = max(momentums, key=momentums.get)
+
+        # 3. Rotate
+        current_pos_symbol = self.get_current_holding_symbol() # Pseudo-code
+
+        if current_pos_symbol != best_symbol:
+            if current_pos_symbol:
+                self.close_position(current_pos_symbol)
+            # Target 95% position
+            self.order_target_percent(target_percent=0.95, symbol=best_symbol)
+```
+
+### 3.5 Use Adjusted Series for Signals, Real Prices for Execution
+
+When your data provides `adj_close` or `adj_factor`, you can fetch adjusted series directly via `get_history(symbol=..., field="adj_close", n)` for signal computation, while matching and valuation still use real `close`. See `examples/16_adj_returns_signal.py`.
+
+```python
 class AdjSignal(Strategy):
     warmup_period = 5
     def on_bar(self, bar):
@@ -46,289 +250,22 @@ class AdjSignal(Strategy):
             self.close_position(bar.symbol)
 ```
 
-### 3.1 Dual Moving Average Strategy
+## 4. Other AKShare Examples
 
-**Core Concept**:
-The Dual Moving Average strategy uses two moving averages (SMA) with different periods to determine market trends.
-*   **Short-term SMA** (e.g., 5 days): Sensitive, closely follows price fluctuations.
-*   **Long-term SMA** (e.g., 20 days): Lagging, represents the long-term trend.
+The `examples/` directory contains more scripts demonstrating AKShare integration:
 
-**Trading Signals**:
-*   **Golden Cross**: When the short-term SMA **crosses above** the long-term SMA, it indicates a strengthening short-term trend, which is a **Buy** signal.
-*   **Death Cross**: When the short-term SMA **crosses below** the long-term SMA, it indicates a weakening short-term trend, which is a **Sell** signal.
+*   **[11_plot_visualization.py](https://github.com/akfamily/akquant/blob/main/examples/11_plot_visualization.py)**:
+    *   Complete workflow: Fetch data -> Backtest -> Visualize.
+    *   Demonstrates how to generate professional HTML reports.
 
-This example uses high-performance incremental indicators `aq.SMA` implemented in Rust.
+*   **[14_multi_frequency.py](https://github.com/akfamily/akquant/blob/main/examples/14_multi_frequency.py)**:
+    *   **Mixed Frequency**: Combining Daily (for trend) and Minute (for execution) data.
+    *   Note: Uses synthetic minute data derived from AKShare daily data for demonstration.
 
-```python
-import akquant as aq
+*   **[15_plot_intraday.py](https://github.com/akfamily/akquant/blob/main/examples/15_plot_intraday.py)**:
+    *   **Intraday Simulation**: Generates synthetic minute-level data from AKShare daily data.
+    *   Demonstrates high-frequency backtesting capabilities.
 
-class DualSMAStrategy(aq.Strategy):
-    def __init__(self, short_window=5, long_window=20):
-        # Initialize two indicators: Short SMA and Long SMA
-        # Use Rust implemented high-performance incremental SMA indicators
-        self.sma_short = aq.SMA(short_window)
-        self.sma_long = aq.SMA(long_window)
-
-    def on_bar(self, bar: aq.Bar):
-        # 1. Update indicator status
-        # The update method accepts the current closing price and returns the latest MA value
-        short_val = self.sma_short.update(bar.close)
-        long_val = self.sma_long.update(bar.close)
-
-        # 2. Skip if indicator data is insufficient (e.g., cannot calculate 20-day MA at the start)
-        if short_val is None or long_val is None:
-            return
-
-        # Get current position quantity
-        position = self.get_position(bar.symbol)
-
-        # 3. Generate Trading Signals
-
-        # Golden Cross (Short MA crosses above Long MA) -> And no position -> Buy
-        if short_val > long_val and position == 0:
-            self.buy(bar.symbol, 100)
-
-        # Death Cross (Short MA crosses below Long MA) -> And holding position -> Sell to Close
-        elif short_val < long_val and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-### 3.2 RSI Mean Reversion Strategy
-
-**Core Concept**:
-RSI (Relative Strength Index) is a momentum indicator ranging from 0 to 100, measuring the magnitude of recent price changes.
-*   **Mean Reversion**: This strategy assumes that prices will not rise or fall indefinitely and will eventually revert to a normal level after excessive deviation.
-*   **Oversold**: RSI below a threshold (e.g., 30) implies the recent drop is excessive, suggesting a potential rebound -> **Buy**.
-*   **Overbought**: RSI above a threshold (e.g., 70) implies the recent rise is excessive, suggesting a potential pullback -> **Sell**.
-
-This example demonstrates how to use `get_history_df` to retrieve historical data and combine it with `pandas` to calculate complex indicators.
-
-```python
-import akquant as aq
-import pandas as pd
-import numpy as np
-
-class RSIStrategy(aq.Strategy):
-    def __init__(self, period=14, buy_threshold=30, sell_threshold=70):
-        self.period = period
-        self.buy_threshold = buy_threshold
-        self.sell_threshold = sell_threshold
-        # IMPORTANT: Set historical data lookback depth
-        # Since calculating RSI requires past N days of data, sufficient history window must be reserved
-        self.set_history_depth(period + 20)
-
-    def calculate_rsi(self, prices: pd.Series) -> pd.Series:
-        """Calculate RSI using pandas."""
-        delta = prices.diff()
-        # Simple RSI algorithm implementation
-        gain = (delta.where(delta > 0, 0)).rolling(window=self.period).mean()
-        loss = (-delta.where(delta < 0, 0)).rolling(window=self.period).mean()
-        rs = gain / loss
-        return 100 - (100 / (1 + rs))
-
-    def on_bar(self, bar: aq.Bar):
-        # 1. Get historical closing price DataFrame
-        # get_history_df returns data for the past N bars
-        history = self.get_history_df(self.period + 20, bar.symbol)
-
-        # Return if data is insufficient
-        if len(history) < self.period + 1:
-            return
-
-        # 2. Calculate RSI
-        rsi_series = self.calculate_rsi(history['close'])
-        current_rsi = rsi_series.iloc[-1] # Get the latest RSI value
-
-        if np.isnan(current_rsi):
-            return
-
-        position = self.get_position(bar.symbol)
-
-        # 3. Trading Logic
-
-        # RSI < 30 (Oversold) -> Expect Rebound -> Buy
-        if current_rsi < self.buy_threshold and position == 0:
-            self.buy(bar.symbol, 100)
-
-        # RSI > 70 (Overbought) -> Expect Drop -> Sell
-        elif current_rsi > self.sell_threshold and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-### 3.3 Bollinger Bands Strategy
-
-**Core Concept**:
-Bollinger Bands consist of three lines:
-*   **Middle Band**: N-day Moving Average.
-*   **Upper Band**: Middle Band + K * Standard Deviation.
-*   **Lower Band**: Middle Band - K * Standard Deviation.
-
-According to statistical principles, prices have a high probability (e.g., 95%) of falling between the upper and lower bands.
-*   When price **breaks below the lower band**, it is often seen as an irrational **oversold** state, and price may revert to the middle band -> **Buy**.
-*   When price **breaks above the upper band**, it is often seen as an irrational **overbought** state, and price may pullback -> **Sell**.
-
-```python
-import akquant as aq
-import pandas as pd
-
-class BollingerStrategy(aq.Strategy):
-    def __init__(self, window=20, num_std=2):
-        self.window = window
-        self.num_std = num_std
-        # Set history depth to ensure enough data for mean and std calculation
-        self.set_history_depth(window + 5)
-
-    def on_bar(self, bar: aq.Bar):
-        # 1. Get historical data
-        history = self.get_history_df(self.window, bar.symbol)
-        if len(history) < self.window:
-            return
-
-        # 2. Calculate Bollinger Bands
-        close_prices = history['close']
-        ma = close_prices.mean()          # Middle Band (Mean)
-        std = close_prices.std()          # Standard Deviation
-        upper_band = ma + self.num_std * std # Upper Band
-        lower_band = ma - self.num_std * std # Lower Band
-
-        position = self.get_position(bar.symbol)
-        current_price = bar.close
-
-        # 3. Trading Logic
-
-        # Price breaks below lower band -> Oversold reversal signal -> Buy
-        if current_price < lower_band and position == 0:
-            self.buy(bar.symbol, 100)
-
-        # Price breaks above upper band -> Overbought reversal signal -> Sell
-        elif current_price > upper_band and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-### 3.4 Mixed Asset Backtest {: #mixed-asset }
-
-**Core Concept**:
-In real trading, strategies may involve multiple assets like stocks, futures, and options simultaneously. Different assets have different trading attributes:
-*   **Stocks**: Usually 1 lot = 100 shares, fully paid trading.
-*   **Futures**: Have **Contract Multiplier** (e.g., 1 point = $300) and **Margin Ratio** (e.g., buy contract with 10% funds).
-
-This example demonstrates how to use `InstrumentConfig` to configure special attributes for futures and mix trade stocks and futures in the same strategy.
-
-```python
-import akquant as aq
-from akquant import InstrumentConfig
-import pandas as pd
-import numpy as np
-
-# 1. Prepare data (Mock data)
-def create_dummy_data(symbol, start_time, n_bars, price=100.0):
-    dates = pd.date_range(start_time, periods=n_bars, freq="B")
-    np.random.seed(42)
-    changes = np.random.randn(n_bars)
-    prices = price + np.cumsum(changes)
-
-    df = pd.DataFrame({
-        "open": prices, "high": prices + 1, "low": prices - 1, "close": prices,
-        "volume": 1000, "symbol": symbol
-    }, index=dates)
-    return df
-
-class TestStrategy(aq.Strategy):
-    def __init__(self):
-        self.count = 0
-
-    def on_bar(self, bar: aq.Bar):
-        # Simple logic: Buy stock and future respectively on first two bars
-        if self.count < 2:
-            print(f"[{bar.timestamp}] Buying {bar.symbol}")
-            self.buy(bar.symbol, 1)
-        self.count += 1
-
-# 2. Generate data
-df_stock = create_dummy_data("STOCK_A", "2023-01-01", 100, 100.0)
-df_future = create_dummy_data("FUTURE_B", "2023-01-01", 100, 3500.0)
-data = {"STOCK_A": df_stock, "FUTURE_B": df_future}
-
-# 3. Configure futures parameters
-# Tell backtest engine: FUTURE_B is a future, multiplier 300, margin 10%
-future_config = InstrumentConfig(
-    symbol="FUTURE_B",
-    asset_type="FUTURES",
-    multiplier=300, # Index future multiplier
-    margin_ratio=0.1 # 10% Margin
-)
-
-# 4. Run
-run_backtest(
-    data=data,
-    strategy=TestStrategy,
-    instruments_config=[future_config]
-)
-```
-
-## 4. Complex Orders & Risk Control {: #complex-orders }
-
-**Core Concept**:
-Advanced trading often requires precise order management.
-*   **Bracket Order**: A combination of "Entry + Stop Loss + Take Profit". When you open a position (Entry), you immediately set a "Stop Loss" and "Take Profit" order for this position, bracketing the price like a pair of brackets.
-*   **OCO (One-Cancels-Other)**: Refers to the relationship between the "Stop Loss" and "Take Profit" orders. If price rises and triggers Take Profit, the Stop Loss order should be automatically cancelled (since the position is closed, no need to stop loss anymore), and vice versa.
-
-Although AKQuant's core matching engine does not natively support OCO order types yet, you can easily implement these advanced logic via strategy callback functions (`on_trade`, `on_order`).
-
-### 4.1 OCO and Bracket Order Implementation
-
-**Logic Flow**:
-1.  **Entry**: Strategy sends an open position signal.
-2.  **Trade Callback (`on_trade`)**: Once entry order is filled, immediately send two closing orders:
-    *   **Stop Loss**: Sell if price drops to X (protect principal).
-    *   **Take Profit**: Sell if price rises to Y (lock in profit).
-3.  **Subsequent Trades**:
-    *   If Stop Loss filled -> Immediately cancel Take Profit.
-    *   If Take Profit filled -> Immediately cancel Stop Loss.
-
-```python
-def on_trade(self, trade):
-    # 1. Entry order filled -> Immediately place SL and TP
-    if trade.order_id == self.entry_order_id:
-        # Place Stop Loss (Stop Market: Sell at market price after trigger)
-        self.stop_loss_id = self.sell(
-            trade.symbol, trade.quantity,
-            trigger_price=trade.price * 0.98, # Stop Price (Cost - 2%)
-            price=None # None means Market Sell after trigger
-        )
-
-        # Place Take Profit (Limit Sell: Sell at specified price)
-        self.take_profit_id = self.sell(
-            trade.symbol, trade.quantity,
-            price=trade.price * 1.05 # Take Profit Price (Cost + 5%)
-        )
-
-    # 2. Stop Loss filled -> Cancel Take Profit
-    # We have exited with stop loss, cancel the previous take profit order
-    elif trade.order_id == self.stop_loss_id:
-        self.cancel_order(self.take_profit_id)
-
-    # 3. Take Profit filled -> Cancel Stop Loss
-    # We have exited with profit, cancel the previous stop loss order
-    elif trade.order_id == self.take_profit_id:
-        self.cancel_order(self.stop_loss_id)
-```
-
-!!! tip "Parameter Optimization"
-    The `stop_loss_pct` and `take_profit_pct` parameters of this strategy can be optimized via grid search using `akquant.run_optimization`.
-
-    ```python
-    from akquant import run_optimization
-    from examples.complex_orders import BracketStrategy
-
-    param_grid = {
-        "stop_loss_pct": [0.01, 0.02, 0.03],
-        "take_profit_pct": [0.03, 0.05, 0.08]
-    }
-
-    results = run_optimization(BracketStrategy, param_grid, data=df)
-    ```
-
-Please refer to [examples/05_complex_orders.py](file:///examples/05_complex_orders.py) for the full code.
-
-> **Note**: Methods `buy` / `sell` / `stop_buy` / `stop_sell` all return a unique `order_id` (str). You can use this ID to precisely track the status of each order in `on_trade` and `on_order` callbacks.
+*   **[17_readme_demo.py](https://github.com/akfamily/akquant/blob/main/examples/17_readme_demo.py)**:
+    *   A simple, standalone script for the README demonstration.
+    *   Good for a quick "Hello World" test.

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -44,14 +44,195 @@ df = df[cols].sort_values("date").reset_index(drop=True)
 
 以下是一些常用量化策略的实现代码，可以直接在您的项目中使用。我们为每个策略提供了详细的逻辑说明，帮助您理解其核心思想。
 
-### 使用后复权序列作信号，真实价格撮合
+### 3.1 A股双均线策略 (Dual Moving Average)
 
-当数据包含 `adj_close` 或 `adj_factor` 时，可直接通过 `get_history(symbol=..., field="adj_close", n)` 获取后复权序列用于信号计算，而撮合与估值仍使用真实收盘价 `close`。示例见仓库 `examples/13_adj_returns_signal.py`。
+[查看完整源码](https://github.com/akfamily/akquant/blob/main/examples/strategies/01_stock_dual_moving_average.py)
+
+**核心概念**:
+利用长短两条均线的交叉来判断趋势。
+- **金叉 (Golden Cross)**: 短期均线上穿长期均线，买入信号。
+- **死叉 (Death Cross)**: 短期均线下穿长期均线，卖出信号。
+
+**AKQuant 特性演示**:
+- 使用 `get_history` 获取历史数据（包含当前 Bar）。
+- A股交易规则（1手=100股）。
 
 ```python
-import akquant as aq
-from akquant import Strategy
+class DualMovingAverageStrategy(Strategy):
+    def __init__(self, short_window=5, long_window=20):
+        self.short_window = short_window
+        self.long_window = long_window
+        # 预热期设置
+        self.warmup_period = long_window
 
+    def on_bar(self, bar):
+        # 获取包含当前 Bar 的历史数据
+        closes = self.get_history(count=self.long_window, symbol=bar.symbol, field="close")
+
+        if len(closes) < self.long_window:
+            return
+
+        # 计算均线
+        short_ma = np.mean(closes[-self.short_window:])
+        long_ma = np.mean(closes[-self.long_window:])
+
+        current_pos = self.get_position(bar.symbol)
+
+        # 金叉买入
+        if short_ma > long_ma and current_pos == 0:
+            self.order_target_percent(symbol=bar.symbol, target_percent=0.95)
+
+        # 死叉卖出
+        elif short_ma < long_ma and current_pos > 0:
+            self.close_position(symbol=bar.symbol)
+```
+
+### 3.2 股票网格交易 (Grid Trading)
+
+[查看完整源码](https://github.com/akfamily/akquant/blob/main/examples/strategies/02_stock_grid_trading.py)
+
+**核心概念**:
+一种基于价格波动的机械式交易策略。
+- **下跌加仓**: 价格每下跌一定比例，买入一份。
+- **上涨减仓**: 价格每上涨一定比例，卖出一份。
+- **适合震荡市**: 在价格反复震荡中通过高抛低吸获利。
+
+**AKQuant 特性演示**:
+- 在 `on_bar` 中维护自定义状态变量 (`self.last_trade_price`)。
+- 复杂持仓管理。
+
+```python
+class GridTradingStrategy(Strategy):
+    def __init__(self, grid_pct=0.03, lot_size=100):
+        self.grid_pct = grid_pct
+        self.trade_lot = lot_size
+        self.last_trade_price = {}
+
+    def on_bar(self, bar):
+        symbol = bar.symbol
+        close = bar.close
+
+        # 初始建仓
+        if symbol not in self.last_trade_price:
+            self.buy(symbol=symbol, quantity=10 * self.trade_lot)
+            self.last_trade_price[symbol] = close
+            return
+
+        last_price = self.last_trade_price[symbol]
+        change_pct = (close - last_price) / last_price
+
+        # 下跌网格买入
+        if change_pct <= -self.grid_pct:
+            self.buy(symbol=symbol, quantity=self.trade_lot)
+            self.last_trade_price[symbol] = close
+
+        # 上涨网格卖出
+        elif change_pct >= self.grid_pct:
+            current_pos = self.get_position(symbol)
+            if current_pos >= self.trade_lot:
+                self.sell(symbol=symbol, quantity=self.trade_lot)
+                self.last_trade_price[symbol] = close
+```
+
+### 3.3 ATR 通道突破策略 (ATR Breakout)
+
+[查看完整源码](https://github.com/akfamily/akquant/blob/main/examples/strategies/03_stock_atr_breakout.py)
+
+**核心概念**:
+利用 ATR (平均真实波幅) 构建价格通道，捕捉趋势突破。
+- **上轨**: 昨日收盘价 + k * ATR
+- **下轨**: 昨日收盘价 - k * ATR
+- **突破买入**: 价格突破上轨。
+- **跌破卖出**: 价格跌破下轨。
+
+**AKQuant 特性演示**:
+- **避免未来函数**: 使用 `get_history` 获取数据后，通过切片 `[:-1]` 剔除当前 Bar，仅使用历史数据计算今日的突破阈值。
+
+```python
+class AtrBreakoutStrategy(Strategy):
+    def __init__(self, period=20, k=2.0):
+        self.period = period
+        self.k = k
+        self.warmup_period = period + 1
+
+    def on_bar(self, bar):
+        # 获取 N+1 个数据
+        req_count = self.period + 1
+        h_closes = self.get_history(count=req_count, field="close")
+
+        if len(h_closes) < req_count:
+            return
+
+        # 剔除当前 Bar (最后一个数据)，仅使用历史数据计算指标
+        closes = h_closes[:-1]
+
+        # ... (ATR 计算逻辑) ...
+        atr = calculate_atr(closes) # 伪代码
+
+        # 基于昨日收盘价计算轨道
+        prev_close = closes[-1]
+        upper_band = prev_close + self.k * atr
+        lower_band = prev_close - self.k * atr
+
+        # 交易逻辑
+        if bar.close > upper_band:
+            self.buy(quantity=500)
+        elif bar.close < lower_band:
+            self.close_position()
+```
+
+[查看完整源码](https://github.com/akfamily/akquant/blob/main/examples/strategies/04_stock_momentum_rotation.py)
+
+### 3.4 多股票动量轮动 (Momentum Rotation)
+
+**核心概念**:
+在多只标的之间，持有近期动量（收益率）最强的那一只。
+- 定期（如每日）计算候选标的的动量。
+- 卖出弱势标的，全仓买入最强标的。
+
+**AKQuant 特性演示**:
+- **多标的数据**: 传入 `Dict[str, DataFrame]` 给回测引擎。
+- **跨标的比较**: 在策略中遍历 `self.symbols`，分别调用 `get_history`。
+- **目标仓位管理**: 使用 `order_target_percent` 方便地进行换仓。
+
+```python
+class MomentumRotationStrategy(Strategy):
+    def __init__(self, lookback_period=20):
+        self.lookback_period = lookback_period
+        self.symbols = ["sh600519", "sz000858"] # 茅台 vs 五粮液
+        self.warmup_period = lookback_period + 1
+
+    def on_bar(self, bar):
+        # 仅在处理最后一个标的时执行轮动逻辑 (每日一次)
+        if bar.symbol != self.symbols[-1]:
+            return
+
+        # 1. 计算动量
+        momentums = {}
+        for s in self.symbols:
+            closes = self.get_history(count=self.lookback_period, symbol=s, field="close")
+            # 动量 = (当前价 - N天前价格) / N天前价格
+            mom = (closes[-1] - closes[0]) / closes[0]
+            momentums[s] = mom
+
+        # 2. 选出最强
+        best_symbol = max(momentums, key=momentums.get)
+
+        # 3. 换仓
+        current_pos_symbol = self.get_current_holding_symbol() # 伪代码
+
+        if current_pos_symbol != best_symbol:
+            if current_pos_symbol:
+                self.close_position(current_pos_symbol)
+            # 目标仓位 95%
+            self.order_target_percent(target_percent=0.95, symbol=best_symbol)
+```
+
+### 3.5 使用后复权序列作信号，真实价格撮合
+
+当数据包含 `adj_close` 或 `adj_factor` 时，可直接通过 `get_history(symbol=..., field="adj_close", n)` 获取后复权序列用于信号计算，而撮合与估值仍使用真实收盘价 `close`。示例见仓库 `examples/16_adj_returns_signal.py`。
+
+```python
 class AdjSignal(Strategy):
     warmup_period = 5
     def on_bar(self, bar):
@@ -69,378 +250,22 @@ class AdjSignal(Strategy):
             self.close_position(bar.symbol)
 ```
 
-运行该示例（AKShare 数据）：
+## 4. 更多 AKShare 示例
 
-```python
-import akshare as ak
-import pandas as pd
-from akquant import run_backtest
+`examples/` 目录下还包含更多演示 AKShare 集成的脚本：
 
-# 未复权收盘价 (用于撮合/估值)
-df_raw = ak.stock_zh_a_daily(symbol="sz000001")
-if "date" not in df_raw.columns:
-    df_raw = df_raw.reset_index().rename(columns={"index": "date"})
-df_raw.columns = [c.lower() for c in df_raw.columns]
-if "time" in df_raw.columns and "date" not in df_raw.columns:
-    df_raw = df_raw.rename(columns={"time": "date"})
-df_raw["date"] = pd.to_datetime(df_raw["date"]).dt.tz_localize("Asia/Shanghai")
-df_raw["symbol"] = "000001"
-df_raw = df_raw[["date", "open", "high", "low", "close", "volume", "symbol"]]
+*   **[11_plot_visualization.py](https://github.com/akfamily/akquant/blob/main/examples/11_plot_visualization.py)**:
+    *   完整流程：获取数据 -> 运行回测 -> 生成可视化报告。
+    *   演示如何生成专业的 HTML 交互式报告。
 
-# 前复权收盘价 (用于信号): 作为 adj_close 列
-df_adj = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
-if "date" not in df_adj.columns:
-    df_adj = df_adj.reset_index().rename(columns={"index": "date"})
-df_adj.columns = [c.lower() for c in df_adj.columns]
-if "time" in df_adj.columns and "date" not in df_adj.columns:
-    df_adj = df_adj.rename(columns={"time": "date"})
-df_adj["date"] = pd.to_datetime(df_adj["date"]).dt.tz_localize("Asia/Shanghai")
-df_adj = df_adj[["date", "close"]].rename(columns={"close": "adj_close"})
+*   **[14_multi_frequency.py](https://github.com/akfamily/akquant/blob/main/examples/14_multi_frequency.py)**:
+    *   **混合频率 (Mixed Frequency)**: 结合日线数据（用于趋势判断）和分钟线数据（用于执行）。
+    *   注：为了演示方便，该示例基于 AKShare 的日线数据合成了分钟线数据。
 
-# 合并两者，既有真实收盘 close，又有后复权 adj_close
-df = pd.merge(df_raw, df_adj, on="date", how="inner").sort_values("date").reset_index(drop=True)
+*   **[15_plot_intraday.py](https://github.com/akfamily/akquant/blob/main/examples/15_plot_intraday.py)**:
+    *   **日内模拟 (Intraday Simulation)**: 基于 AKShare 日线数据生成合成的分钟级数据。
+    *   演示高频回测能力。
 
-result = run_backtest(
-    data=df,
-    strategy=AdjSignal,
-    lot_size=100
-)
-```
-
-### 3.1 双均线策略 (Dual Moving Average)
-
-**核心思想**：
-双均线策略利用两条不同周期的移动平均线（SMA）来判断市场趋势。
-*   **短期均线**（如 5 日）：反应灵敏，紧跟价格波动。
-*   **长期均线**（如 20 日）：反应迟钝，代表长期趋势。
-
-**交易信号**：
-*   **金叉 (Golden Cross)**：当短期均线 **上穿** 长期均线时，表明短期趋势走强，是 **买入** 信号。
-*   **死叉 (Death Cross)**：当短期均线 **下穿** 长期均线时，表明短期趋势走弱，是 **卖出** 信号。
-
-本示例使用了 Rust 实现的高性能增量指标 `aq.SMA`，计算速度极快。
-
-```python
-import akquant as aq
-
-class DualSMAStrategy(aq.Strategy):
-    def __init__(self, short_window=5, long_window=20):
-        self.sma_short = aq.SMA(short_window)
-        self.sma_long = aq.SMA(long_window)
-
-    def on_bar(self, bar: aq.Bar):
-        short_val = self.sma_short.update(bar.close)
-        long_val = self.sma_long.update(bar.close)
-
-        if short_val is None or long_val is None:
-            return
-
-        position = self.get_position(bar.symbol)
-
-        if short_val > long_val and position == 0:
-            self.buy(bar.symbol, 100)
-
-        elif short_val < long_val and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-运行该策略（AKShare 数据）：
-
-```python
-import akshare as ak
-import pandas as pd
-from akquant import run_backtest
-
-df = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
-if "date" not in df.columns:
-    df = df.reset_index().rename(columns={"index": "date"})
-df.columns = [c.lower() for c in df.columns]
-if "time" in df.columns and "date" not in df.columns:
-    df = df.rename(columns={"time": "date"})
-df["date"] = pd.to_datetime(df["date"]).dt.tz_localize("Asia/Shanghai")
-df["symbol"] = "000001"
-df = df[["date", "open", "high", "low", "close", "volume", "symbol"]].sort_values("date")
-
-result = run_backtest(data=df, strategy=DualSMAStrategy, lot_size=100)
-```
-
-### 3.2 RSI 均值回归策略 (RSI Mean Reversion)
-
-**核心思想**：
-RSI (相对强弱指标) 是一种动量指标，数值范围在 0 到 100 之间，用于衡量近期价格变化的幅度。
-*   **均值回归 (Mean Reversion)**：该策略假设价格不会一直涨或一直跌，过度偏离后会回归正常水平。
-*   **超卖 (Oversold)**：RSI 低于某个阈值（如 30），意味着近期跌幅过大，可能反弹 -> **买入**。
-*   **超买 (Overbought)**：RSI 高于某个阈值（如 70），意味着近期涨幅过大，可能回调 -> **卖出**。
-
-本示例展示了如何利用 `get_history_df` 获取历史数据，并结合 `pandas` 计算复杂指标。
-
-```python
-import akquant as aq
-import pandas as pd
-import numpy as np
-
-class RSIStrategy(aq.Strategy):
-    def __init__(self, period=14, buy_threshold=30, sell_threshold=70):
-        self.period = period
-        self.buy_threshold = buy_threshold
-        self.sell_threshold = sell_threshold
-        self.set_history_depth(period + 20)
-
-    def calculate_rsi(self, prices: pd.Series) -> pd.Series:
-        delta = prices.diff()
-        gain = (delta.where(delta > 0, 0)).rolling(window=self.period).mean()
-        loss = (-delta.where(delta < 0, 0)).rolling(window=self.period).mean()
-        rs = gain / loss
-        return 100 - (100 / (1 + rs))
-
-    def on_bar(self, bar: aq.Bar):
-        history = self.get_history_df(self.period + 20, bar.symbol)
-
-        if len(history) < self.period + 1:
-            return
-
-        rsi_series = self.calculate_rsi(history['close'])
-        current_rsi = rsi_series.iloc[-1]
-
-        if np.isnan(current_rsi):
-            return
-
-        position = self.get_position(bar.symbol)
-
-        if current_rsi < self.buy_threshold and position == 0:
-            self.buy(bar.symbol, 100)
-
-        elif current_rsi > self.sell_threshold and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-运行该策略（AKShare 数据）：
-
-```python
-import akshare as ak
-import pandas as pd
-from akquant import run_backtest
-
-df = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
-if "date" not in df.columns:
-    df = df.reset_index().rename(columns={"index": "date"})
-df.columns = [c.lower() for c in df.columns]
-if "time" in df.columns and "date" not in df.columns:
-    df = df.rename(columns={"time": "date"})
-df["date"] = pd.to_datetime(df["date"]).dt.tz_localize("Asia/Shanghai")
-df["symbol"] = "000001"
-df = df[["date", "open", "high", "low", "close", "volume", "symbol"]].sort_values("date")
-
-result = run_backtest(data=df, strategy=RSIStrategy, lot_size=100)
-```
-
-### 3.3 布林带策略 (Bollinger Bands)
-
-**核心思想**：
-布林带由三条轨道线组成：
-*   **中轨**：N 日移动平均线。
-*   **上轨**：中轨 + K 倍标准差。
-*   **下轨**：中轨 - K 倍标准差。
-
-根据统计学原理，价格有很大（如 95%）的概率落在上下轨之间。
-*   当价格**跌破下轨**时，通常被视为非理性的**超卖**状态，价格可能会回归中轨 -> **买入**。
-*   当价格**突破上轨**时，通常被视为非理性的**超买**状态，价格可能会回调 -> **卖出**。
-
-```python
-import akquant as aq
-import pandas as pd
-
-class BollingerStrategy(aq.Strategy):
-    def __init__(self, window=20, num_std=2):
-        self.window = window
-        self.num_std = num_std
-        self.set_history_depth(window + 5)
-
-    def on_bar(self, bar: aq.Bar):
-        history = self.get_history_df(self.window, bar.symbol)
-        if len(history) < self.window:
-            return
-
-        close_prices = history['close']
-        ma = close_prices.mean()
-        std = close_prices.std()
-        upper_band = ma + self.num_std * std
-        lower_band = ma - self.num_std * std
-
-        position = self.get_position(bar.symbol)
-        current_price = bar.close
-
-        if current_price < lower_band and position == 0:
-            self.buy(bar.symbol, 100)
-
-        elif current_price > upper_band and position > 0:
-            self.sell(bar.symbol, 100)
-```
-
-运行该策略（AKShare 数据）：
-
-```python
-import akshare as ak
-import pandas as pd
-from akquant import run_backtest
-
-df = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
-if "date" not in df.columns:
-    df = df.reset_index().rename(columns={"index": "date"})
-df.columns = [c.lower() for c in df.columns]
-if "time" in df.columns and "date" not in df.columns:
-    df = df.rename(columns={"time": "date"})
-df["date"] = pd.to_datetime(df["date"]).dt.tz_localize("Asia/Shanghai")
-df["symbol"] = "000001"
-df = df[["date", "open", "high", "low", "close", "volume", "symbol"]].sort_values("date")
-
-result = run_backtest(data=df, strategy=BollingerStrategy, lot_size=100)
-```
-
-### 3.4 混合资产回测 (Mixed Asset Backtest) {: #mixed-asset }
-
-**核心思想**：
-在实际交易中，策略可能同时涉及股票、期货、期权等多种资产。不同资产的交易属性不同：
-*   **股票**：通常 1 手 = 100 股，全额交易。
-*   **期货**：有**合约乘数**（如 1 点 = 300 元）和**保证金比例**（如 10% 资金即可买入合约）。
-
-本示例展示了如何使用 `InstrumentConfig` 来配置期货的特殊属性，并在同一个策略中混合交易股票和期货（此示例为演示期货参数，保留模拟数据）。
-
-```python
-import akquant as aq
-from akquant import InstrumentConfig
-import pandas as pd
-import numpy as np
-
-# 1. 准备数据 (模拟数据)
-def create_dummy_data(symbol, start_time, n_bars, price=100.0):
-    dates = pd.date_range(start_time, periods=n_bars, freq="B")
-    np.random.seed(42)
-    changes = np.random.randn(n_bars)
-    prices = price + np.cumsum(changes)
-
-    df = pd.DataFrame({
-        "open": prices, "high": prices + 1, "low": prices - 1, "close": prices,
-        "volume": 1000, "symbol": symbol
-    }, index=dates)
-    return df
-
-class TestStrategy(aq.Strategy):
-    def __init__(self):
-        self.count = 0
-
-    def on_bar(self, bar: aq.Bar):
-        # 简单逻辑: 前两根 Bar 分别买入股票和期货
-        if self.count < 2:
-            print(f"[{bar.timestamp}] Buying {bar.symbol}")
-            self.buy(bar.symbol, 1)
-        self.count += 1
-
-# 2. 生成数据
-df_stock = create_dummy_data("STOCK_A", "2023-01-01", 100, 100.0)
-df_future = create_dummy_data("FUTURE_B", "2023-01-01", 100, 3500.0)
-data = {"STOCK_A": df_stock, "FUTURE_B": df_future}
-
-# 3. 配置期货参数
-# 这里告诉回测引擎：FUTURE_B 是一个期货，乘数 300，保证金 10%
-future_config = InstrumentConfig(
-    symbol="FUTURE_B",
-    asset_type="FUTURES",
-    multiplier=300, # 股指期货乘数
-    margin_ratio=0.1 # 10% 保证金
-)
-
-# 4. 运行
-run_backtest(
-    data=data,
-    strategy=TestStrategy,
-    instruments_config=[future_config]
-)
-```
-
-可选：使用 AKShare 替换股票数据
-
-```python
-import akshare as ak
-import pandas as pd
-
-df_stock = ak.stock_zh_a_daily(symbol="sz000001", adjust="qfq")
-if "date" not in df_stock.columns:
-    df_stock = df_stock.reset_index().rename(columns={"index": "date"})
-df_stock.columns = [c.lower() for c in df_stock.columns]
-if "time" in df_stock.columns and "date" not in df_stock.columns:
-    df_stock = df_stock.rename(columns={"time": "date"})
-df_stock["date"] = pd.to_datetime(df_stock["date"]).dt.tz_localize("Asia/Shanghai")
-df_stock["symbol"] = "000001"
-df_stock = df_stock[["date", "open", "high", "low", "close", "volume", "symbol"]]
-
-# 与模拟的期货数据组合
-data = {"000001": df_stock, "FUTURE_B": df_future}
-```
-
-## 4. 复杂订单与风控 (Complex Orders) {: #complex-orders }
-
-**核心思想**：
-高级交易通常需要精细的订单管理。
-*   **Bracket Order (括号订单)**：这是一种“进场 + 止损 + 止盈”的组合单。当你开仓（进场）后，立刻为这笔持仓设置“止损单”和“止盈单”，像括号一样把价格包在中间。
-*   **OCO (One-Cancels-Other)**：指“止损单”和“止盈单”之间的关系。如果价格上涨触发了止盈，那么止损单就应该自动取消（因为仓位已经平了，不需要再止损了），反之亦然。
-
-虽然 AKQuant 的核心撮合引擎尚未原生内置 OCO 订单类型，但你可以通过策略层的回调函数 (`on_trade`, `on_order`) 轻松实现这些高级逻辑。
-
-### 4.1 OCO 与 Bracket Order 实现
-
-**逻辑流程**：
-1.  **进场**：策略发出开仓信号。
-2.  **成交回调 (`on_trade`)**：一旦开仓单成交，立即发出两笔平仓单：
-    *   **止损单 (Stop Loss)**：价格跌到 X 时卖出（保护本金）。
-    *   **止盈单 (Take Profit)**：价格涨到 Y 时卖出（锁定利润）。
-3.  **后续成交**：
-    *   如果止损单成交 -> 立即取消止盈单。
-    *   如果止盈单成交 -> 立即取消止损单。
-
-```python
-def on_trade(self, trade):
-    # 1. 进场单成交 -> 立即挂止损和止盈
-    if trade.order_id == self.entry_order_id:
-        # 下达止损单 (Stop Market: 达到触发价后以市价卖出)
-        self.stop_loss_id = self.sell(
-            trade.symbol, trade.quantity,
-            trigger_price=trade.price * 0.98, # 止损价 (成本价 - 2%)
-            price=None # None 表示触发后市价卖出
-        )
-
-        # 下达止盈单 (Limit Sell: 达到指定价格卖出)
-        self.take_profit_id = self.sell(
-            trade.symbol, trade.quantity,
-            price=trade.price * 1.05 # 止盈价 (成本价 + 5%)
-        )
-
-    # 2. 止损成交 -> 取消止盈
-    # 说明我们已经止损离场了，之前挂的止盈单需要撤销
-    elif trade.order_id == self.stop_loss_id:
-        self.cancel_order(self.take_profit_id)
-
-    # 3. 止盈成交 -> 取消止损
-    # 说明我们已经止盈离场了，之前挂的止损单需要撤销
-    elif trade.order_id == self.take_profit_id:
-        self.cancel_order(self.stop_loss_id)
-```
-
-!!! tip "参数优化"
-    该策略的 `stop_loss_pct` 和 `take_profit_pct` 参数可以通过 `akquant.run_optimization` 进行网格搜索优化。
-
-    ```python
-    from akquant import run_optimization
-    from examples.complex_orders import BracketStrategy
-
-    param_grid = {
-        "stop_loss_pct": [0.01, 0.02, 0.03],
-        "take_profit_pct": [0.03, 0.05, 0.08]
-    }
-
-    results = run_optimization(BracketStrategy, param_grid, data=df)
-    ```
-
-完整代码请参考 [examples/05_complex_orders.py](file:///examples/05_complex_orders.py)。
-
-> **注意**: `buy` / `sell` / `stop_buy` / `stop_sell` 方法都会返回唯一的 `order_id` (str)，你可以利用这个 ID 在 `on_trade` 和 `on_order` 回调中精确追踪每个订单的状态。
+*   **[17_readme_demo.py](https://github.com/akfamily/akquant/blob/main/examples/17_readme_demo.py)**:
+    *   README 中的演示脚本，是一个简单的独立文件。
+    *   适合作为 "Hello World" 快速测试。

--- a/examples/strategies/01_stock_dual_moving_average.py
+++ b/examples/strategies/01_stock_dual_moving_average.py
@@ -1,0 +1,120 @@
+"""
+A股趋势跟踪策略示例 (Stock Trend Following Strategy).
+
+================================================
+
+本示例展示如何使用 AKShare 获取 A 股历史数据，并运行一个简单的双均线策略。
+
+教学目标 (Learning Objectives):
+1.  使用 `ak.stock_zh_a_daily` 获取特定股票的历史数据。
+2.  使用 AKQuant 内置的 `self.get_history` 接口获取历史数据。
+3.  实现双均线策略逻辑。
+
+前置条件 (Prerequisites):
+- 安装 akshare: `pip install akshare`
+"""
+
+from typing import Any
+
+import akquant as aq
+import akshare as ak
+import numpy as np
+from akquant import Bar, Strategy
+
+
+class DualMovingAverageStrategy(Strategy):
+    """
+    双均线策略 (Dual Moving Average Strategy).
+
+    逻辑:
+    - 当 短期均线 > 长期均线 且 无持仓 -> 买入 (金叉)
+    - 当 短期均线 < 长期均线 且 有持仓 -> 卖出 (死叉)
+    """
+
+    def __init__(
+        self, short_window: int = 5, long_window: int = 20, *args: Any, **kwargs: Any
+    ) -> None:
+        """
+        Initialize strategy parameters.
+
+        :param short_window: 短期均线窗口
+        :param long_window: 长期均线窗口
+        """
+        super().__init__(*args, **kwargs)
+        self.short_window = short_window
+        self.long_window = long_window
+
+        # 必须设置 warmup_period，否则无法使用 get_history
+        # 这里的预热期至少需要等于长期均线的窗口大小
+        self.warmup_period = long_window
+
+    def on_bar(self, bar: Bar) -> None:
+        """Process each Bar data."""
+        symbol = bar.symbol
+
+        # 1. 获取历史收盘价
+        # 注意：get_history 返回的数据包含当前 bar
+        # 所以我们需要获取 long_window 个数据
+
+        # 获取过去 N 个历史收盘价 (包含当前 bar)
+        closes = self.get_history(count=self.long_window, symbol=symbol, field="close")
+        # print(closes)
+
+        # 如果历史数据不足，直接返回
+        if len(closes) < self.long_window:
+            return
+
+        # 2. 计算均线
+        # 使用 numpy 计算更高效
+        short_ma = np.mean(closes[-self.short_window :])
+        long_ma = np.mean(closes[-self.long_window :])
+
+        # 3. 获取当前持仓
+        current_pos = self.get_position(symbol)
+
+        # 4. 交易逻辑
+        # 金叉：短均线 > 长均线
+        if short_ma > long_ma and current_pos == 0:
+            # 全仓买入 (order_target_percent 自动计算数量)
+            # 注意：A股买入必须是 100 的倍数，框架会自动处理(向下取整)
+            self.order_target_percent(symbol=symbol, target_percent=0.95)
+            print(
+                f"[{bar.timestamp_str}] BUY SIGNAL: Short({short_ma:.2f}) > "
+                f"Long({long_ma:.2f}), Price={bar.close:.2f}"
+            )
+
+        # 死叉：短均线 < 长均线
+        elif short_ma < long_ma and current_pos > 0:
+            # 清仓
+            self.close_position(symbol=symbol)
+            print(
+                f"[{bar.timestamp_str}] SELL SIGNAL: Short({short_ma:.2f}) < "
+                f"Long({long_ma:.2f}), Price={bar.close:.2f}"
+            )
+
+
+if __name__ == "__main__":
+    # 1. 准备数据
+    # 以平安银行 (sz000001) 为例
+    # 注意：ak.stock_zh_a_daily 需要带前缀 sh 或 sz
+    symbol = "sz000001"
+
+    df = ak.stock_zh_a_daily(
+        symbol=symbol, start_date="20220101", end_date="20231231", adjust="qfq"
+    )
+
+    # 2. 运行回测
+    result = aq.run_backtest(
+        data=df,
+        strategy=DualMovingAverageStrategy,
+        symbol=symbol,
+        initial_cash=100_000.0,
+        commission_rate=0.0003,  # 万三佣金
+        min_commission=5.0,  # 最低5元
+        stamp_tax_rate=0.001,  # 千一印花税 (仅卖出)
+        lot_size=100,  # A股每手100股
+    )
+
+    # 3. 输出结果
+    print("\n=== Backtest Result ===")
+    print(result)

--- a/examples/strategies/02_stock_grid_trading.py
+++ b/examples/strategies/02_stock_grid_trading.py
@@ -1,0 +1,127 @@
+"""
+股票网格交易策略示例 (Stock Grid Trading Strategy).
+
+===========================================
+
+本示例展示如何使用 AKShare 获取股票历史数据，并运行一个经典的网格交易策略。
+
+教学目标 (Learning Objectives):
+1.  使用 `ak.stock_zh_a_daily` 获取股票数据。
+2.  理解网格交易的基本逻辑：分批建仓、高抛低吸。
+3.  演示如何在 `on_bar` 中管理复杂的持仓状态。
+
+前置条件 (Prerequisites):
+- 安装 akshare: `pip install akshare`
+"""
+
+from typing import Any
+
+import akquant as aq
+import akshare as ak
+from akquant import Bar, Strategy
+
+
+class GridTradingStrategy(Strategy):
+    """
+    网格交易策略 (Grid Trading).
+
+    逻辑:
+    - 设定一个基准价格 (base_price) 和网格间距 (grid_pct)。
+    - 价格每下跌 grid_pct，买入一份 (Buy Dip)。
+    - 价格每上涨 grid_pct，卖出一份 (Sell Rally)。
+    - 这里的实现是一个简化的动态网格：
+        - 初始建仓 50%。
+        - 记录上次交易价格。
+        - 相比上次买入价下跌 X%，加仓。
+        - 相比上次卖出价上涨 X%，减仓。
+    """
+
+    def __init__(
+        self, grid_pct: float = 0.03, lot_size: int = 100, *args: Any, **kwargs: Any
+    ) -> None:
+        """
+        初始化策略参数.
+
+        :param grid_pct: 网格间距 (e.g., 0.03 = 3%)
+        :param lot_size: 每次交易数量 (股/份)
+        """
+        super().__init__(*args, **kwargs)
+        self.grid_pct = grid_pct
+        self.trade_lot = lot_size
+
+        # 记录每个标的的上次交易价格
+        self.last_trade_price: dict[str, float] = {}
+
+    def on_bar(self, bar: Bar) -> None:
+        """Process each Bar data."""
+        symbol = bar.symbol
+        close = bar.close
+
+        # 1. 初始建仓 (如果从未交易过)
+        if symbol not in self.last_trade_price:
+            # 假设初始建仓 10 手
+            initial_lots = 10
+            self.buy(symbol=symbol, quantity=initial_lots * self.trade_lot)
+            self.last_trade_price[symbol] = close
+            print(
+                f"[{bar.timestamp_str}] Initial Position: "
+                f"Buy {initial_lots * self.trade_lot} at {close:.3f}"
+            )
+            return
+
+        last_price = self.last_trade_price[symbol]
+
+        # 2. 计算价格变化幅度
+        change_pct = (close - last_price) / last_price
+
+        # 3. 网格逻辑
+
+        # 情况 A: 价格下跌超过 grid_pct -> 加仓 (买入)
+        if change_pct <= -self.grid_pct:
+            self.buy(symbol=symbol, quantity=self.trade_lot)
+            self.last_trade_price[symbol] = close
+            print(
+                f"[{bar.timestamp_str}] Grid BUY: Price dropped {change_pct:.2%}, "
+                f"Buy {self.trade_lot} at {close:.3f}"
+            )
+
+        # 情况 B: 价格上涨超过 grid_pct -> 减仓 (卖出)
+        elif change_pct >= self.grid_pct:
+            # 检查持仓是否足够
+            current_pos = self.get_position(symbol)
+            if current_pos >= self.trade_lot:
+                self.sell(symbol=symbol, quantity=self.trade_lot)
+                self.last_trade_price[symbol] = close
+                print(
+                    f"[{bar.timestamp_str}] Grid SELL: Price rose {change_pct:.2%}, "
+                    f"Sell {self.trade_lot} at {close:.3f}"
+                )
+            else:
+                print(
+                    f"[{bar.timestamp_str}] Grid Signal: Sell triggered but "
+                    f"insufficient position ({current_pos})"
+                )
+
+
+if __name__ == "__main__":
+    # 1. 准备数据: 使用波动较大的股票，例如 宁德时代 (sz300750)
+    symbol = "sz300750"
+
+    df = ak.stock_zh_a_daily(
+        symbol=symbol, start_date="20220101", end_date="20231231", adjust="qfq"
+    )
+
+    # 2. 运行回测
+    result = aq.run_backtest(
+        data=df,
+        strategy=GridTradingStrategy,
+        symbol=symbol,
+        initial_cash=500_000.0,
+        lot_size=100,  # 股票每手100股
+        commission_rate=0.0003,  # 万三佣金
+        stamp_tax_rate=0.001,  # 千一印花税
+    )
+
+    # 3. 输出结果
+    print("\n=== Backtest Result ===")
+    print(result)

--- a/examples/strategies/03_stock_atr_breakout.py
+++ b/examples/strategies/03_stock_atr_breakout.py
@@ -1,0 +1,137 @@
+"""
+股票 ATR 通道突破策略 (Stock ATR Breakout Strategy).
+
+==============================================
+
+本示例展示如何使用 AKShare 获取股票数据，并实现经典的 ATR 通道突破策略。
+
+教学目标 (Learning Objectives):
+1.  使用 `ak.stock_zh_a_daily` 获取股票数据。
+2.  使用 `self.get_history` 高效计算 ATR (平均真实波幅)。
+3.  实现基于波动率的通道突破策略。
+
+前置条件 (Prerequisites):
+- 安装 akshare: `pip install akshare`
+"""
+
+from typing import Any
+
+import akquant as aq
+import akshare as ak
+from akquant import Bar, Strategy
+
+
+class AtrBreakoutStrategy(Strategy):
+    """
+    ATR 通道突破策略 (ATR Channel Breakout).
+
+    逻辑:
+    - 计算 ATR (平均真实波幅)。
+    - 计算上轨: Close + k * ATR
+    - 计算下轨: Close - k * ATR
+    - 价格突破上轨 -> 买入 (Buy)
+    - 价格跌破下轨 -> 卖出 (Sell)
+    """
+
+    def __init__(
+        self, period: int = 20, k: float = 2.0, *args: Any, **kwargs: Any
+    ) -> None:
+        """
+        初始化策略参数.
+
+        :param period: ATR 计算周期
+        :param k: 通道宽度系数
+        """
+        self.period = period
+        self.k = k
+        # 设置数据预热长度 (必须设置才能使用 get_history)
+        self.warmup_period = period + 1
+
+    def on_bar(self, bar: Bar) -> None:
+        """处理每个 Bar 数据."""
+        symbol = bar.symbol
+
+        # 1. 获取历史数据
+        # ATR 需要 High, Low, Close
+        # 注意：get_history 返回的数据可能包含当前 bar，为了避免未来函数
+        # 我们需要获取 N+1 个数据并剔除最后一个
+        req_count = self.period + 1
+        h_highs = self.get_history(count=req_count, symbol=symbol, field="high")
+        h_lows = self.get_history(count=req_count, symbol=symbol, field="low")
+        h_closes = self.get_history(count=req_count, symbol=symbol, field="close")
+
+        # 检查数据是否足够
+        if len(h_closes) < req_count:
+            return
+
+        highs = h_highs[:-1]
+        lows = h_lows[:-1]
+        closes = h_closes[:-1]
+
+        # 2. 计算 ATR
+        # 注意: 这里简化计算，使用过去 period 天的 TR 的平均值
+        # 真实的 ATR 通常使用 EMA 平滑
+
+        tr_sum = 0.0
+        for i in range(1, len(closes)):
+            h = highs[i]
+            low_val = lows[i]
+            pc = closes[i - 1]
+            tr = max(h - low_val, abs(h - pc), abs(low_val - pc))
+            tr_sum += tr
+
+        # 加上第 0 个元素 (假设第 0 个元素的 TR 为 H-L，因为没有前一天的数据)
+        tr_sum += highs[0] - lows[0]
+
+        atr = tr_sum / len(closes)
+
+        # 3. 计算轨道
+        # 使用昨天的收盘价作为基准
+        prev_close = closes[-1]
+        upper_band = prev_close + self.k * atr
+        lower_band = prev_close - self.k * atr
+
+        # 4. 交易逻辑
+        current_pos = self.get_position(symbol)
+
+        # 突破上轨 -> 买入
+        if bar.close > upper_band and current_pos == 0:
+            # 买入 500 股
+            self.buy(symbol=symbol, quantity=500)
+            print(
+                f"[{bar.timestamp_str}] LONG BREAKOUT: Price {bar.close:.2f} > "
+                f"Upper {upper_band:.2f} (ATR={atr:.2f})"
+            )
+
+        # 跌破下轨 -> 卖出平仓
+        elif bar.close < lower_band and current_pos > 0:
+            self.close_position(symbol=symbol)
+            print(
+                f"[{bar.timestamp_str}] CLOSE LONG: Price {bar.close:.2f} < "
+                f"Lower {lower_band:.2f} (ATR={atr:.2f})"
+            )
+
+
+if __name__ == "__main__":
+    # 1. 准备数据: 贵州茅台 (sh600519)
+    # 这种高价股适合演示资金管理，但这里简单演示策略逻辑
+    symbol = "sh600519"
+
+    df = ak.stock_zh_a_daily(
+        symbol=symbol, start_date="20220101", end_date="20231231", adjust="qfq"
+    )
+
+    # 2. 运行回测
+    result = aq.run_backtest(
+        data=df,
+        strategy=AtrBreakoutStrategy,
+        symbol=symbol,
+        initial_cash=1_000_000.0,
+        commission_rate=0.0003,
+        stamp_tax_rate=0.001,
+        lot_size=100,
+    )
+
+    # 3. 结果分析
+    print("\n=== Backtest Result ===")
+    print(result)

--- a/examples/strategies/04_stock_momentum_rotation.py
+++ b/examples/strategies/04_stock_momentum_rotation.py
@@ -1,0 +1,155 @@
+"""
+多股票轮动策略示例 (Multi-Stock Rotation Strategy).
+
+==============================================
+
+本示例展示如何同时回测多个标的，并实现基于动量的轮动策略。
+
+教学目标 (Learning Objectives):
+1.  同时获取并清洗多只股票的数据 (如 贵州茅台 vs 五粮液)。
+2.  使用 `self.get_history` 高效获取多标的历史数据。
+3.  实现跨标的比较与仓位轮动逻辑。
+
+前置条件 (Prerequisites):
+- 安装 akshare: `pip install akshare`
+"""
+
+from typing import Any
+
+import akquant as aq
+import akshare as ak
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+class MomentumRotationStrategy(Strategy):
+    """
+    动量轮动策略 (Momentum Rotation).
+
+    逻辑:
+    - 每日收盘时计算所有标的过去 N 天的收益率 (Momentum)。
+    - 持有动量最强的标的。
+    - 如果当前持仓不是最强标的，则换仓。
+    """
+
+    def __init__(self, lookback_period: int = 20, *args: Any, **kwargs: Any) -> None:
+        """
+        Initialize strategy parameters.
+
+        :param lookback_period: Momentum lookback period (days)
+        """
+        super().__init__(*args, **kwargs)
+        self.lookback_period = lookback_period
+        # 定义需要轮动的标的列表
+        self.symbols = ["sh600519", "sz000858"]  # 茅台 vs 五粮液
+        # 设置数据预热长度
+        self.warmup_period = lookback_period + 1
+
+    def on_bar(self, bar: Bar) -> None:
+        """处理每个 Bar 数据."""
+        # 注意: 在多标的回测中，on_bar 会被每个标的分别触发。
+        # 对于轮动策略，我们通常只需要在"每天"处理一次。
+        # 简单起见，我们在处理到列表最后一个标的时执行轮动逻辑。
+        # 或者，更严谨的做法是使用 on_timer 定时触发。
+
+        if bar.symbol != self.symbols[-1]:
+            return
+
+        # 1. 计算所有标的的动量
+        momentums: dict[str, float] = {}
+        for s in self.symbols:
+            # 获取历史收盘价 (包含当前bar)
+            closes = self.get_history(
+                count=self.lookback_period, symbol=s, field="close"
+            )
+
+            # 检查数据是否足够
+            if len(closes) < self.lookback_period:
+                return
+
+            # 计算动量: (当前收盘价 - N天前收盘价) / N天前收盘价
+            p_now = closes[-1]
+            p_prev = closes[0]
+            mom = (p_now - p_prev) / p_prev
+            momentums[s] = mom
+
+        # 2. 选出动量最大的标的
+        best_symbol = max(momentums, key=lambda k: momentums[k])
+        best_mom = momentums[best_symbol]
+
+        # 3. 交易执行
+        # 如果动量为负，是否空仓？这里假设只要有正动量就持有，全负则空仓 (可选)
+        if best_mom < 0:
+            # 清空所有持仓
+            for s in self.symbols:
+                if self.get_position(s) > 0:
+                    self.close_position(s)
+            return
+
+        # 持有 best_symbol
+        current_pos_symbol = None
+        for s in self.symbols:
+            if self.get_position(s) > 0:
+                current_pos_symbol = s
+                break
+
+        # 如果当前没有持仓，买入 best
+        if current_pos_symbol is None:
+            # 目标仓位 95%
+            # 注意: order_target_percent 的第一个参数是 target_percent
+            # 第二个是 symbol (可选)
+            # 或者使用关键字参数
+            self.order_target_percent(target_percent=0.95, symbol=best_symbol)
+            print(f"[{bar.timestamp_str}] BUY {best_symbol}: Momentum={best_mom:.2%}")
+
+        # 如果持有其他标的，换仓
+        elif current_pos_symbol != best_symbol:
+            print(
+                f"[{bar.timestamp_str}] ROTATE: "
+                f"Sell {current_pos_symbol} -> Buy {best_symbol}"
+            )
+            self.close_position(current_pos_symbol)
+            self.order_target_percent(target_percent=0.95, symbol=best_symbol)
+
+
+if __name__ == "__main__":
+    # 1. 准备数据: 白酒双雄
+    symbols = ["sh600519", "sz000858"]  # 贵州茅台, 五粮液
+    data_map = {}
+
+    print("Fetching data...")
+    for s in symbols:
+        df = ak.stock_zh_a_daily(
+            symbol=s, start_date="20220101", end_date="20231231", adjust="qfq"
+        )
+        if not df.empty:
+            # 简单清洗: 筛选列 + 标准化
+            df = df[["date", "open", "high", "low", "close", "volume"]]
+            df["date"] = pd.to_datetime(df["date"])
+            df["symbol"] = s
+            df = df.sort_values("date").reset_index(drop=True)
+            data_map[s] = df
+        else:
+            print(f"Skipping {s} due to no data")
+
+    if not data_map:
+        print("No data available.")
+        exit(0)
+
+    # 2. 运行回测
+    print(f"\nRunning Rotation Strategy on {list(data_map.keys())}...")
+
+    # 注意: 当传入多个标的数据时，data 参数接受一个字典 {symbol: DataFrame}
+    result = aq.run_backtest(
+        data=data_map,
+        strategy=MomentumRotationStrategy,
+        # symbol 参数在多标的模式下可以省略，或者指定为 BENCHMARK
+        symbol="BENCHMARK",
+        initial_cash=1_000_000.0,
+        commission_rate=0.0003,
+        stamp_tax_rate=0.001,
+    )
+
+    # 3. 结果
+    print("\n=== Backtest Result ===")
+    print(result)

--- a/examples/strategies/README.md
+++ b/examples/strategies/README.md
@@ -1,0 +1,57 @@
+# 常用策略示例 (Common Strategies)
+
+本目录包含一系列常用量化策略的实现代码，旨在帮助用户快速上手 AKQuant 策略开发。
+
+这些示例展示了如何结合 [AKShare](https://github.com/akfamily/akshare) 获取数据并进行回测，但也适用于其他数据源。
+
+## 核心提示 (Key Concepts)
+
+在使用 AKQuant 编写策略时，请注意以下核心机制：
+
+1.  **数据获取 (`get_history`)**:
+    -   `self.get_history(count=N)` 返回的是**包含当前 Bar** 的最近 N 条数据。
+    -   **计算均线 (MA)**: 直接使用 `get_history(N)` 即可（包含今日收盘价）。
+    -   **计算突破信号 (Breakout)**: 如果需要基于*昨日*收盘价计算指标（避免未来函数），请获取 `N+1` 条数据并切片 `[:-1]` 剔除当前 Bar。
+
+2.  **多标的回测**:
+    -   `run_backtest` 的 `data` 参数支持传入字典 `{symbol: DataFrame}`。
+    -   在策略中通过 `self.get_history(..., symbol=s)` 获取指定标的数据。
+
+## 案例列表
+
+### 1. [01_stock_dual_moving_average.py](./01_stock_dual_moving_average.py) - A股双均线策略
+- **目标**: 演示如何获取单只股票（如平安银行 sz000001）的历史数据。
+- **策略**: 双均线策略 (Golden Cross / Death Cross)。
+- **核心点**:
+    - 数据清洗与复权处理 (`adjust="qfq"`).
+    - `get_history` 的基本使用（包含当前 Bar 数据用于计算当日 MA）。
+
+### 2. [02_stock_grid_trading.py](./02_stock_grid_trading.py) - 股票网格交易
+- **目标**: 演示股票网格交易策略逻辑。
+- **策略**: 动态网格策略，价格下跌分批买入，上涨分批卖出。
+- **核心点**:
+    - `on_bar` 中的持仓状态管理。
+    - 复杂交易逻辑的实现（基于上次成交价的网格）。
+
+### 3. [03_stock_atr_breakout.py](./03_stock_atr_breakout.py) - 股票 ATR 通道策略
+- **目标**: 演示基于波动率的通道突破策略。
+- **策略**: ATR 通道突破策略。
+- **核心点**:
+    - **避免未来函数**: 演示如何剔除当前 Bar 数据来计算基于历史的指标（ATR/通道上下轨）。
+    - 波动率指标计算。
+
+### 4. [04_stock_momentum_rotation.py](./04_stock_momentum_rotation.py) - 多股票轮动
+- **目标**: 演示多只股票（如 贵州茅台 vs 五粮液）的数据获取与组合管理。
+- **策略**: 动量轮动策略 (Momentum Rotation)。
+- **核心点**:
+    - 多标的数据传入 (`Dict[str, DataFrame]`).
+    - 跨标的动量比较与换仓逻辑.
+    - `order_target_percent` 的正确使用。
+
+## 使用方法
+
+直接运行对应的 Python 脚本即可：
+
+```bash
+python examples/strategies/01_stock_dual_moving_average.py
+```

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1309,7 +1309,7 @@ class Strategy:
         :param kwargs: 其他下单参数
         """
         portfolio_value = self.get_portfolio_value()
-        target_value = portfolio_value * target_percent
+        target_value = portfolio_value * float(target_percent)
         self.order_target_value(target_value, symbol, price, **kwargs)
 
     def buy_all(self, symbol: Optional[str] = None) -> None:


### PR DESCRIPTION
- 重构 `docs/zh/guide/examples.md` 和 `docs/en/guide/examples.md`，将原有复杂示例替换为更清晰、基于 AKShare 的四个核心策略示例（双均线、网格交易、ATR突破、动量轮动）
- 新增 `examples/strategies/` 目录，包含四个完整的策略实现文件 (`01_stock_dual_moving_average.py`, `02_stock_grid_trading.py`, `03_stock_atr_breakout.py`, `04_stock_momentum_rotation.py`) 和详细的 README.md
- 修复 `python/akquant/strategy.py` 中 `order_target_percent` 方法的潜在类型错误，确保 `target_percent` 参数被转换为浮点数
- 更新文档结构，强调使用真实数据（AKShare）和避免未来函数等核心概念，提升示例的实用性和教育价值