### PR TITLE
feat(strategy): 引入增量指标模式并重构指标注册机制

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.63"
+version = "0.1.64"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.63"
+version = "0.1.64"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -443,32 +443,51 @@ Supported Indicators: `SMA`, `EMA`, `MACD`, `RSI`, `BollingerBands`, `ATR`.
 
 ### 7.1 Registration and Usage
 
-AKQuant supports **Auto-Discovery**. You can simply assign indicators to `self` in `__init__`, and they will be registered automatically.
+AKQuant follows a dual-platform and single-strategy style. Each strategy must explicitly set `indicator_mode` and use the matching registration API:
+
+* `indicator_mode="precompute"` + `register_precomputed_indicator(...)`
+* `indicator_mode="incremental"` + `register_incremental_indicator(...)`
 
 ```python
-from akquant import Strategy
-from akquant.indicators import SMA, RSI
+from akquant import Bar, SMA, Strategy
 
 class IndicatorStrategy(Strategy):
     def __init__(self):
-        # Method 1: Auto-Discovery (Recommended)
-        # Assign to self.xxx, automatically registered and calculated
+        self.indicator_mode = "precompute"
         self.sma20 = SMA(20)
-        self.rsi14 = RSI(14)
+        self.register_precomputed_indicator("sma20", self.sma20)
 
     def on_start(self):
         self.subscribe("AAPL")
 
-        # Method 2: Manual Registration
-        # self.register_indicator("sma20", SMA(20))
+    def on_bar(self, bar: Bar):
+        val = self.sma20.get_value(bar.symbol, bar.timestamp)
+        if bar.close > val:
+            self.buy(bar.symbol, 100)
+```
+
+```python
+from akquant import Bar, SMA, Strategy
+
+class IncrementalIndicatorStrategy(Strategy):
+    def __init__(self):
+        self.indicator_mode = "incremental"
+        self.sma20 = SMA(20)
+        self.register_incremental_indicator(
+            "sma20",
+            self.sma20,
+            source="close",
+            symbols=["AAPL"],
+        )
 
     def on_bar(self, bar: Bar):
-        # Access value via property
-        if bar.close > self.sma20.value:
+        if bar.symbol != "AAPL":
+            return
+        val = self.sma20.value
+        if val is None:
+            return
+        if bar.close > val:
             self.buy(bar.symbol, 100)
-
-        # Or get historical value
-        # val = self.sma20.get_value(bar.symbol, bar.timestamp)
 ```
 
 ## 7. Strategy Cookbook

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -563,32 +563,51 @@ def on_bar(self, bar: Bar):
 
 ### 7.2 指标 (Indicators)
 
