### PR TITLE
docs: 从mkdocs.yml中移除sitemap插件

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,6 @@ extra_javascript:
 
 plugins:
   - search
-  - sitemap
   - i18n:
       docs_structure: folder
       languages:


### PR DESCRIPTION
不再需要自动生成站点地图功能，简化插件配置。