### PR TITLE
feat(factor): 添加执行计划以支持嵌套正交窗口函数

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.50"
+version = "0.1.51"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.50"
+version = "0.1.51"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.50"
+version = "0.1.51"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/factor/engine.py
+++ b/python/akquant/factor/engine.py
@@ -80,17 +80,33 @@ class FactorEngine:
         :param end_date: Filter end date (inclusive).
         :return: DataFrame with [date, symbol, factor] columns.
         """
-        logger.info(f"Parsing expression: {expr_str}")
-        factor_expr = self.parser.parse(expr_str)
-
         lf = self.load_data()
-        lf = self._ensure_date_column(lf)
+        return self.run_on_data(lf, expr_str, start_date, end_date)
 
-        # Sort is crucial for rolling window functions
+    def run_on_data(
+        self,
+        data: pl.LazyFrame | pl.DataFrame,
+        expr_str: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> pl.DataFrame:
+        """
+        Execute a factor expression on provided data.
+
+        :param data: Polars DataFrame or LazyFrame containing input data.
+        :param expr_str: The factor expression string.
+        :param start_date: Filter start date (inclusive).
+        :param end_date: Filter end date (inclusive).
+        :return: DataFrame with [date, symbol, factor] columns.
+        """
+        if isinstance(data, pl.DataFrame):
+            lf = data.lazy()
+        else:
+            lf = data
+
+        lf = self._ensure_date_column(lf)
         lf = lf.sort(["symbol", "date"])
 
-        # Handle date filtering
-        # Convert string dates to datetime literals for comparison
         if start_date:
             lf = lf.filter(
                 pl.col("date") >= pl.lit(start_date).str.to_datetime(strict=False)
@@ -100,25 +116,61 @@ class FactorEngine:
                 pl.col("date") <= pl.lit(end_date).str.to_datetime(strict=False)
             )
 
-        # Select and Compute
-        result_lf = lf.select(
-            [pl.col("date"), pl.col("symbol"), factor_expr.alias("factor_value")]
-        )
+        # Plan execution
+        logger.info(f"Planning expression: {expr_str}")
+        steps = self.parser.plan(expr_str)
 
-        # Collect results
-        logger.info("Executing query plan...")
-        df = result_lf.collect()
-        return df
+        # Execute steps sequentially
+        current_lf = lf
+        for var_name, sub_expr_str in steps:
+            logger.info(f"Executing step: {var_name} = {sub_expr_str}")
+            sub_expr = self.parser.parse(sub_expr_str)
+
+            # If it's the final result, select it
+            if var_name == "result":
+                final_expr = sub_expr.alias("factor_value")
+                return current_lf.select(
+                    [pl.col("date"), pl.col("symbol"), final_expr]
+                ).collect()
+            else:
+                # Intermediate step: compute and materialize
+                # We use with_columns to add the intermediate result
+                # IMPORTANT: We MUST collect() to break the Lazy graph and force
+                # materialization to avoid the nested window function issue
+                # (Polars #25691). Polars treats nested `over()` as hierarchical,
+                # but TS/CS ops are orthogonal. Explicit materialization ensures
+                # the inner result is fully computed before the outer window
+                # function runs.
+
+                temp_df = current_lf.with_columns(sub_expr.alias(var_name)).collect()
+                current_lf = temp_df.lazy()
+
+        # Should not reach here
+        return pl.DataFrame()
 
     def run_batch(self, exprs: List[str]) -> pl.DataFrame:
         """Run multiple expressions at once."""
         lf = self.load_data()
         lf = self._ensure_date_column(lf)
-        lf = lf.sort(["symbol", "date"])
 
-        selections = [pl.col("date"), pl.col("symbol")]
+        # We need a base dataframe with all dates/symbols to join against
+        # This can be expensive if data is huge.
+        # Alternatively, we can use the first result as base, but outer join might be
+        # needed if filters differ (here filters are global).
+
+        # Optimization: Scan unique date/symbol only
+        base_df = (
+            lf.select(["date", "symbol"]).unique().collect().sort(["date", "symbol"])
+        )
+
         for i, expr_str in enumerate(exprs):
-            expr = self.parser.parse(expr_str)
-            selections.append(expr.alias(f"factor_{i}"))
+            # Run each expression.
+            # Note: run_on_data sorts internally, so order is consistent.
+            res = self.run_on_data(lf, expr_str)
+            res = res.rename({"factor_value": f"factor_{i}"})
 
-        return lf.select(selections).collect()
+            # Join back to base
+            # Use left join if base has all keys
+            base_df = base_df.join(res, on=["date", "symbol"], how="left")
+
+        return base_df

--- a/python/akquant/factor/ops.py
+++ b/python/akquant/factor/ops.py
@@ -198,3 +198,42 @@ OPS_MAP: Dict[str, Callable] = {
     "SignedPower": signed_power,
     "If": if_else,
 }
+
+# Define Operator Categories for Parser Optimization
+# TS: Time-Series (over symbol)
+# CS: Cross-Sectional (over date)
+# EL: Element-wise (neutral)
+OP_CATEGORY: Dict[str, str] = {
+    # TS
+    "Ts_Mean": "TS",
+    "Mean": "TS",
+    "Ts_Std": "TS",
+    "Std": "TS",
+    "Ts_Max": "TS",
+    "Max": "TS",
+    "Ts_Min": "TS",
+    "Min": "TS",
+    "Ts_Sum": "TS",
+    "Sum": "TS",
+    "Ts_Corr": "TS",
+    "Corr": "TS",
+    "Ts_Cov": "TS",
+    "Cov": "TS",
+    "Delay": "TS",
+    "Ref": "TS",
+    "Delta": "TS",
+    "Ts_ArgMax": "TS",
+    "ArgMax": "TS",
+    "Ts_ArgMin": "TS",
+    "ArgMin": "TS",
+    "Ts_Rank": "TS",
+    # CS
+    "Rank": "CS",
+    "Scale": "CS",
+    # EL
+    "Log": "EL",
+    "Abs": "EL",
+    "Sign": "EL",
+    "SignedPower": "EL",
+    "If": "EL",
+}

--- a/python/akquant/factor/parser.py
+++ b/python/akquant/factor/parser.py
@@ -1,9 +1,9 @@
 import ast
-from typing import Any
+from typing import Any, List, Tuple
 
 import polars as pl
 
-from .ops import OPS_MAP
+from .ops import OP_CATEGORY, OPS_MAP
 
 
 class ExpressionParser:
@@ -25,6 +25,102 @@ class ExpressionParser:
             raise ValueError(f"Invalid expression syntax: {expr_str}") from e
 
         return self._visit(tree.body)
+
+    def plan(self, expr_str: str) -> List[Tuple[str, str]]:
+        """
+        Generate an execution plan to handle nested window functions.
+
+        This method detects conflicts between orthogonal partition types (e.g., TS over
+        symbol vs CS over date) and splits the execution into sequential steps.
+
+        Reference: Polars Issue #25691
+        (https://github.com/pola-rs/polars/issues/25691) Polars treats nested
+        `.over()` calls as hierarchical partitions (inner within outer). However,
+        in factor calculations, TS (Time-Series) and CS (Cross-Sectional)
+        operations are often orthogonal, not hierarchical. To correctly compute
+        `CS(TS(...))` or `TS(CS(...))`, we must materialize the inner result
+        first (e.g., via `with_columns()`).
+
+        Returns a list of (var_name, expr_str) tuples.
+        The last item's var_name is 'result'.
+        """
+        expr_str = expr_str.strip()
+        try:
+            tree = ast.parse(expr_str, mode="eval")
+        except SyntaxError as e:
+            raise ValueError(f"Invalid expression syntax: {expr_str}") from e
+
+        steps = []
+        counter = 0  # Use nonlocal or simple var
+
+        def _get_category(func_name: str) -> str:
+            return OP_CATEGORY.get(func_name, "EL")
+
+        # We need a custom transformer that populates 'steps'
+        class PlanTransformer(ast.NodeTransformer):
+            def visit_Call(self, node: ast.Call) -> ast.AST:
+                nonlocal counter
+                # First visit children to handle deepest nesting first
+                self.generic_visit(node)
+
+                if not isinstance(node.func, ast.Name):
+                    return node
+
+                func_name = node.func.id
+                cat = _get_category(func_name)
+
+                # Check arguments for mismatch
+                new_args: List[ast.expr] = []
+                for arg in node.args:
+                    # Only check calls (expressions)
+                    if isinstance(arg, ast.Call) and isinstance(arg.func, ast.Name):
+                        arg_cat = _get_category(arg.func.id)
+
+                        # Detect conflict: CS(TS) or TS(CS)
+                        conflict = False
+                        if cat == "CS" and arg_cat == "TS":
+                            conflict = True
+                        elif cat == "TS" and arg_cat == "CS":
+                            conflict = True
+
+                        if conflict:
+                            # Extract argument to a step
+                            # Use ast.unparse (Python 3.9+)
+                            try:
+                                arg_str = ast.unparse(arg)
+                            except AttributeError:
+                                raise RuntimeError(
+                                    "Python 3.9+ required for ast.unparse"
+                                )
+
+                            step_var = f"_auto_var_{counter}"
+                            counter += 1
+                            steps.append((step_var, arg_str))
+
+                            # Replace arg with Name(id=step_var)
+                            # Use ast.Name for replacement
+                            new_args.append(ast.Name(id=step_var, ctx=ast.Load()))
+                        else:
+                            new_args.append(arg)
+                    else:
+                        new_args.append(arg)  # type: ignore
+
+                node.args = new_args  # type: ignore
+                return node
+
+        # Transform the tree
+        transformer = PlanTransformer()
+        new_tree = transformer.visit(tree.body)  # Visit body directly
+
+        # Final expression
+        try:
+            final_expr = ast.unparse(new_tree)
+        except AttributeError:
+            raise RuntimeError("Python 3.9+ required for ast.unparse")
+
+        steps.append(("result", final_expr))
+
+        return steps
 
     def _visit(self, node: Any) -> Any:
         # Handle Function Calls


### PR DESCRIPTION
引入 OP_CATEGORY 对算子进行分类（TS/CS/EL），并实现 ExpressionParser.plan 方法。 该方法检测 TS（时间序列）和 CS（横截面）算子之间的冲突，将嵌套表达式拆分为顺序执行步骤。
FactorEngine.run_on_data 方法按计划执行，通过 collect() 显式物化中间结果，以解决 Polars 嵌套窗口函数的正交性问题。 同时增加 run_on_data 方法，支持在任意数据上执行因子表达式。