-AKQuant 支持**自动发现**机制，你可以直接在 `__init__` 中将指标赋值给 `self` 属性，系统会自动完成注册。
+AKQuant 采用“平台双主流、策略单主流”模式。每个策略需要显式设置 `indicator_mode`，并使用对应注册接口：
+
+*   `indicator_mode="precompute"` + `register_precomputed_indicator(...)`
+*   `indicator_mode="incremental"` + `register_incremental_indicator(...)`
 
 ```python
-from akquant import Strategy
-from akquant.indicators import SMA, RSI
+from akquant import Bar, SMA, Strategy
 
 class IndicatorStrategy(Strategy):
     def __init__(self):
-        # 方式 1: 自动注册 (推荐)
-        # 只要赋值给 self.xxx，系统会自动发现并计算
+        self.indicator_mode = "precompute"
         self.sma20 = SMA(20)
-        self.rsi14 = RSI(14)
+        self.register_precomputed_indicator("sma20", self.sma20)
 
     def on_start(self):
         self.subscribe("AAPL")
 
-        # 方式 2: 手动注册 (传统方式)
-        # self.register_indicator("sma20", SMA(20))
+    def on_bar(self, bar: Bar):
+        val = self.sma20.get_value(bar.symbol, bar.timestamp)
+        if bar.close > val:
+            self.buy(bar.symbol, 100)
+```
+
+```python
+from akquant import Bar, SMA, Strategy
+
+class IncrementalIndicatorStrategy(Strategy):
+    def __init__(self):
+        self.indicator_mode = "incremental"
+        self.sma20 = SMA(20)
+        self.register_incremental_indicator(
+            "sma20",
+            self.sma20,
+            source="close",
+            symbols=["AAPL"],
+        )
 
     def on_bar(self, bar: Bar):
-        # 直接通过属性访问指标值
-        if bar.close > self.sma20.value:
+        if bar.symbol != "AAPL":
+            return
+        val = self.sma20.value
+        if val is None:
+            return
+        if bar.close > val:
             self.buy(bar.symbol, 100)
-
-        # 或者通过 get_value 获取历史值
-        # val = self.sma20.get_value(bar.symbol, bar.timestamp)
 
 ## 8. 高级特性：热启动 (Warm Start)
 

--- a/examples/14_multi_frequency.py
+++ b/examples/14_multi_frequency.py
@@ -143,7 +143,7 @@ class MultiFrequencyAdapter:
             if not daily.empty:
                 daily = daily.copy()
                 tz_name = request.timezone or "Asia/Shanghai"
-                local_index = daily.index
+                local_index = pd.DatetimeIndex(daily.index)
                 if local_index.tz is None:
                     local_index = local_index.tz_localize("UTC")
                 local_index = local_index.tz_convert(tz_name)
@@ -173,9 +173,17 @@ class MultiFreqStrategy(aq.Strategy):
     def __init__(self) -> None:
         """Initialize the strategy."""
         super().__init__()
+        self.indicator_mode = "incremental"
         self.daily_trend = 0  # 1 for Up, -1 for Down, 0 for Neutral
         self.ma_window = 3  # Short MA for demo
-        self.daily_prices: List[float] = []
+        self.daily_symbol = "000001.SZ_1D"
+        self.daily_sma = aq.SMA(self.ma_window)
+        self.register_incremental_indicator(
+            "daily_sma",
+            self.daily_sma,
+            source="close",
+            symbols=[self.daily_symbol],
+        )
 
         # Track position manually for simple demo (optional, akquant handles it)
         self.has_position = False
@@ -196,7 +204,7 @@ class MultiFreqStrategy(aq.Strategy):
         # Use helper for formatted string (Default: %Y-%m-%d %H:%M:%S)
         ts_str = self.format_time(bar.timestamp)
 
-        if bar.symbol == "000001.SZ_1D":
+        if bar.symbol == self.daily_symbol:
             print(f"\n{'=' * 60}")
             print(
                 f"EVENT: Daily Bar Arrived | {ts_str} (BJ) | "
@@ -213,15 +221,8 @@ class MultiFreqStrategy(aq.Strategy):
 
     def _handle_daily_bar(self, bar: aq.Bar) -> None:
         """Process Daily Bar: Update Trend."""
-        self.daily_prices.append(bar.close)
-
-        # Keep only needed history
-        if len(self.daily_prices) > self.ma_window + 5:
-            self.daily_prices.pop(0)
-
-        # Calculate MA
-        if len(self.daily_prices) >= self.ma_window:
-            ma = sum(self.daily_prices[-self.ma_window :]) / self.ma_window
+        ma = self.daily_sma.value
+        if ma is not None:
             prev_trend = self.daily_trend
 
             # Determine Trend
@@ -241,8 +242,7 @@ class MultiFreqStrategy(aq.Strategy):
             )
         else:
             print(
-                f"[Logic 1D] Collecting history... "
-                f"({len(self.daily_prices)}/{self.ma_window})"
+                f"[Logic 1D] Collecting history... (need {self.ma_window} daily bars)"
             )
 
     def _handle_minute_bar(self, bar: aq.Bar, ts_bj: pd.Timestamp) -> None:
@@ -308,7 +308,10 @@ if __name__ == "__main__":
     from akquant import BacktestConfig, StrategyConfig
 
     config = BacktestConfig(
-        strategy_config=StrategyConfig(initial_cash=100_000.0),
+        strategy_config=StrategyConfig(
+            initial_cash=100_000.0,
+            indicator_mode="incremental",
+        ),
         instruments_config=[stock_1m_config],
         show_progress=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.63"
+version = "0.1.64"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -246,6 +246,7 @@ def _coerce_strategy_runtime_config(
             portfolio_update_eps=value.portfolio_update_eps,
             error_mode=value.error_mode,
             re_raise_on_error=value.re_raise_on_error,
+            indicator_mode=value.indicator_mode,
         )
     if isinstance(value, dict):
         unknown_fields = sorted(set(value.keys()) - _RUNTIME_CONFIG_FIELDS)
@@ -275,6 +276,10 @@ def _runtime_config_conflicts(
         if before != after:
             conflicts.append(f"{key}: {before} -> {after}")
     return conflicts
+
+
+def _should_prepare_precomputed_indicators(strategy_instance: Strategy) -> bool:
+    return str(strategy_instance.indicator_mode).strip().lower() == "precompute"
 
 
 def _apply_strategy_runtime_config(
@@ -551,6 +556,10 @@ def run_backtest(
                 Optional[float],
                 getattr(strategy_config, "portfolio_risk_budget", None),
             )
+        if strategy_runtime_config is None:
+            config_indicator_mode = getattr(strategy_config, "indicator_mode", None)
+            if config_indicator_mode is not None:
+                strategy_runtime_config = {"indicator_mode": config_indicator_mode}
     if strategies_by_slot is not None and not isinstance(strategies_by_slot, dict):
         raise TypeError("strategies_by_slot must be a dict when provided")
     if strategy_max_order_value is not None and not isinstance(
@@ -1136,21 +1145,6 @@ def run_backtest(
             if hasattr(current_strategy, "_trading_day_bounds"):
                 current_strategy._trading_day_bounds = day_bounds
 
-    # 3.5 Pre-calculate indicators
-    # Inject data into indicators so they can be accessed in on_bar via get_value()
-    if data_map_for_indicators:
-        for current_strategy in all_strategy_instances:
-            if hasattr(current_strategy, "_indicators"):
-                for symbol_key, df_val in data_map_for_indicators.items():
-                    for ind in current_strategy._indicators:
-                        try:
-                            ind(df_val, symbol_key)
-                        except Exception as e:
-                            logger.error(
-                                f"Failed to calculate indicator {ind.name} "
-                                f"for {symbol_key}: {e}"
-                            )
-
     # 4. 配置引擎
     engine = Engine()
     for current_strategy in all_strategy_instances:
@@ -1720,10 +1714,12 @@ def run_backtest(
         for current_strategy in all_strategy_instances:
             current_strategy.set_history_depth(effective_depth)
 
-    # 7.5 Prepare Indicators (Vectorized Pre-calculation)
+    # 7.5 Prepare Indicators (Precompute mode only)
     if data_map_for_indicators:
         for current_strategy in all_strategy_instances:
-            if hasattr(current_strategy, "_prepare_indicators"):
+            if _should_prepare_precomputed_indicators(current_strategy) and hasattr(
+                current_strategy, "_prepare_indicators"
+            ):
                 current_strategy._prepare_indicators(data_map_for_indicators)
 
     try:
@@ -1896,6 +1892,10 @@ def run_warm_start(
                 Optional[float],
                 getattr(strategy_config, "portfolio_risk_budget", None),
             )
+        if strategy_runtime_config is None:
+            config_indicator_mode = getattr(strategy_config, "indicator_mode", None)
+            if config_indicator_mode is not None:
+                strategy_runtime_config = {"indicator_mode": config_indicator_mode}
     if strategies_by_slot is not None and not isinstance(strategies_by_slot, dict):
         raise TypeError("strategies_by_slot must be a dict when provided")
     if strategy_max_order_value is not None and not isinstance(
@@ -2498,14 +2498,6 @@ def run_warm_start(
             stream_mode,
         )
 
-    if data_map_for_indicators:
-        for current_strategy in all_strategy_instances:
-            if hasattr(current_strategy, "_prepare_indicators"):
-                try:
-                    current_strategy._prepare_indicators(data_map_for_indicators)
-                except Exception as e:
-                    logger.error(f"Failed to update indicators for warm start: {e}")
-
     if hasattr(strategy_instance, "_on_start_internal"):
         strategy_instance._on_start_internal()
     elif hasattr(strategy_instance, "on_start"):
@@ -2521,6 +2513,16 @@ def run_warm_start(
                 if hasattr(slot_strategy, "on_resume"):
                     slot_strategy.on_resume()
             slot_strategy.on_start()
+
+    if data_map_for_indicators:
+        for current_strategy in all_strategy_instances:
+            if _should_prepare_precomputed_indicators(current_strategy) and hasattr(
+                current_strategy, "_prepare_indicators"
+            ):
+                try:
+                    current_strategy._prepare_indicators(data_map_for_indicators)
+                except Exception as e:
+                    logger.error(f"Failed to update indicators for warm start: {e}")
 
     # 4. 运行
     try:

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -193,6 +193,9 @@ class StrategyConfig:
                              capped at 25% of the bar's volume. Default 0.25.
     :param exit_on_last_bar: Auto-close all positions at the end of backtest.
                              Default True.
+    :param indicator_mode: Indicator execution mode. "incremental" updates indicator
+                           state on each bar; "precompute" prepares full series before
+                           run.
 
     **Constraints & Risk:**
     :param max_long_positions: Max number of simultaneous long positions.
@@ -221,6 +224,7 @@ class StrategyConfig:
 
     # Other
     exit_on_last_bar: bool = True
+    indicator_mode: str = "precompute"
 
     # Risk Config
     risk: Optional[RiskConfig] = None

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -169,6 +169,7 @@ class StrategyRuntimeConfig:
     portfolio_update_eps: float = 0.0
     error_mode: Literal["raise", "continue", "legacy"] = "raise"
     re_raise_on_error: bool = True
+    indicator_mode: Literal["incremental", "precompute"] = "precompute"
 
     def __post_init__(self) -> None:
         """校验并标准化配置."""
@@ -179,6 +180,10 @@ class StrategyRuntimeConfig:
         if mode not in {"raise", "continue", "legacy"}:
             raise ValueError("error_mode must be one of: raise, continue, legacy")
         self.error_mode = cast(Literal["raise", "continue", "legacy"], mode)
+        indicator_mode = str(self.indicator_mode).strip().lower()
+        if indicator_mode not in {"incremental", "precompute"}:
+            raise ValueError("indicator_mode must be one of: incremental, precompute")
+        self.indicator_mode = cast(Literal["incremental", "precompute"], indicator_mode)
         self.enable_precise_day_boundary_hooks = bool(
             self.enable_precise_day_boundary_hooks
         )
@@ -201,7 +206,8 @@ class Strategy:
     # Rust maintains HistoryBuffer for indicator calculation.
     # Python side accesses it via self.ctx.history() (efficient copy).
     # No duplicate storage in Python.
-    _indicators: List["Indicator"]
+    _precomputed_indicators: List["Indicator"]
+    _incremental_indicators: Dict[str, Dict[str, Any]]
     _subscriptions: List[str]
     _last_prices: Dict[str, float]
     _rolling_train_window: int
@@ -252,7 +258,8 @@ class Strategy:
         instance.sizer = FixedSize(100)
         instance.current_bar = None
         instance.current_tick = None
-        instance._indicators = []
+        instance._precomputed_indicators = []
+        instance._incremental_indicators = {}
         instance._subscriptions = []
         instance._last_prices = {}
         instance._known_orders = {}
@@ -268,6 +275,7 @@ class Strategy:
         class_portfolio_eps = cls.__dict__.get("portfolio_update_eps", 0.0)
         class_error_mode = cls.__dict__.get("error_mode", "raise")
         class_re_raise = cls.__dict__.get("re_raise_on_error", True)
+        class_indicator_mode = cls.__dict__.get("indicator_mode", "precompute")
         if isinstance(raw_runtime_config, dict):
             instance.runtime_config = StrategyRuntimeConfig(**raw_runtime_config)
         elif isinstance(raw_runtime_config, StrategyRuntimeConfig):
@@ -276,6 +284,7 @@ class Strategy:
                 portfolio_update_eps=raw_runtime_config.portfolio_update_eps,
                 error_mode=raw_runtime_config.error_mode,
                 re_raise_on_error=raw_runtime_config.re_raise_on_error,
+                indicator_mode=raw_runtime_config.indicator_mode,
             )
         else:
             instance.runtime_config = StrategyRuntimeConfig(
@@ -285,6 +294,9 @@ class Strategy:
                     Literal["raise", "continue", "legacy"], str(class_error_mode)
                 ),
                 re_raise_on_error=bool(class_re_raise),
+                indicator_mode=cast(
+                    Literal["incremental", "precompute"], str(class_indicator_mode)
+                ),
             )
         instance._last_event_type = ""
         instance._trading_days = []
@@ -386,6 +398,10 @@ class Strategy:
                     str(self.__dict__.pop("error_mode", "raise")),
                 ),
                 re_raise_on_error=bool(self.__dict__.pop("re_raise_on_error", True)),
+                indicator_mode=cast(
+                    Literal["incremental", "precompute"],
+                    str(self.__dict__.pop("indicator_mode", "precompute")),
+                ),
             )
         self.ctx = None
         self.current_bar = None
@@ -429,6 +445,7 @@ class Strategy:
                 portfolio_update_eps=value.portfolio_update_eps,
                 error_mode=value.error_mode,
                 re_raise_on_error=value.re_raise_on_error,
+                indicator_mode=value.indicator_mode,
             )
             return
         if isinstance(value, dict):
@@ -452,6 +469,7 @@ class Strategy:
             portfolio_update_eps=cfg.portfolio_update_eps,
             error_mode=cfg.error_mode,
             re_raise_on_error=cfg.re_raise_on_error,
+            indicator_mode=cfg.indicator_mode,
         )
 
     @property
@@ -468,6 +486,7 @@ class Strategy:
             portfolio_update_eps=float(value),
             error_mode=cfg.error_mode,
             re_raise_on_error=cfg.re_raise_on_error,
+            indicator_mode=cfg.indicator_mode,
         )
 
     @property
@@ -484,6 +503,7 @@ class Strategy:
             portfolio_update_eps=cfg.portfolio_update_eps,
             error_mode=cast(Literal["raise", "continue", "legacy"], value),
             re_raise_on_error=cfg.re_raise_on_error,
+            indicator_mode=cfg.indicator_mode,
         )
 
     @property
@@ -500,6 +520,23 @@ class Strategy:
             portfolio_update_eps=cfg.portfolio_update_eps,
             error_mode=cfg.error_mode,
             re_raise_on_error=bool(value),
+            indicator_mode=cfg.indicator_mode,
+        )
+
+    @property
+    def indicator_mode(self) -> Literal["incremental", "precompute"]:
+        """返回指标执行模式."""
+        return self.runtime_config.indicator_mode
+
+    @indicator_mode.setter
+    def indicator_mode(self, value: Literal["incremental", "precompute"]) -> None:
+        cfg = self.runtime_config
+        self.runtime_config = StrategyRuntimeConfig(
+            enable_precise_day_boundary_hooks=cfg.enable_precise_day_boundary_hooks,
+            portfolio_update_eps=cfg.portfolio_update_eps,
+            error_mode=cfg.error_mode,
+            re_raise_on_error=cfg.re_raise_on_error,
+            indicator_mode=value,
         )
 
     @property
@@ -527,7 +564,7 @@ class Strategy:
         pass
 
     def _on_start_internal(self) -> None:
-        """内部启动回调，用于自动发现指标等."""
+        """内部启动回调."""
         if self._start_initialized:
             return
 
@@ -536,20 +573,7 @@ class Strategy:
             self.on_resume()
 
         self.on_start()
-        self._discover_indicators()
         self._start_initialized = True
-
-    def _discover_indicators(self) -> None:
-        """自动发现并注册 self 属性中的指标."""
-        from .indicator import Indicator
-
-        # Scan instance attributes
-        for name, value in self.__dict__.items():
-            if isinstance(value, Indicator):
-                # Avoid duplicate registration
-                if value not in self._indicators:
-                    self.register_indicator(name, value)
-                    # print(f"Auto-registered indicator: {name}")
 
     def on_stop(self) -> None:
         """
@@ -761,7 +785,39 @@ class Strategy:
         This allows accessing the indicator via self.name and ensures it is
         calculated before the backtest starts.
         """
-        self._indicators.append(indicator)
+        self.register_precomputed_indicator(name, indicator)
+
+    def register_precomputed_indicator(self, name: str, indicator: "Indicator") -> None:
+        """注册预计算指标."""
+        if self.indicator_mode != "precompute":
+            raise ValueError(
+                "register_precomputed_indicator requires indicator_mode='precompute'"
+            )
+        if indicator not in self._precomputed_indicators:
+            self._precomputed_indicators.append(indicator)
+        setattr(self, name, indicator)
+
+    def register_incremental_indicator(
+        self,
+        name: str,
+        indicator: Any,
+        source: str = "close",
+        symbols: Optional[Union[str, List[str], Tuple[str, ...], set[str]]] = None,
+    ) -> None:
+        """注册增量指标."""
+        if self.indicator_mode != "incremental":
+            raise ValueError(
+                "register_incremental_indicator requires indicator_mode='incremental'"
+            )
+        source_key = str(source).strip().lower()
+        if source_key not in {"open", "high", "low", "close", "volume"}:
+            raise ValueError("source must be one of: open, high, low, close, volume")
+        symbol_filter = self._normalize_indicator_symbols(symbols)
+        self._incremental_indicators[name] = {
+            "indicator": indicator,
+            "source": source_key,
+            "symbols": symbol_filter,
+        }
         setattr(self, name, indicator)
 
     def subscribe(self, instrument_id: str) -> None:
@@ -774,14 +830,53 @@ class Strategy:
             self._subscriptions.append(instrument_id)
 
     def _prepare_indicators(self, data: Dict[str, pd.DataFrame]) -> None:
-        """Pre-calculate indicators."""
-        if not self._indicators:
+        """Pre-calculate indicators for precompute mode."""
+        if self.indicator_mode != "precompute":
+            return
+        if not self._precomputed_indicators:
             return
 
-        for ind in self._indicators:
+        for ind in self._precomputed_indicators:
             for sym, df in data.items():
                 # Calculate and cache inside indicator
                 ind(df, sym)
+
+    def _update_incremental_indicators(self, bar: Bar) -> None:
+        if self.indicator_mode != "incremental":
+            return
+        if not self._incremental_indicators:
+            return
+        for item in self._incremental_indicators.values():
+            symbol_filter = item["symbols"]
+            if symbol_filter is not None and bar.symbol not in symbol_filter:
+                continue
+            ind = item["indicator"]
+            source = item["source"]
+            value = getattr(bar, source)
+            ind.update(value)
+
+    def _normalize_indicator_symbols(
+        self,
+        symbols: Optional[Union[str, List[str], Tuple[str, ...], set[str]]],
+    ) -> Optional[set[str]]:
+        if symbols is None:
+            return None
+        if isinstance(symbols, str):
+            symbol_text = symbols.strip()
+            if not symbol_text:
+                raise ValueError("symbols cannot contain empty symbol")
+            return {symbol_text}
+        if isinstance(symbols, (list, tuple, set)):
+            normalized: set[str] = set()
+            for symbol in symbols:
+                symbol_text = str(symbol).strip()
+                if not symbol_text:
+                    raise ValueError("symbols cannot contain empty symbol")
+                normalized.add(symbol_text)
+            if not normalized:
+                raise ValueError("symbols cannot be empty")
+            return normalized
+        raise TypeError("symbols must be str, list[str], tuple[str, ...], set[str]")
 
     def on_order(self, order: Any) -> None:
         """

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -49,6 +49,8 @@ def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     previous_price = strategy._last_prices.get(bar.symbol)
     strategy.current_bar = bar
     strategy.current_tick = None
+    if hasattr(strategy, "_update_incremental_indicators"):
+        strategy._update_incremental_indicators(bar)
     strategy._last_prices[bar.symbol] = bar.close
     if current_pos != 0 and previous_price is not None and previous_price != bar.close:
         mark_portfolio_dirty(strategy)

--- a/tests/test_strategy_timers_indicators.py
+++ b/tests/test_strategy_timers_indicators.py
@@ -1,6 +1,8 @@
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pandas as pd
+import pytest
 from akquant.akquant import StrategyContext
 from akquant.indicator import Indicator
 from akquant.strategy import Strategy
@@ -21,9 +23,6 @@ class MyTimerStrategy(Strategy):
 
     def __init__(self) -> None:
         """Initialize."""
-        # Auto-discovery test
-        self.sma5 = SMA(5)
-        self.sma10 = SMA(10)
         self.timer_triggered = False
 
     def on_start(self) -> None:
@@ -109,22 +108,98 @@ def test_timer_registration() -> None:
     assert (daily_ts_2, "__daily__|14:55:00|daily_timer") in clean_call_args
 
 
-def test_indicator_autodiscovery() -> None:
-    """Test indicator autodiscovery."""
+def test_register_precomputed_indicator() -> None:
+    """Registers precomputed indicator under precompute mode."""
     strategy = MyTimerStrategy()
+    strategy.indicator_mode = "precompute"
+    indicator = SMA(5)
 
-    # Mock context to prevent RuntimeError in on_start
-    strategy.ctx = MagicMock(spec=StrategyContext)
+    strategy.register_precomputed_indicator("sma5", indicator)
 
-    # Simulate internal start sequence
-    strategy._on_start_internal()
+    assert getattr(strategy, "sma5") is indicator
+    assert indicator in strategy._precomputed_indicators
 
-    # Verify indicators are registered
-    assert len(strategy._indicators) == 2
-    assert strategy.sma5 in strategy._indicators
-    assert strategy.sma10 in strategy._indicators
 
-    # Verify names
-    names = [ind.name for ind in strategy._indicators]
-    assert "sma5" in names
-    assert "sma10" in names
+def test_register_incremental_indicator_requires_incremental_mode() -> None:
+    """Rejects incremental registration when mode is precompute."""
+    strategy = MyTimerStrategy()
+    strategy.indicator_mode = "precompute"
+
+    with pytest.raises(ValueError, match="indicator_mode='incremental'"):
+        strategy.register_incremental_indicator("sma5", MagicMock())
+
+
+def test_register_precomputed_indicator_requires_precompute_mode() -> None:
+    """Rejects precomputed registration when mode is incremental."""
+    strategy = MyTimerStrategy()
+    strategy.indicator_mode = "incremental"
+
+    with pytest.raises(ValueError, match="indicator_mode='precompute'"):
+        strategy.register_precomputed_indicator("sma5", SMA(5))
+
+
+def test_incremental_indicator_updates_from_bar_close() -> None:
+    """Updates incremental indicator from close price source."""
+
+    class IncrementalIndicator:
+        def __init__(self) -> None:
+            self.values: list[float] = []
+
+        def update(self, value: float) -> None:
+            self.values.append(value)
+
+    class FakeBar:
+        def __init__(self, close: float) -> None:
+            self.open = 0.0
+            self.high = 0.0
+            self.low = 0.0
+            self.close = close
+            self.volume = 0.0
+
+    strategy = MyTimerStrategy()
+    strategy.indicator_mode = "incremental"
+    indicator = IncrementalIndicator()
+    strategy.register_incremental_indicator("inc_sma", indicator, source="close")
+
+    strategy._update_incremental_indicators(FakeBar(close=12.5))  # type: ignore[arg-type]
+
+    assert indicator.values == [12.5]
+
+
+def test_incremental_indicator_symbol_filter() -> None:
+    """Updates only when bar symbol is in configured filter."""
+
+    class IncrementalIndicator:
+        def __init__(self) -> None:
+            self.values: list[float] = []
+
+        def update(self, value: float) -> None:
+            self.values.append(value)
+
+    class FakeBar:
+        def __init__(self, symbol: str, close: float) -> None:
+            self.symbol = symbol
+            self.open = 0.0
+            self.high = 0.0
+            self.low = 0.0
+            self.close = close
+            self.volume = 0.0
+
+    strategy = MyTimerStrategy()
+    strategy.indicator_mode = "incremental"
+    indicator = IncrementalIndicator()
+    strategy.register_incremental_indicator(
+        "inc_sma",
+        indicator,
+        source="close",
+        symbols=["000001.SZ_1D"],
+    )
+
+    strategy._update_incremental_indicators(
+        cast(Any, FakeBar(symbol="000001.SZ", close=12.5))
+    )
+    strategy._update_incremental_indicators(
+        cast(Any, FakeBar(symbol="000001.SZ_1D", close=13.0))
+    )
+
+    assert indicator.values == [13.0]


### PR DESCRIPTION
重构指标系统以支持“预计算”和“增量”两种模式。移除自动发现机制，要求策略显式设置 `indicator_mode` 并使用对应的注册方法：
- `indicator_mode="precompute"` 配合 `register_precomputed_indicator`
- `indicator_mode="incremental"` 配合 `register_incremental_indicator`

在增量模式下，指标通过 `_update_incremental_indicators` 在每个bar事件中更新，提高了实时策略的性能和灵活性。更新了示例代码、文档和测试以反映新的API，并确保向后兼容性。