### PR TITLE
feat(strategy-loader): 添加动态策略加载支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.64"
+version = "0.1.65"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.64"
+version = "0.1.65"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@
 
 👉 **[阅读完整文档](https://akquant.akfamily.xyz/)** | **[English Documentation](https://akquant.akfamily.xyz/en/)**
 
+## 快速导航
+
+*   动态策略加载（明文 / 加密）：[examples/44_strategy_source_loader_demo.py](examples/44_strategy_source_loader_demo.py)
+*   教材章节（动态策略加载）：[examples/textbook/ch15_strategy_loader.py](examples/textbook/ch15_strategy_loader.py)
+*   运行时配置与加载器说明（中文）：[docs/zh/advanced/runtime_config.md](docs/zh/advanced/runtime_config.md#9-动态策略加载strategysource--strategyloader)
+*   Runtime config and loader guide (English): [docs/en/advanced/runtime_config.md](docs/en/advanced/runtime_config.md#9-dynamic-strategy-loading-strategy_source--strategy_loader)
+
 ## 安装说明
 
 **AKQuant** 已发布至 PyPI，无需安装 Rust 环境即可直接使用。

--- a/docs/en/advanced/runtime_config.md
+++ b/docs/en/advanced/runtime_config.md
@@ -88,6 +88,7 @@ See also: [Warm Start Guide](warm_start.md).
 See runnable demo:
 
 - [22_strategy_runtime_config_demo.py](file:///c:/Users/albert/Documents/trae_projects/akquant/examples/22_strategy_runtime_config_demo.py)
+- [44_strategy_source_loader_demo.py](file:///c:/Users/albert/Documents/trae_projects/akquant/examples/44_strategy_source_loader_demo.py)
 
 Expected output markers:
 
@@ -104,3 +105,49 @@ Expected output markers:
 | Runtime config passed but strategy behavior unchanged | `runtime_config_override=False` is enabled | Set `runtime_config_override=True` or remove the flag |
 | Conflict warning appears only once | Warning dedup is per strategy instance and conflict payload | This is expected; create a new strategy instance if you need repeated warning output |
 | Warm-start resume still raises callback exceptions | Restored strategy config remains active and override not applied | Pass `strategy_runtime_config={"error_mode": "continue"}` with `runtime_config_override=True` |
+
+## 9. Dynamic Strategy Loading (`strategy_source` / `strategy_loader`)
+
+`run_backtest(...)` supports loading strategy implementation dynamically at call time:
+
+- `strategy_source`: strategy input, supports file path (`str` / `PathLike`) or `bytes`
+- `strategy_loader`: loader name, defaults to `python_plain`
+- `strategy_loader_options`: loader options dict
+
+Built-in loaders:
+
+- `python_plain`: load strategy from a local Python source file
+- `encrypted_external`: delegate decryption and loading to external callback
+
+### 9.1 `python_plain` example
+
+```python
+result = run_backtest(
+    data=data,
+    strategy=None,
+    strategy_source="my_strategy.py",
+    strategy_loader="python_plain",
+    strategy_loader_options={"strategy_attr": "MyStrategy"},
+)
+```
+
+### 9.2 `encrypted_external` example
+
+```python
+def decrypt_and_load(source, options):
+    ...
+    return MyStrategy
+
+result = run_backtest(
+    data=data,
+    strategy=None,
+    strategy_source=b"...encrypted-bytes...",
+    strategy_loader="encrypted_external",
+    strategy_loader_options={"decrypt_and_load": decrypt_and_load},
+)
+```
+
+### 9.3 Relation to `run_warm_start`
+
+`run_warm_start(...)` currently restores strategy instance from checkpoint and does not
+reload strategy implementation via `strategy_source` / `strategy_loader`.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -218,6 +218,9 @@ For more examples, please refer to the `examples/` directory.
 *   Phase-5 migration FAQ (quickstart): [Phase-5 Migration FAQ](start/quickstart.md#phase-5-migration-faq)
 *   Full compatibility notes (API reference): [Compatibility & Migration Notes](reference/api.md#compatibility--migration-notes)
 *   Multi-strategy migration checklist (advanced): [Multi-Strategy Migration Guide](advanced/multi_strategy_migration.md)
+*   Dynamic strategy loading guide (advanced): [Runtime Config Guide](advanced/runtime_config.md#9-dynamic-strategy-loading-strategy_source--strategy_loader)
+*   Dynamic strategy loading example (examples): [44_strategy_source_loader_demo.py](../../examples/44_strategy_source_loader_demo.py)
+*   Dynamic strategy loading textbook chapter (examples/textbook): [ch15_strategy_loader.py](../../examples/textbook/ch15_strategy_loader.py)
 *   Warm-start state persistence and resume: [Warm Start Guide](advanced/warm_start.md)
 
 ## Strategy Playbook Entry

--- a/docs/zh/advanced/runtime_config.md
+++ b/docs/zh/advanced/runtime_config.md
@@ -86,6 +86,7 @@ result = run_warm_start(
 可直接运行：
 
 - [22_strategy_runtime_config_demo.py](file:///c:/Users/albert/Documents/trae_projects/akquant/examples/22_strategy_runtime_config_demo.py)
+- [44_strategy_source_loader_demo.py](file:///c:/Users/albert/Documents/trae_projects/akquant/examples/44_strategy_source_loader_demo.py)
 
 另见：[热启动指南](warm_start.md)。
 
@@ -104,3 +105,49 @@ result = run_warm_start(
 | 传了 runtime 配置但策略行为没变化 | 启用了 `runtime_config_override=False` | 改为 `runtime_config_override=True` 或移除该参数 |
 | 冲突告警只出现一次 | 告警按“同一策略实例 + 同一冲突内容”去重 | 这是预期行为；如需重复观察可新建策略实例 |
 | 热启动后仍抛出回调异常 | 恢复后的策略配置生效，外部覆盖未应用 | 传入 `strategy_runtime_config={"error_mode": "continue"}` 且确保 `runtime_config_override=True` |
+
+## 9. 动态策略加载（strategy_source / strategy_loader）
+
+`run_backtest(...)` 支持在调用时通过策略源码动态加载策略：
+
+- `strategy_source`：策略输入，支持文件路径（`str` / `PathLike`）或 `bytes`
+- `strategy_loader`：加载器名称，默认 `python_plain`
+- `strategy_loader_options`：加载器参数字典
+
+默认加载器：
+
+- `python_plain`：从本地 Python 文件加载策略
+- `encrypted_external`：通过外部回调解密并返回策略对象
+
+### 9.1 python_plain 示例
+
+```python
+result = run_backtest(
+    data=data,
+    strategy=None,
+    strategy_source="my_strategy.py",
+    strategy_loader="python_plain",
+    strategy_loader_options={"strategy_attr": "MyStrategy"},
+)
+```
+
+### 9.2 encrypted_external 示例
+
+```python
+def decrypt_and_load(source, options):
+    ...
+    return MyStrategy
+
+result = run_backtest(
+    data=data,
+    strategy=None,
+    strategy_source=b"...encrypted-bytes...",
+    strategy_loader="encrypted_external",
+    strategy_loader_options={"decrypt_and_load": decrypt_and_load},
+)
+```
+
+### 9.3 与 run_warm_start 的关系
+
+`run_warm_start(...)` 当前从 checkpoint 恢复策略实例，不会通过
+`strategy_source` / `strategy_loader` 重新加载策略实现。

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -157,6 +157,9 @@ run_backtest(strategy=MyStrategy, data=df, symbol="600000")
 *   快速查看迁移 FAQ（快速开始）：[快速开始中的阶段 5 迁移 FAQ](start/quickstart.md#阶段-5-迁移-faq)
 *   查看完整兼容说明（API 参考）：[API 兼容与迁移说明](reference/api.md#兼容与迁移说明)
 *   多策略迁移清单（进阶专题）：[多策略迁移指南](advanced/multi_strategy_migration.md)
+*   动态策略加载说明（进阶专题）：[运行时配置指南](advanced/runtime_config.md#9-动态策略加载strategysource--strategyloader)
+*   动态策略加载示例（examples）：[44_strategy_source_loader_demo.py](../../examples/44_strategy_source_loader_demo.py)
+*   动态策略加载教材章节（examples/textbook）：[ch15_strategy_loader.py](../../examples/textbook/ch15_strategy_loader.py)
 
 ## 策略实战入口
 

--- a/examples/44_strategy_source_loader_demo.py
+++ b/examples/44_strategy_source_loader_demo.py
@@ -1,0 +1,109 @@
+"""Dynamic strategy loading demo for strategy_source and strategy_loader."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import akquant as aq
+from akquant import Bar, Strategy
+
+
+def make_bars(symbol: str, count: int) -> list[Bar]:
+    """Build deterministic bars for demo."""
+    start = datetime(2024, 1, 1, 9, 30, tzinfo=timezone.utc)
+    bars: list[Bar] = []
+    for i in range(count):
+        dt = start + timedelta(minutes=i)
+        ts_ns = int(dt.timestamp() * 1_000_000_000)
+        price = 100.0 + float(i)
+        bars.append(
+            Bar(
+                timestamp=ts_ns,
+                open=price,
+                high=price + 1.0,
+                low=price - 1.0,
+                close=price + 0.5,
+                volume=1000.0 + float(i),
+                symbol=symbol,
+            )
+        )
+    return bars
+
+
+def run_python_plain_scenario() -> None:
+    """Load strategy from plain python source file."""
+    bars = make_bars(symbol="PLAIN_DEMO", count=3)
+    with TemporaryDirectory() as tmp_dir:
+        strategy_path = Path(tmp_dir) / "plain_strategy.py"
+        strategy_path.write_text(
+            "\n".join(
+                [
+                    "from akquant.strategy import Strategy",
+                    "",
+                    "class DemoPlainStrategy(Strategy):",
+                    "    def __init__(self):",
+                    "        self.calls = 0",
+                    "",
+                    "    def on_bar(self, bar):",
+                    "        self.calls += 1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        result = aq.run_backtest(
+            data=bars,
+            strategy=None,
+            strategy_source=str(strategy_path),
+            strategy_loader="python_plain",
+            strategy_loader_options={"strategy_attr": "DemoPlainStrategy"},
+            symbol="PLAIN_DEMO",
+            show_progress=False,
+        )
+    strategy = result.strategy
+    calls = getattr(strategy, "calls", -1) if strategy is not None else -1
+    print(f"plain_loader_calls={calls}")
+
+
+def run_encrypted_external_scenario() -> None:
+    """Load strategy via encrypted_external callback hook."""
+    bars = make_bars(symbol="ENC_DEMO", count=2)
+
+    class DecryptedStrategy(Strategy):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            _ = bar
+            self.calls += 1
+
+    def decrypt_and_load(source: Any, options: dict[str, Any]) -> type[Strategy]:
+        _ = source
+        _ = options
+        return DecryptedStrategy
+
+    result = aq.run_backtest(
+        data=bars,
+        strategy=None,
+        strategy_source=b"encrypted_payload",
+        strategy_loader="encrypted_external",
+        strategy_loader_options={"decrypt_and_load": decrypt_and_load},
+        symbol="ENC_DEMO",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    calls = getattr(strategy, "calls", -1) if strategy is not None else -1
+    print(f"encrypted_loader_calls={calls}")
+
+
+def main() -> None:
+    """Run all dynamic loading scenarios."""
+    run_python_plain_scenario()
+    run_encrypted_external_scenario()
+    print("done_strategy_source_loader_demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,7 @@
 - [41_live_multi_slot_orchestration_demo.py](./41_live_multi_slot_orchestration_demo.py): LiveRunner 多策略 slot 编排示例（paper）。
 - [42_live_broker_event_audit_demo.py](./42_live_broker_event_audit_demo.py): broker 事件审计与 owner_strategy_id 追踪示例。
 - [43_target_weights_rebalance.py](./43_target_weights_rebalance.py): TopN 动态权重调仓示例（横截面动量 + `order_target_weights`）。
+- [44_strategy_source_loader_demo.py](./44_strategy_source_loader_demo.py): strategy_source + strategy_loader 动态加载示例（明文 + 外部解密）。
 
 ## 流式回测与实时报告
 
@@ -66,4 +67,4 @@
 ## 相关子目录
 
 - [strategies/README.md](./strategies/README.md): 策略示例集合。
-- `textbook/`: 教程章节示例脚本。
+- [textbook/ch15_strategy_loader.py](./textbook/ch15_strategy_loader.py): 教程章节动态策略加载示例。

--- a/examples/textbook/ch15_strategy_loader.py
+++ b/examples/textbook/ch15_strategy_loader.py
@@ -1,0 +1,114 @@
+"""
+第 15 章：动态策略加载（Strategy Loader）.
+
+本章演示如何在不直接导入策略类的情况下，通过 strategy_source + strategy_loader
+在运行时加载策略实现。
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+import akquant as aq
+from akquant import Bar, Strategy
+
+
+def make_bars(symbol: str, count: int) -> list[Bar]:
+    """构造示例 K 线."""
+    start = datetime(2024, 1, 2, 9, 30, tzinfo=timezone.utc)
+    bars: list[Bar] = []
+    for i in range(count):
+        dt = start + timedelta(minutes=i)
+        ts_ns = int(dt.timestamp() * 1_000_000_000)
+        price = 50.0 + float(i)
+        bars.append(
+            Bar(
+                timestamp=ts_ns,
+                open=price,
+                high=price + 0.8,
+                low=price - 0.8,
+                close=price + 0.3,
+                volume=2000.0 + float(i),
+                symbol=symbol,
+            )
+        )
+    return bars
+
+
+def chapter_plain_loader() -> None:
+    """场景一：python_plain 从源码文件加载策略类."""
+    bars = make_bars("CH15_PLAIN", 3)
+    with TemporaryDirectory() as tmp_dir:
+        strategy_path = Path(tmp_dir) / "chapter_strategy.py"
+        strategy_path.write_text(
+            "\n".join(
+                [
+                    "from akquant.strategy import Strategy",
+                    "",
+                    "class ChapterPlainStrategy(Strategy):",
+                    "    def __init__(self):",
+                    "        self.calls = 0",
+                    "",
+                    "    def on_bar(self, bar):",
+                    "        self.calls += 1",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        result = aq.run_backtest(
+            data=bars,
+            strategy=None,
+            strategy_source=str(strategy_path),
+            strategy_loader="python_plain",
+            strategy_loader_options={"strategy_attr": "ChapterPlainStrategy"},
+            symbol="CH15_PLAIN",
+            show_progress=False,
+        )
+    strategy = result.strategy
+    calls = getattr(strategy, "calls", -1) if strategy is not None else -1
+    print(f"chapter15_plain_calls={calls}")
+
+
+def chapter_encrypted_loader() -> None:
+    """场景二：encrypted_external 通过外部回调加载策略类."""
+    bars = make_bars("CH15_ENC", 2)
+
+    class ChapterEncryptedStrategy(Strategy):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            _ = bar
+            self.calls += 1
+
+    def decrypt_and_load(source: Any, options: dict[str, Any]) -> type[Strategy]:
+        _ = source
+        _ = options
+        return ChapterEncryptedStrategy
+
+    result = aq.run_backtest(
+        data=bars,
+        strategy=None,
+        strategy_source=b"chapter15_encrypted_payload",
+        strategy_loader="encrypted_external",
+        strategy_loader_options={"decrypt_and_load": decrypt_and_load},
+        symbol="CH15_ENC",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    calls = getattr(strategy, "calls", -1) if strategy is not None else -1
+    print(f"chapter15_encrypted_calls={calls}")
+
+
+def main() -> None:
+    """运行第 15 章示例."""
+    chapter_plain_loader()
+    chapter_encrypted_loader()
+    print("done_ch15_strategy_loader")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.64"
+version = "0.1.65"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -37,6 +37,7 @@ from .optimize import OptimizationResult, run_grid_search, run_walk_forward
 from .plot import plot_result
 from .sizer import AllInSizer, FixedSize, PercentSizer, Sizer
 from .strategy import Strategy, StrategyRuntimeConfig
+from .strategy_loader import register_strategy_loader, resolve_strategy_input
 from .utils import fetch_akshare_symbol, load_bar_from_df, prepare_dataframe
 
 __doc__ = _akquant.__doc__
@@ -51,6 +52,8 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "AllInSizer",
         "Strategy",
         "StrategyRuntimeConfig",
+        "register_strategy_loader",
+        "resolve_strategy_input",
         "DataLoader",
         "DataFeedAdapter",
         "FeedSlice",
@@ -96,6 +99,8 @@ else:
         "AllInSizer",
         "Strategy",
         "StrategyRuntimeConfig",
+        "register_strategy_loader",
+        "resolve_strategy_input",
         "DataLoader",
         "DataFeedAdapter",
         "FeedSlice",

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -1,3 +1,4 @@
+import os
 from typing import Any, Callable, Dict, List, Literal, Optional, Type, TypedDict, Union
 
 import pandas as pd
@@ -38,6 +39,9 @@ class BacktestStreamEvent(TypedDict):
 def run_backtest(
     data: Optional[BacktestDataInput] = ...,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = ...,
+    strategy_source: Optional[Union[str, bytes, os.PathLike[str]]] = ...,
+    strategy_loader: Optional[str] = ...,
+    strategy_loader_options: Optional[Dict[str, Any]] = ...,
     symbol: Union[str, List[str]] = ...,
     initial_cash: Optional[float] = ...,
     commission_rate: Optional[float] = ...,

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -33,6 +33,7 @@ from ..feed_adapter import DataFeedAdapter, FeedSlice
 from ..log import get_logger, register_logger
 from ..risk import apply_risk_config
 from ..strategy import Strategy, StrategyRuntimeConfig
+from ..strategy_loader import resolve_strategy_input
 from ..utils import df_to_arrays, prepare_dataframe
 from ..utils.inspector import infer_warmup_period
 from .result import BacktestResult
@@ -344,6 +345,9 @@ def _coerce_analyzer_plugins(
 def run_backtest(
     data: Optional[BacktestDataInput] = None,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = None,
+    strategy_source: Optional[Union[str, bytes, os.PathLike[str]]] = None,
+    strategy_loader: Optional[str] = None,
+    strategy_loader_options: Optional[Dict[str, Any]] = None,
     symbol: Union[str, List[str]] = "BENCHMARK",
     initial_cash: Optional[float] = None,
     commission_rate: Optional[float] = None,
@@ -410,6 +414,13 @@ def run_backtest(
                         或 RiskConfig 对象。如果同时提供了 config.strategy_config.risk，
                         此参数将覆盖其中的同名字段。
     :param strategy: 策略类、策略实例或 on_bar 回调函数
+    :param strategy_source: 策略源码输入（路径字符串 / bytes / PathLike），
+                            当 strategy=None 时用于动态加载策略
+    :param strategy_loader: 策略加载器名称，默认 "python_plain"，
+                            可选 "encrypted_external" 或用户注册加载器
+    :param strategy_loader_options: 传给策略加载器的参数字典（可选），
+                                    如 {"strategy_attr": "MyStrategy"} 或
+                                    {"decrypt_and_load": callable}
     :param symbol: 标的代码
     :param initial_cash: 初始资金 (默认 1,000,000.0)
     :param commission_rate: 佣金率 (默认 0.0)
@@ -560,6 +571,21 @@ def run_backtest(
             config_indicator_mode = getattr(strategy_config, "indicator_mode", None)
             if config_indicator_mode is not None:
                 strategy_runtime_config = {"indicator_mode": config_indicator_mode}
+        if strategy_source is None:
+            strategy_source = cast(
+                Optional[Union[str, bytes, os.PathLike[str]]],
+                getattr(strategy_config, "strategy_source", None),
+            )
+        if strategy_loader is None:
+            strategy_loader = cast(
+                Optional[str],
+                getattr(strategy_config, "strategy_loader", None),
+            )
+        if strategy_loader_options is None:
+            strategy_loader_options = cast(
+                Optional[Dict[str, Any]],
+                getattr(strategy_config, "strategy_loader_options", None),
+            )
     if strategies_by_slot is not None and not isinstance(strategies_by_slot, dict):
         raise TypeError("strategies_by_slot must be a dict when provided")
     if strategy_max_order_value is not None and not isinstance(
@@ -767,8 +793,14 @@ def run_backtest(
         strategy_runtime_config = kwargs.pop("strategy_runtime_config")
 
     strategy_kwargs = dict(kwargs)
+    strategy_input = resolve_strategy_input(
+        strategy=strategy,
+        strategy_source=strategy_source,
+        strategy_loader=strategy_loader,
+        strategy_loader_options=strategy_loader_options,
+    )
     strategy_instance = _build_strategy_instance(
-        strategy,
+        strategy_input,
         strategy_kwargs,
         logger,
         initialize,
@@ -1815,6 +1847,11 @@ def run_warm_start(
 ) -> BacktestResult:
     """
     热启动回测 (Warm Start Backtest).
+
+    注意：当前 run_warm_start 的策略实例来自 checkpoint 恢复，
+    不会通过 strategy_source / strategy_loader 重新加载策略类。
+    如需替换策略实现，请优先使用 run_backtest 或在恢复后通过
+    strategies_by_slot 覆盖 slot 策略。
 
     故障速查可参考 docs/zh/advanced/runtime_config.md，
     英文文档参考 docs/en/advanced/runtime_config.md

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -232,6 +232,9 @@ class StrategyConfig:
     # Multi-Strategy Topology & Risk Controls
     strategy_id: Optional[str] = None
     strategies_by_slot: Optional[Dict[str, Any]] = None
+    strategy_source: Optional[str] = None
+    strategy_loader: Optional[str] = None
+    strategy_loader_options: Optional[Dict[str, Any]] = None
     strategy_max_order_value: Optional[Dict[str, float]] = None
     strategy_max_order_size: Optional[Dict[str, float]] = None
     strategy_max_position_size: Optional[Dict[str, float]] = None

--- a/python/akquant/live.py
+++ b/python/akquant/live.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
 from akquant import Bar, DataFeed, Engine, Instrument, Strategy
 from akquant.gateway.factory import create_gateway_bundle
 from akquant.gateway.models import UnifiedOrderRequest
+from akquant.strategy_loader import resolve_strategy_input
 
 
 class _StrategyCallbackFanout:
@@ -68,8 +69,13 @@ class LiveRunner:
 
     def __init__(
         self,
-        strategy_cls: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None]],
+        strategy_cls: Optional[
+            Union[Type[Strategy], Strategy, Callable[[Any, Bar], None]]
+        ],
         instruments: List[Instrument],
+        strategy_source: Optional[Union[str, bytes]] = None,
+        strategy_loader: Optional[str] = None,
+        strategy_loader_options: Optional[Dict[str, Any]] = None,
         strategy_id: Optional[str] = None,
         strategies_by_slot: Optional[
             Dict[str, Union[Type[Strategy], Strategy, Callable[[Any, Bar], None]]]
@@ -134,6 +140,9 @@ class LiveRunner:
         :param on_broker_event: Optional broker event observer callback.
         """
         self.strategy_cls = strategy_cls
+        self.strategy_source = strategy_source
+        self.strategy_loader = strategy_loader
+        self.strategy_loader_options = strategy_loader_options
         self.strategy_id = (strategy_id or "_default").strip() or "_default"
         self.strategies_by_slot = strategies_by_slot or {}
         self.instruments = instruments
@@ -284,16 +293,27 @@ class LiveRunner:
             self._print_summary()
 
     def _build_strategy_instance(self, strategy_input: Any) -> Strategy:
-        if isinstance(strategy_input, type) and issubclass(strategy_input, Strategy):
-            return cast(Strategy, strategy_input())
-        if isinstance(strategy_input, Strategy):
-            return strategy_input
-        if callable(strategy_input):
+        resolved_strategy_input = resolve_strategy_input(
+            strategy=cast(
+                Optional[Union[type[Strategy], Strategy, Callable[[Any, Bar], None]]],
+                strategy_input,
+            ),
+            strategy_source=getattr(self, "strategy_source", None),
+            strategy_loader=getattr(self, "strategy_loader", None),
+            strategy_loader_options=getattr(self, "strategy_loader_options", None),
+        )
+        if isinstance(resolved_strategy_input, type) and issubclass(
+            resolved_strategy_input, Strategy
+        ):
+            return cast(Strategy, resolved_strategy_input())
+        if isinstance(resolved_strategy_input, Strategy):
+            return resolved_strategy_input
+        if callable(resolved_strategy_input):
             from akquant.backtest import FunctionalStrategy
 
             return FunctionalStrategy(
                 initialize=self.initialize,
-                on_bar=cast(Callable[[Any, Bar], None], strategy_input),
+                on_bar=cast(Callable[[Any, Bar], None], resolved_strategy_input),
                 on_start=self.on_start,
                 on_stop=self.on_stop,
                 on_tick=self.on_tick,

--- a/python/akquant/strategy_loader.py
+++ b/python/akquant/strategy_loader.py
@@ -1,0 +1,134 @@
+import importlib.util
+import os
+import uuid
+from typing import Any, Callable, Dict, Optional, Union, cast
+
+from .akquant import Bar
+from .strategy import Strategy
+
+StrategyLike = Union[type[Strategy], Strategy, Callable[[Any, Bar], None]]
+StrategySource = Union[str, bytes, os.PathLike[str]]
+StrategyLoader = Callable[[StrategySource, Dict[str, Any]], StrategyLike]
+
+_LOADERS: Dict[str, StrategyLoader] = {}
+
+
+def _is_strategy_like(value: Any) -> bool:
+    if isinstance(value, type) and issubclass(value, Strategy):
+        return True
+    if isinstance(value, Strategy):
+        return True
+    if callable(value):
+        return True
+    return False
+
+
+def register_strategy_loader(name: str, loader: StrategyLoader) -> None:
+    """Register a strategy loader by name."""
+    normalized = str(name).strip()
+    if not normalized:
+        raise ValueError("strategy loader name cannot be empty")
+    if not callable(loader):
+        raise TypeError("strategy loader must be callable")
+    _LOADERS[normalized] = loader
+
+
+def get_strategy_loader(name: str) -> StrategyLoader:
+    """Resolve a registered strategy loader."""
+    normalized = str(name).strip()
+    if not normalized:
+        raise ValueError("strategy loader name cannot be empty")
+    if normalized not in _LOADERS:
+        raise ValueError(f"unknown strategy_loader: {normalized}")
+    return _LOADERS[normalized]
+
+
+def _load_python_plain(source: StrategySource, options: Dict[str, Any]) -> StrategyLike:
+    if isinstance(source, bytes):
+        raise TypeError("python_plain loader does not accept bytes source")
+    module_path = os.fspath(source)
+    module_name = f"akquant_user_strategy_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"failed to create module spec from: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    attr_name_raw = options.get("strategy_attr")
+    attr_name = str(attr_name_raw).strip() if attr_name_raw is not None else ""
+    if attr_name:
+        picked = getattr(module, attr_name, None)
+        if picked is not None:
+            if _is_strategy_like(picked):
+                return cast(StrategyLike, picked)
+            raise TypeError(f"module attr '{attr_name}' is not a valid strategy input")
+
+    candidates = [
+        obj
+        for obj in module.__dict__.values()
+        if isinstance(obj, type) and issubclass(obj, Strategy) and obj is not Strategy
+    ]
+    if len(candidates) == 1:
+        return cast(StrategyLike, candidates[0])
+    if not candidates:
+        raise ValueError(
+            "no Strategy subclass found in module; "
+            "provide strategy_attr in loader options"
+        )
+    raise ValueError(
+        "multiple Strategy subclasses found; provide strategy_attr in loader options"
+    )
+
+
+def _load_encrypted_external(
+    source: StrategySource, options: Dict[str, Any]
+) -> StrategyLike:
+    callback = options.get("decrypt_and_load")
+    if not callable(callback):
+        raise ValueError(
+            "encrypted_external loader requires callable option: decrypt_and_load"
+        )
+    loaded = callback(source, dict(options))
+    if not _is_strategy_like(loaded):
+        raise TypeError("decrypt_and_load must return Strategy type/instance/callable")
+    return cast(StrategyLike, loaded)
+
+
+def resolve_strategy_input(
+    strategy: Optional[StrategyLike] = None,
+    strategy_source: Optional[StrategySource] = None,
+    strategy_loader: Optional[str] = None,
+    strategy_loader_options: Optional[Dict[str, Any]] = None,
+) -> StrategyLike:
+    """Resolve strategy-like input from direct strategy or source + loader."""
+    if strategy is not None:
+        return strategy
+    if strategy_source is None:
+        raise ValueError("Strategy must be provided.")
+    if strategy_loader is not None and not isinstance(strategy_loader, str):
+        raise TypeError("strategy_loader must be str when provided")
+    if strategy_loader_options is not None and not isinstance(
+        strategy_loader_options, dict
+    ):
+        raise TypeError("strategy_loader_options must be dict when provided")
+    loader_name = strategy_loader.strip() if strategy_loader else "python_plain"
+    options: Dict[str, Any] = dict(strategy_loader_options or {})
+    loader = get_strategy_loader(loader_name)
+    loaded = loader(strategy_source, options)
+    if not _is_strategy_like(loaded):
+        raise TypeError("resolved strategy must be Strategy type/instance/callable")
+    return loaded
+
+
+register_strategy_loader("python_plain", _load_python_plain)
+register_strategy_loader("encrypted_external", _load_encrypted_external)
+
+
+__all__ = [
+    "StrategyLike",
+    "StrategySource",
+    "StrategyLoader",
+    "register_strategy_loader",
+    "get_strategy_loader",
+    "resolve_strategy_input",
+]

--- a/tests/test_live_runner_broker_bridge.py
+++ b/tests/test_live_runner_broker_bridge.py
@@ -1,7 +1,9 @@
 import time
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable, cast
 
+import pytest
 from akquant.live import LiveRunner
 from akquant.strategy import Strategy
 
@@ -546,6 +548,95 @@ def test_live_runner_builds_functional_strategy_instance() -> None:
     strategy.on_bar(cast(Any, SimpleNamespace(symbol="TEST")))
     strategy.on_stop()
     assert events == ["initialize", "on_start", "bar:7", "on_stop"]
+
+
+def test_live_runner_builds_strategy_instance_from_strategy_source(
+    tmp_path: Path,
+) -> None:
+    """Build strategy instance from configured strategy_source."""
+    strategy_file = tmp_path / "live_source_strategy.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.strategy_cls = None
+    runner.strategy_source = str(strategy_file)
+    runner.strategy_loader = "python_plain"
+    runner.strategy_loader_options = None
+    runner.initialize = None
+    runner.on_start = None
+    runner.on_stop = None
+    runner.on_tick = None
+    runner.on_order = None
+    runner.on_trade = None
+    runner.on_timer = None
+    runner.context = {}
+    strategy = runner._build_strategy_instance(runner.strategy_cls)
+
+    assert isinstance(strategy, Strategy)
+    assert type(strategy).__name__ == "Strategy"
+
+
+def test_live_runner_builds_strategy_from_encrypted_external_loader() -> None:
+    """Build strategy instance using encrypted_external loader callback."""
+
+    class _LoadedStrategy(Strategy):
+        def on_bar(self, bar: Any) -> None:
+            _ = bar
+
+    def _decrypt_loader(source: Any, options: dict[str, Any]) -> type[Strategy]:
+        _ = source
+        _ = options
+        return _LoadedStrategy
+
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.strategy_cls = None
+    runner.strategy_source = b"cipher"
+    runner.strategy_loader = "encrypted_external"
+    runner.strategy_loader_options = {"decrypt_and_load": _decrypt_loader}
+    runner.initialize = None
+    runner.on_start = None
+    runner.on_stop = None
+    runner.on_tick = None
+    runner.on_order = None
+    runner.on_trade = None
+    runner.on_timer = None
+    runner.context = {}
+    strategy = runner._build_strategy_instance(runner.strategy_cls)
+
+    assert isinstance(strategy, _LoadedStrategy)
+
+
+def test_live_runner_rejects_missing_strategy_and_source() -> None:
+    """Live runner should fail when both strategy and source are missing."""
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.strategy_cls = None
+    runner.strategy_source = None
+    runner.strategy_loader = None
+    runner.strategy_loader_options = None
+    runner.initialize = None
+    runner.on_start = None
+    runner.on_stop = None
+    runner.on_tick = None
+    runner.on_order = None
+    runner.on_trade = None
+    runner.on_timer = None
+    runner.context = {}
+    with pytest.raises(ValueError, match="Strategy must be provided"):
+        runner._build_strategy_instance(runner.strategy_cls)
 
 
 def test_live_runner_builds_strategy_topology_with_slots() -> None:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -9,6 +9,7 @@ import pytest
 from akquant import (
     BacktestConfig,
     StrategyConfig,
+    register_strategy_loader,
     run_backtest,
     run_warm_start,
     save_snapshot,
@@ -590,6 +591,331 @@ def _make_bars(
             )
         )
     return bars
+
+
+def test_run_backtest_accepts_strategy_source_python_plain(tmp_path: Path) -> None:
+    """run_backtest should load strategy class from python source file."""
+    strategy_file = tmp_path / "strategy_plain.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bars = _make_bars("2023-01-01", 3, symbol="PLAIN")
+    result = run_backtest(
+        data=bars,
+        strategy_source=str(strategy_file),
+        strategy_loader="python_plain",
+        symbol="PLAIN",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 3
+
+
+def test_run_backtest_accepts_strategy_source_encrypted_external(
+    tmp_path: Path,
+) -> None:
+    """run_backtest should load strategy via encrypted_external loader hook."""
+    bars = _make_bars("2023-01-01", 2, symbol="ENC")
+    strategy_file = tmp_path / "strategy_encrypted.mock"
+    strategy_file.write_bytes(b"cipher")
+
+    class EncryptedLoadedStrategy(Strategy):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            self.calls += 1
+
+    def _mock_decrypt_loader(source: Any, options: dict[str, Any]) -> type[Strategy]:
+        _ = source
+        _ = options
+        return EncryptedLoadedStrategy
+
+    result = run_backtest(
+        data=bars,
+        strategy_source=str(strategy_file),
+        strategy_loader="encrypted_external",
+        strategy_loader_options={"decrypt_and_load": _mock_decrypt_loader},
+        symbol="ENC",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 2
+
+
+def test_run_backtest_rejects_unknown_strategy_loader_name() -> None:
+    """Unknown strategy loader should fail fast."""
+    bars = _make_bars("2023-01-01", 1, symbol="BAD_LOADER")
+    with pytest.raises(ValueError, match="unknown strategy_loader"):
+        run_backtest(
+            data=bars,
+            strategy_source="missing.py",
+            strategy_loader="not_exist",
+            symbol="BAD_LOADER",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_rejects_invalid_strategy_loader_options_type() -> None:
+    """Invalid strategy_loader_options type should fail fast."""
+    bars = _make_bars("2023-01-01", 1, symbol="BAD_OPT")
+    with pytest.raises(TypeError, match="strategy_loader_options"):
+        run_backtest(
+            data=bars,
+            strategy_source="missing.py",
+            strategy_loader_options=cast(Any, "bad"),
+            symbol="BAD_OPT",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_rejects_invalid_strategy_loader_type() -> None:
+    """Invalid strategy_loader type should fail fast."""
+    bars = _make_bars("2023-01-01", 1, symbol="BAD_LOADER_TYPE")
+    with pytest.raises(TypeError, match="strategy_loader must be str"):
+        run_backtest(
+            data=bars,
+            strategy_source="missing.py",
+            strategy_loader=cast(Any, 123),
+            symbol="BAD_LOADER_TYPE",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_rejects_python_plain_with_bytes_source() -> None:
+    """python_plain loader should reject bytes source."""
+    bars = _make_bars("2023-01-01", 1, symbol="BAD_PLAIN_BYTES")
+    with pytest.raises(TypeError, match="python_plain loader"):
+        run_backtest(
+            data=bars,
+            strategy_source=b"cipher",
+            strategy_loader="python_plain",
+            symbol="BAD_PLAIN_BYTES",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_rejects_encrypted_loader_without_callback() -> None:
+    """encrypted_external loader should require decrypt callback."""
+    bars = _make_bars("2023-01-01", 1, symbol="BAD_ENC_OPT")
+    with pytest.raises(ValueError, match="decrypt_and_load"):
+        run_backtest(
+            data=bars,
+            strategy_source="encrypted.mock",
+            strategy_loader="encrypted_external",
+            symbol="BAD_ENC_OPT",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_python_plain_supports_strategy_attr_selection(
+    tmp_path: Path,
+) -> None:
+    """python_plain loader should support selecting strategy by strategy_attr."""
+    strategy_file = tmp_path / "strategy_multi.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Alpha(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 1",
+                "",
+                "class Beta(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 10",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bars = _make_bars("2023-01-01", 2, symbol="ATTR")
+    result = run_backtest(
+        data=bars,
+        strategy_source=str(strategy_file),
+        strategy_loader="python_plain",
+        strategy_loader_options={"strategy_attr": "Beta"},
+        symbol="ATTR",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 20
+
+
+def test_run_backtest_rejects_python_plain_with_multiple_classes_without_attr(
+    tmp_path: Path,
+) -> None:
+    """python_plain loader should fail on multiple Strategy subclasses without hint."""
+    strategy_file = tmp_path / "strategy_multi_no_attr.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Alpha(Strategy):",
+                "    def on_bar(self, bar):",
+                "        _ = bar",
+                "",
+                "class Beta(Strategy):",
+                "    def on_bar(self, bar):",
+                "        _ = bar",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bars = _make_bars("2023-01-01", 1, symbol="MULTI")
+    with pytest.raises(ValueError, match="multiple Strategy subclasses found"):
+        run_backtest(
+            data=bars,
+            strategy_source=str(strategy_file),
+            strategy_loader="python_plain",
+            symbol="MULTI",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_rejects_missing_strategy_and_strategy_source() -> None:
+    """run_backtest should fail when neither strategy nor strategy_source is given."""
+    bars = _make_bars("2023-01-01", 1, symbol="NO_STRATEGY")
+    with pytest.raises(ValueError, match="Strategy must be provided"):
+        run_backtest(
+            data=bars,
+            strategy=None,
+            strategy_source=None,
+            symbol="NO_STRATEGY",
+            show_progress=False,
+        )
+
+
+def test_run_backtest_accepts_registered_custom_strategy_loader() -> None:
+    """Custom registered loader should be supported."""
+    bars = _make_bars("2023-01-01", 2, symbol="CUSTOM_LOADER")
+
+    class CustomLoadedStrategy(Strategy):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            self.calls += 1
+
+    loader_name = "test_custom_loader_for_source"
+
+    def _loader(source: Any, options: dict[str, Any]) -> type[Strategy]:
+        _ = source
+        _ = options
+        return CustomLoadedStrategy
+
+    register_strategy_loader(loader_name, _loader)
+    result = run_backtest(
+        data=bars,
+        strategy_source=b"mock",
+        strategy_loader=loader_name,
+        symbol="CUSTOM_LOADER",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 2
+
+
+def test_run_backtest_loads_strategy_source_from_config(tmp_path: Path) -> None:
+    """Backtest config should provide strategy_source and loader settings."""
+    strategy_file = tmp_path / "strategy_from_config.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bars = _make_bars("2023-01-01", 2, symbol="CFG")
+    cfg = BacktestConfig(
+        strategy_config=StrategyConfig(
+            strategy_source=str(strategy_file),
+            strategy_loader="python_plain",
+        ),
+        show_progress=False,
+    )
+    result = run_backtest(
+        data=bars,
+        strategy=None,
+        symbol="CFG",
+        config=cfg,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 2
+
+
+def test_run_backtest_prefers_explicit_strategy_over_strategy_source(
+    tmp_path: Path,
+) -> None:
+    """Explicit strategy argument should win over strategy_source settings."""
+    strategy_file = tmp_path / "ignored_source.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def __init__(self):",
+                "        self.calls = 0",
+                "",
+                "    def on_bar(self, bar):",
+                "        self.calls += 100",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    bars = _make_bars("2023-01-01", 2, symbol="PRIO")
+
+    class ExplicitPriorityStrategy(Strategy):
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            self.calls += 1
+
+    result = run_backtest(
+        data=bars,
+        strategy=ExplicitPriorityStrategy,
+        strategy_source=str(strategy_file),
+        strategy_loader="python_plain",
+        symbol="PRIO",
+        show_progress=False,
+    )
+    strategy = result.strategy
+    assert strategy is not None
+    assert getattr(strategy, "calls", 0) == 2
 
 
 def test_run_warm_start_end_to_end_lifecycle(tmp_path: Path) -> None:


### PR DESCRIPTION
引入 strategy_source、strategy_loader 和 strategy_loader_options 配置参数， 支持在运行时动态加载策略实现。提供 python_plain 和 encrypted_external 两种内置加载器，分别用于从本地源码文件和外部解密回调加载策略。

新增 resolve_strategy_input 函数统一处理策略输入解析，并在 run_backtest 和 LiveRunner 中集成动态加载功能。同时更新相关文档和添加示例代码。