### PR TITLE
docs: 更新示例文档与脚本以反映TopN动态权重调仓

### DIFF
--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -5,7 +5,7 @@
 *   [Examples Directory Index](https://github.com/akfamily/akquant/blob/main/examples/README.md): Quick entry to all scripts under `examples/`, including scenario-based shortest run paths.
 *   [Quick Start](../start/quickstart.md): Complete workflow covering manual data backtesting and AKShare data backtesting.
 *   [Simple SMA Strategy](strategy.md#class-based): Demonstrates how to write a strategy in class style and perform simple trading logic in `on_bar`.
-*   [Shortest Path for Multi-Asset Target Weights](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): Focuses on `order_target_weights` and demonstrates one-shot portfolio rebalance after collecting a full timestamp bucket.
+*   [Shortest Path for Multi-Asset Target Weights](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): TopN dynamic rebalance example using momentum ranking and one-shot portfolio adjustment.
 
 > Data Source Convention: Unless otherwise specified (e.g. simulated data), examples on this page default to using AKShare to fetch real market data.
 
@@ -339,5 +339,5 @@ The `examples/` directory contains more scripts demonstrating AKShare integratio
     *   Prints `bundle.metadata` to confirm the custom broker is resolved by factory.
 
 *   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
-    *   Demonstrates a minimal runnable `order_target_weights` flow: rebalance once after collecting all symbols for the same timestamp bucket.
-    *   Shows practical usage of `liquidate_unmentioned` and `rebalance_tolerance`, then prints `final_positions` / `final_equity`.
+    *   Demonstrates TopN dynamic weights: rank symbols by momentum, select winners, then rebalance with `order_target_weights`.
+    *   Shows practical usage of `liquidate_unmentioned` and `rebalance_tolerance`, then prints `selected_history` / `final_positions` / `final_equity`.

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -5,7 +5,7 @@
 *   [Examples 目录索引](https://github.com/akfamily/akquant/blob/main/examples/README.md): 快速浏览 `examples/` 下所有脚本入口，并包含按场景整理的最短执行路径。
 *   [快速开始 (Quickstart)](../start/quickstart.md): 包含手动数据回测和 AKShare 数据回测的完整流程。
 *   [简单的均线策略 (SMA Strategy)](strategy.md#class-based): 展示了如何使用类风格编写策略，并在 `on_bar` 中进行简单的交易逻辑。
-*   [多标的目标权重调仓最短路径](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): 聚焦 `order_target_weights`，展示同时间切片收齐后的一次性组合调仓。
+*   [多标的目标权重调仓最短路径](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): TopN 动态调仓示例，展示同时间切片收齐后基于动量的组合再平衡。
 
 > 数据源约定：除特别标注需要模拟数据外，本页示例默认使用 AKShare 获取真实市场数据。
 
@@ -339,5 +339,5 @@ class AdjSignal(Strategy):
     *   输出 `bundle.metadata` 以确认自定义 broker 已被工厂解析。
 
 *   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
-    *   演示 `order_target_weights` 的最小可运行闭环：收齐同一时间切片的多标的 Bar 后一次性按权重调仓。
-    *   展示 `liquidate_unmentioned` 与 `rebalance_tolerance` 的组合用法，并输出 `final_positions` / `final_equity`。
+    *   演示 TopN 动态权重调仓：先按动量打分选强势标的，再通过 `order_target_weights` 一次性完成组合再平衡。
+    *   展示 `liquidate_unmentioned` 与 `rebalance_tolerance` 的组合用法，并输出 `selected_history` / `final_positions` / `final_equity`。

--- a/examples/43_target_weights_rebalance.py
+++ b/examples/43_target_weights_rebalance.py
@@ -41,40 +41,61 @@ def make_data() -> dict[str, pd.DataFrame]:
 
 
 class TargetWeightsRebalanceStrategy(Strategy):
-    """Minimal target-weights rebalance demo."""
+    """TopN 动态权重调仓示例策略."""
 
     def __init__(self, symbols: list[str]) -> None:
-        """Initialize timestamp bucket and rebalance state."""
+        """初始化横截面计算所需状态."""
         super().__init__()
         self.symbols = symbols
         self.pending: dict[int, set[str]] = defaultdict(set)
-        self.rebalance_count = 0
+        self.lookback = 3
+        self.top_n = 2
+        self.target_total_weight = 0.9
+        self.selected_history: list[tuple[int, list[str], dict[str, float]]] = []
 
     def on_bar(self, bar: Bar) -> None:
-        """Run rebalance once per complete timestamp."""
+        """收齐同一时间切片后，按动量选 TopN 并调仓."""
+        # on_bar 会按 symbol 逐个触发，这里先缓存，确保每个时间点只调仓一次
         bucket = self.pending[bar.timestamp]
         bucket.add(bar.symbol)
         if len(bucket) < len(self.symbols):
             return
         self.pending.pop(bar.timestamp, None)
 
-        if self.rebalance_count == 0:
-            weights = {"AAA": 0.6, "BBB": 0.3}
-        elif self.rebalance_count == 1:
-            weights = {"AAA": 0.2, "BBB": 0.6, "CCC": 0.1}
-        else:
-            weights = {"BBB": 0.7}
+        # 1) 计算每个标的的简单动量：最新收盘 / 窗口首收盘 - 1
+        scores: dict[str, float] = {}
+        for symbol in self.symbols:
+            closes = self.get_history(count=self.lookback, symbol=symbol, field="close")
+            if len(closes) < self.lookback:
+                return
+            first_close = float(closes[0])
+            last_close = float(closes[-1])
+            if first_close <= 0:
+                return
+            scores[symbol] = last_close / first_close - 1.0
 
+        # 2) 选出 TopN 强势标的
+        ranked = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        selected = [symbol for symbol, _ in ranked[: self.top_n]]
+        if not selected:
+            return
+
+        # 3) 生成目标权重：TopN 等权，总仓位上限由 target_total_weight 控制
+        each_weight = self.target_total_weight / float(len(selected))
+        target_weights = {symbol: each_weight for symbol in selected}
+
+        # 4) 一次调用完成组合调仓
+        #    liquidate_unmentioned=True 会把不在 target_weights 的持仓清到 0
         self.order_target_weights(
-            target_weights=weights,
+            target_weights=target_weights,
             liquidate_unmentioned=True,
             rebalance_tolerance=0.01,
         )
-        self.rebalance_count += 1
+        self.selected_history.append((bar.timestamp, selected, target_weights))
 
 
 def main() -> None:
-    """Run demo and print key outputs."""
+    """运行示例并打印调仓轨迹与最终状态."""
     symbols = ["AAA", "BBB", "CCC"]
     result = aq.run_backtest(
         data=make_data(),
@@ -88,8 +109,17 @@ def main() -> None:
         min_commission=0.0,
         lot_size=1,
         execution_mode="current_close",
+        # get_history 依赖历史缓存深度，这里设置为 lookback 对应长度
+        history_depth=3,
         show_progress=False,
     )
+
+    strategy = result.strategy
+    if strategy is not None:
+        print("selected_history")
+        for ts, selected, weights in strategy.selected_history:
+            local_ts = pd.Timestamp(ts, tz="UTC").tz_convert("Asia/Shanghai")
+            print(f"{local_ts} selected={selected} weights={weights}")
 
     print("final_positions")
     print(result.positions.iloc[-1])

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,7 +44,7 @@
 - [40_functional_multi_slot_risk_demo.py](./40_functional_multi_slot_risk_demo.py): 函数式 + 多策略 slot + 风控限制端到端示例。
 - [41_live_multi_slot_orchestration_demo.py](./41_live_multi_slot_orchestration_demo.py): LiveRunner 多策略 slot 编排示例（paper）。
 - [42_live_broker_event_audit_demo.py](./42_live_broker_event_audit_demo.py): broker 事件审计与 owner_strategy_id 追踪示例。
-- [43_target_weights_rebalance.py](./43_target_weights_rebalance.py): 多标的 `order_target_weights` 目标权重调仓示例。
+- [43_target_weights_rebalance.py](./43_target_weights_rebalance.py): TopN 动态权重调仓示例（横截面动量 + `order_target_weights`）。
 
 ## 流式回测与实时报告
 


### PR DESCRIPTION
更新示例43的描述，从简单的多标的目标权重演示，改为更贴合实际策略的TopN动态权重调仓（横截面动量）。 同步修改了中文、英文文档以及脚本内的注释和实现，使其逻辑更清晰，并添加了选股历史输出。