### PR TITLE
feat(strategy): 新增多标的目标权重调仓方法 order_target_weights

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.61"
+version = "0.1.62"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.61"
+version = "0.1.62"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -5,6 +5,7 @@
 *   [Examples Directory Index](https://github.com/akfamily/akquant/blob/main/examples/README.md): Quick entry to all scripts under `examples/`, including scenario-based shortest run paths.
 *   [Quick Start](../start/quickstart.md): Complete workflow covering manual data backtesting and AKShare data backtesting.
 *   [Simple SMA Strategy](strategy.md#class-based): Demonstrates how to write a strategy in class style and perform simple trading logic in `on_bar`.
+*   [Shortest Path for Multi-Asset Target Weights](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): Focuses on `order_target_weights` and demonstrates one-shot portfolio rebalance after collecting a full timestamp bucket.
 
 > Data Source Convention: Unless otherwise specified (e.g. simulated data), examples on this page default to using AKShare to fetch real market data.
 
@@ -335,3 +336,7 @@ The `examples/` directory contains more scripts demonstrating AKShare integratio
 *   **[35_custom_broker_registry_demo.py](https://github.com/akfamily/akquant/blob/main/examples/35_custom_broker_registry_demo.py)**:
     *   Demonstrates custom broker registry flow: injects a broker `builder` with `register_broker` and creates gateways by name via `create_gateway_bundle`.
     *   Prints `bundle.metadata` to confirm the custom broker is resolved by factory.
+
+*   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
+    *   Demonstrates a minimal runnable `order_target_weights` flow: rebalance once after collecting all symbols for the same timestamp bucket.
+    *   Shows practical usage of `liquidate_unmentioned` and `rebalance_tolerance`, then prints `final_positions` / `final_equity`.

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -326,6 +326,16 @@ In AKQuant, order status transitions are as follows:
     # Adjust holding to 1000 shares (Buy 1000 if 0, Sell 1000 if 2000)
     self.order_target_value(target_value=1000 * price, symbol="AAPL") # Note: API does not support target_share directly yet, simulate with value
     ```
+    Rebalance multiple symbols with a single target-weight call:
+    ```python
+    self.order_target_weights(
+        target_weights={"AAPL": 0.4, "MSFT": 0.3, "GOOGL": 0.2},
+        liquidate_unmentioned=True,
+        rebalance_tolerance=0.01,
+    )
+    ```
+    By default the sum of weights must be `<= 1.0`; set `allow_leverage=True` to allow higher aggregate exposure.
+    Orders are submitted sell-first and then buy-second to reduce cash-lock conflicts during rotation.
 *   **Cancel Order**:
     ```python
     self.cancel_order(order_id) # Cancel specific order

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -399,6 +399,11 @@ Strategy base class. Users should inherit from this class and override callback 
 *   `place_trailing_stop_limit(symbol, quantity, price, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: Helper for trailing stop-limit orders, promoted to limit order when triggered.
 *   `order_target_value(target_value, symbol, price=None)`: Adjust position to target value.
 *   `order_target_percent(target_percent, symbol, price=None)`: Adjust position to target account percentage.
+*   `order_target_weights(target_weights, price_map=None, liquidate_unmentioned=False, allow_leverage=False, rebalance_tolerance=0.0, ...)`: Rebalance a multi-asset portfolio by target weights.
+    *   `target_weights` is `{symbol: weight}` and by default requires total weight `<= 1.0`.
+    *   `liquidate_unmentioned=True` sets all existing non-mentioned positions to target `0`.
+    *   Orders are submitted in sell-first then buy-second order to reduce cash-lock conflicts.
+    *   `rebalance_tolerance` skips tiny drifts by portfolio-value ratio to reduce churn.
 *   `close_position(symbol)`: Close position for a specific instrument.
 *   `cancel_order(order_id: str)`: Cancel a specific order.
 *   `cancel_all_orders(symbol)`: Cancel all pending orders for a specific instrument. If `symbol` is omitted, cancels all orders.

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -5,6 +5,7 @@
 *   [Examples 目录索引](https://github.com/akfamily/akquant/blob/main/examples/README.md): 快速浏览 `examples/` 下所有脚本入口，并包含按场景整理的最短执行路径。
 *   [快速开始 (Quickstart)](../start/quickstart.md): 包含手动数据回测和 AKShare 数据回测的完整流程。
 *   [简单的均线策略 (SMA Strategy)](strategy.md#class-based): 展示了如何使用类风格编写策略，并在 `on_bar` 中进行简单的交易逻辑。
+*   [多标的目标权重调仓最短路径](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): 聚焦 `order_target_weights`，展示同时间切片收齐后的一次性组合调仓。
 
 > 数据源约定：除特别标注需要模拟数据外，本页示例默认使用 AKShare 获取真实市场数据。
 
@@ -335,3 +336,7 @@ class AdjSignal(Strategy):
 *   **[35_custom_broker_registry_demo.py](https://github.com/akfamily/akquant/blob/main/examples/35_custom_broker_registry_demo.py)**:
     *   演示自定义 broker 注册机制：通过 `register_broker` 注入 `builder` 并使用 `create_gateway_bundle` 按名称创建网关。
     *   输出 `bundle.metadata` 以确认自定义 broker 已被工厂解析。
+
+*   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
+    *   演示 `order_target_weights` 的最小可运行闭环：收齐同一时间切片的多标的 Bar 后一次性按权重调仓。
+    *   展示 `liquidate_unmentioned` 与 `rebalance_tolerance` 的组合用法，并输出 `final_positions` / `final_equity`。

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -410,6 +410,19 @@ class MyStrategy(Strategy):
     *   `self.order_target(target=100, symbol="AAPL")`: 调整持仓数量至 100 股。
     *   `self.order_target_percent(target_percent=0.5, symbol="AAPL")`: 调整持仓至总资产的 50%。
     *   `self.order_target_value(target_value=10000, symbol="AAPL")`: 调整持仓至 10000 元市值。
+    *   `self.order_target_weights(target_weights={"AAPL":0.4,"MSFT":0.3}, liquidate_unmentioned=True, rebalance_tolerance=0.01)`: 按多标的权重统一调仓。
+        *   默认权重和不超过 `1.0`，如需超过请设置 `allow_leverage=True`。
+        *   执行顺序为先卖后买，减少现金占用导致的买入失败。
+
+```python
+def on_timer(self, payload: str):
+    weights = {"sh600519": 0.35, "sz000858": 0.25, "sh601318": 0.20}
+    self.order_target_weights(
+        target_weights=weights,
+        liquidate_unmentioned=True,
+        rebalance_tolerance=0.01,
+    )
+```
 
 *   **撤单 (Cancel Order)**:
     *   `self.cancel_order(order_id)`: 撤销指定订单。

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -374,6 +374,11 @@ result = run_backtest(
 *   `submit_order(..., order_type="StopTrailLimit", price=..., trail_offset=..., trail_reference_price=None)`: 提交跟踪止损限价单。`price` 与 `trail_offset` 必填。
 *   `place_trailing_stop(symbol, quantity, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: 跟踪止损助手，触发后按市价执行。
 *   `place_trailing_stop_limit(symbol, quantity, price, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: 跟踪止损限价助手，触发后按限价执行。
+*   `order_target_weights(target_weights, price_map=None, liquidate_unmentioned=False, allow_leverage=False, rebalance_tolerance=0.0, ...)`: 按多标的目标权重调仓。
+    *   `target_weights` 形如 `{symbol: weight}`，默认要求权重和不超过 `1.0`。
+    *   `liquidate_unmentioned=True` 时，会将未出现在目标字典中的现有持仓目标设为 `0`。
+    *   执行顺序为先卖后买，减少现金约束导致的调仓失败。
+    *   `rebalance_tolerance` 按组合市值比例跳过小偏差，降低无效换手。
 *   `cancel_order(order_id: str)`: 撤销指定订单。
 *   `cancel_all_orders(symbol)`: 取消指定标的的所有挂单。如果不指定 `symbol`，则取消所有挂单。
 *   `create_oco_order_group(first_order_id, second_order_id, group_id=None) -> str`: 创建 OCO 订单组。组内任一订单成交后，另一订单会被自动撤单。

--- a/examples/43_target_weights_rebalance.py
+++ b/examples/43_target_weights_rebalance.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def _build_symbol_df(
+    symbol: str, timestamps: list[pd.Timestamp], closes: list[float]
+) -> pd.DataFrame:
+    rows = []
+    for ts, close in zip(timestamps, closes):
+        rows.append(
+            {
+                "date": ts,
+                "open": close,
+                "high": close,
+                "low": close,
+                "close": close,
+                "volume": 10000.0,
+                "symbol": symbol,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def make_data() -> dict[str, pd.DataFrame]:
+    """Build deterministic multi-symbol demo data."""
+    timestamps = list(
+        pd.date_range("2024-01-02 10:00:00", periods=6, freq="D", tz="Asia/Shanghai")
+    )
+    return {
+        "AAA": _build_symbol_df(
+            "AAA", timestamps, [10.0, 10.2, 10.4, 10.5, 10.4, 10.3]
+        ),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 9.9, 9.8, 9.9, 10.0, 10.1]),
+        "CCC": _build_symbol_df("CCC", timestamps, [10.0, 10.1, 10.0, 9.9, 9.8, 9.7]),
+    }
+
+
+class TargetWeightsRebalanceStrategy(Strategy):
+    """Minimal target-weights rebalance demo."""
+
+    def __init__(self, symbols: list[str]) -> None:
+        """Initialize timestamp bucket and rebalance state."""
+        super().__init__()
+        self.symbols = symbols
+        self.pending: dict[int, set[str]] = defaultdict(set)
+        self.rebalance_count = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        """Run rebalance once per complete timestamp."""
+        bucket = self.pending[bar.timestamp]
+        bucket.add(bar.symbol)
+        if len(bucket) < len(self.symbols):
+            return
+        self.pending.pop(bar.timestamp, None)
+
+        if self.rebalance_count == 0:
+            weights = {"AAA": 0.6, "BBB": 0.3}
+        elif self.rebalance_count == 1:
+            weights = {"AAA": 0.2, "BBB": 0.6, "CCC": 0.1}
+        else:
+            weights = {"BBB": 0.7}
+
+        self.order_target_weights(
+            target_weights=weights,
+            liquidate_unmentioned=True,
+            rebalance_tolerance=0.01,
+        )
+        self.rebalance_count += 1
+
+
+def main() -> None:
+    """Run demo and print key outputs."""
+    symbols = ["AAA", "BBB", "CCC"]
+    result = aq.run_backtest(
+        data=make_data(),
+        strategy=TargetWeightsRebalanceStrategy,
+        symbols=symbols,
+        symbol="BENCHMARK",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        execution_mode="current_close",
+        show_progress=False,
+    )
+
+    print("final_positions")
+    print(result.positions.iloc[-1])
+    print("final_equity")
+    print(float(result.equity_curve.iloc[-1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,7 @@
 - [40_functional_multi_slot_risk_demo.py](./40_functional_multi_slot_risk_demo.py): 函数式 + 多策略 slot + 风控限制端到端示例。
 - [41_live_multi_slot_orchestration_demo.py](./41_live_multi_slot_orchestration_demo.py): LiveRunner 多策略 slot 编排示例（paper）。
 - [42_live_broker_event_audit_demo.py](./42_live_broker_event_audit_demo.py): broker 事件审计与 owner_strategy_id 追踪示例。
+- [43_target_weights_rebalance.py](./43_target_weights_rebalance.py): 多标的 `order_target_weights` 目标权重调仓示例。
 
 ## 流式回测与实时报告
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.61"
+version = "0.1.62"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -135,6 +135,9 @@ from .strategy_trading_api import (
     order_target_value as _order_target_value_impl,
 )
 from .strategy_trading_api import (
+    order_target_weights as _order_target_weights_impl,
+)
+from .strategy_trading_api import (
     resolve_symbol as _resolve_symbol_impl,
 )
 from .strategy_trading_api import (
@@ -1426,6 +1429,35 @@ class Strategy:
         :param kwargs: 其他下单参数
         """
         _order_target_percent_impl(self, target_percent, symbol, price, **kwargs)
+
+    def order_target_weights(
+        self,
+        target_weights: Dict[str, float],
+        price_map: Optional[Dict[str, float]] = None,
+        liquidate_unmentioned: bool = False,
+        allow_leverage: bool = False,
+        rebalance_tolerance: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        """
+        按多标的目标权重调仓.
+
+        :param target_weights: 目标权重字典 {symbol: weight}
+        :param price_map: 每个标的的委托价格字典（可选）
+        :param liquidate_unmentioned: 是否清仓未出现在目标权重中的现有持仓
+        :param allow_leverage: 是否允许目标权重和超过 1.0
+        :param rebalance_tolerance: 调仓容忍阈值（按组合市值比例）
+        :param kwargs: 其他下单参数
+        """
+        _order_target_weights_impl(
+            self,
+            target_weights,
+            price_map,
+            liquidate_unmentioned,
+            allow_leverage,
+            rebalance_tolerance,
+            **kwargs,
+        )
 
     def buy_all(self, symbol: Optional[str] = None) -> None:
         """

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -587,6 +587,84 @@ def order_target_percent(
     order_target_value(strategy, target_value, symbol, price, **kwargs)
 
 
+def order_target_weights(
+    strategy: Any,
+    target_weights: Dict[str, float],
+    price_map: Optional[Dict[str, float]] = None,
+    liquidate_unmentioned: bool = False,
+    allow_leverage: bool = False,
+    rebalance_tolerance: float = 0.0,
+    **kwargs: Any,
+) -> None:
+    """按多标的目标权重调仓."""
+    if strategy.ctx is None:
+        raise RuntimeError("Context not ready")
+
+    if rebalance_tolerance < 0:
+        raise ValueError("rebalance_tolerance must be >= 0")
+
+    normalized_weights: Dict[str, float] = {}
+    for symbol, weight in target_weights.items():
+        if not symbol:
+            raise ValueError("symbol in target_weights must be non-empty")
+        normalized_weight = float(weight)
+        if normalized_weight < 0:
+            raise ValueError(f"target weight for {symbol} must be >= 0")
+        normalized_weights[symbol] = normalized_weight
+
+    total_weight = sum(normalized_weights.values())
+    if not allow_leverage and total_weight > 1.0 + 1e-8:
+        raise ValueError(
+            f"sum of target_weights ({total_weight:.6f}) exceeds 1.0; "
+            "set allow_leverage=True to permit this"
+        )
+
+    if liquidate_unmentioned:
+        for symbol, qty in strategy.ctx.positions.items():
+            if float(qty) != 0.0 and symbol not in normalized_weights:
+                normalized_weights[symbol] = 0.0
+
+    if not normalized_weights:
+        return
+
+    portfolio_value = get_portfolio_value(strategy)
+    abs_tolerance_value = abs(float(portfolio_value)) * float(rebalance_tolerance)
+    planned: List[Tuple[str, float, float]] = []
+
+    for symbol, weight in normalized_weights.items():
+        target_value = float(portfolio_value) * float(weight)
+        current_qty = float(strategy.ctx.get_position(symbol))
+
+        current_price = strategy._last_prices.get(symbol, 0.0)
+        if current_price == 0.0:
+            if strategy.current_bar and strategy.current_bar.symbol == symbol:
+                current_price = strategy.current_bar.close
+            elif strategy.current_tick and strategy.current_tick.symbol == symbol:
+                current_price = strategy.current_tick.price
+
+        current_value = current_qty * float(current_price)
+        delta_value = target_value - current_value
+        if abs(delta_value) <= abs_tolerance_value:
+            continue
+        planned.append((symbol, target_value, delta_value))
+
+    if not planned:
+        return
+
+    sell_legs = [item for item in planned if item[2] < 0]
+    buy_legs = [item for item in planned if item[2] >= 0]
+
+    for symbol, target_value, _ in sorted(sell_legs, key=lambda item: item[2]):
+        leg_price = price_map.get(symbol) if price_map else None
+        order_target_value(strategy, target_value, symbol, leg_price, **kwargs)
+
+    for symbol, target_value, _ in sorted(
+        buy_legs, key=lambda item: item[2], reverse=True
+    ):
+        leg_price = price_map.get(symbol) if price_map else None
+        order_target_value(strategy, target_value, symbol, leg_price, **kwargs)
+
+
 def buy_all(strategy: Any, symbol: Optional[str] = None) -> None:
     """全仓买入 (Buy All)."""
     if strategy.ctx is None:

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from typing import Any
+from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 from akquant import Bar, Strategy, run_backtest
 
 
@@ -183,3 +185,169 @@ def test_multisymbol_bucket_keeps_single_winner_position() -> None:
     positive_counts = (positions > 0).sum(axis=1)
 
     assert (positive_counts <= 1).all()
+
+
+class TargetWeightsStrategy(Strategy):
+    """Strategy for validating multi-symbol target weight rebalancing."""
+
+    def __init__(self, symbols: list[str]) -> None:
+        """Initialize state for staged rotation rebalancing."""
+        super().__init__()
+        self.symbols = symbols
+        self.pending: dict[int, set[str]] = defaultdict(set)
+        self.rebalance_count = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        """Rebalance once all symbols of current timestamp are collected."""
+        bucket = self.pending[bar.timestamp]
+        bucket.add(bar.symbol)
+        if len(bucket) < len(self.symbols):
+            return
+        self.pending.pop(bar.timestamp, None)
+
+        if self.rebalance_count == 0:
+            self.order_target_weights(
+                {"AAA": 1.0},
+                liquidate_unmentioned=True,
+                rebalance_tolerance=0.0,
+            )
+        elif self.rebalance_count in (1, 2):
+            self.order_target_weights(
+                {"BBB": 1.0},
+                liquidate_unmentioned=True,
+                rebalance_tolerance=0.0,
+            )
+        self.rebalance_count += 1
+
+
+class TargetWeightsSplitStrategy(Strategy):
+    """Strategy for validating split target weights."""
+
+    def __init__(self, symbols: list[str]) -> None:
+        """Initialize state for one-shot split allocation."""
+        super().__init__()
+        self.symbols = symbols
+        self.pending: dict[int, set[str]] = defaultdict(set)
+        self.rebalanced = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Apply target split after timestamp bucket is complete."""
+        bucket = self.pending[bar.timestamp]
+        bucket.add(bar.symbol)
+        if len(bucket) < len(self.symbols):
+            return
+        self.pending.pop(bar.timestamp, None)
+
+        if not self.rebalanced:
+            self.order_target_weights(
+                {"AAA": 0.6, "BBB": 0.3},
+                liquidate_unmentioned=True,
+                rebalance_tolerance=0.0,
+            )
+            self.rebalanced = True
+
+
+def test_order_target_weights_rotation_liquidates_unmentioned_symbols() -> None:
+    """Target weights should support one-call rotation and clear old holdings."""
+    timestamps = [
+        pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-05 10:00:00", tz="Asia/Shanghai"),
+    ]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0, 10.0, 10.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0, 10.0, 10.0]),
+    }
+
+    result = run_backtest(
+        data=data_map,
+        strategy=TargetWeightsStrategy,
+        symbols=["AAA", "BBB"],
+        symbol="BENCHMARK",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        execution_mode="current_close",
+        show_progress=False,
+    )
+
+    final_positions = result.positions.iloc[-1]
+    assert float(final_positions.get("AAA", 0.0)) == 0.0
+    assert float(final_positions.get("BBB", 0.0)) > 0.0
+
+
+def test_order_target_weights_split_allocation_is_close_to_target() -> None:
+    """Target weights should allocate multi-symbol positions by portfolio ratio."""
+    timestamps = [
+        pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
+    ]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0]),
+    }
+
+    result = run_backtest(
+        data=data_map,
+        strategy=TargetWeightsSplitStrategy,
+        symbols=["AAA", "BBB"],
+        symbol="BENCHMARK",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        execution_mode="current_close",
+        show_progress=False,
+    )
+
+    final_positions = result.positions.iloc[-1]
+    aaa_value = float(final_positions.get("AAA", 0.0)) * 10.0
+    bbb_value = float(final_positions.get("BBB", 0.0)) * 10.0
+    total_value = float(result.equity_curve.iloc[-1])
+
+    assert abs(aaa_value / total_value - 0.6) < 0.02
+    assert abs(bbb_value / total_value - 0.3) < 0.02
+
+
+def _build_validation_strategy() -> Strategy:
+    """Build strategy with minimal mock context for validation tests."""
+    strategy = TargetWeightsSplitStrategy(symbols=["AAA", "BBB"])
+    strategy.ctx = MagicMock()
+    strategy.ctx.positions = {}
+    strategy.ctx.cash = 100000.0
+    strategy.ctx.get_position.return_value = 0.0
+    return strategy
+
+
+def test_order_target_weights_rejects_negative_tolerance() -> None:
+    """Reject negative rebalance tolerance values."""
+    strategy = _build_validation_strategy()
+    with pytest.raises(ValueError, match="rebalance_tolerance must be >= 0"):
+        strategy.order_target_weights({"AAA": 0.5}, rebalance_tolerance=-0.01)
+
+
+def test_order_target_weights_rejects_weight_sum_over_one_without_leverage() -> None:
+    """Reject total weights above one when leverage is disabled."""
+    strategy = _build_validation_strategy()
+    with pytest.raises(ValueError, match="exceeds 1.0"):
+        strategy.order_target_weights({"AAA": 0.7, "BBB": 0.4})
+
+
+def test_order_target_weights_rejects_negative_weight() -> None:
+    """Reject negative target weight input."""
+    strategy = _build_validation_strategy()
+    with pytest.raises(ValueError, match="must be >= 0"):
+        strategy.order_target_weights({"AAA": -0.1})
+
+
+def test_order_target_weights_rejects_empty_symbol() -> None:
+    """Reject empty symbol key in target weights."""
+    strategy = _build_validation_strategy()
+    with pytest.raises(ValueError, match="must be non-empty"):
+        strategy.order_target_weights({"": 0.2})


### PR DESCRIPTION
新增 `order_target_weights` 方法，支持在一次调用中按目标权重调整多标的组合持仓。该方法允许设置调仓容忍度以减少无效交易，并可选择是否清仓未提及的现有持仓。执行顺序为先卖后买，以降低现金占用导致的调仓失败。

同时更新了相关文档和示例，并添加了相应的单元测试。