### PR TITLE
docs: 从文档配置中移除 polyfill.io 脚本

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -243,7 +243,6 @@ extra:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 copyright: Copyright &copy; 2026 AKQuant Contributors


### PR DESCRIPTION
移除对 polyfill.io 的依赖，因为 MathJax 3 已原生支持现代浏览器，无需额外的 polyfill。这简化了外部依赖并提高了加载可靠性。