### PR TITLE
feat(params): 引入策略参数模型与适配层以支持页面化配置

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,4 +23,4 @@ repos:
         pass_filenames: false
         args: ["--config-file=pyproject.toml", "."]
         additional_dependencies:
-          [types-pytz, pandas-stubs, numpy, pytest, polars, quantstats]
+          [types-pytz, pandas-stubs, numpy, pytest, polars, quantstats, pydantic]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.65"
+version = "0.1.66"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.65"
+version = "0.1.66"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -9,6 +9,133 @@
 
 > Data Source Convention: Unless otherwise specified (e.g. simulated data), examples on this page default to using AKShare to fetch real market data.
 
+### UI-Driven Strategy Parameterization (PARAM_MODEL)
+
+For UI/API integration scenarios, you can declare a strategy-side parameter model and keep optimization search space separate:
+
+```python
+from akquant import (
+    IntParam,
+    ParamModel,
+    Strategy,
+    get_strategy_param_schema,
+    validate_strategy_params,
+    run_grid_search,
+)
+
+
+class SmaParams(ParamModel):
+    fast_period: int = IntParam(10, ge=2, le=200)
+    slow_period: int = IntParam(30, ge=3, le=500)
+
+
+class SmaStrategy(Strategy):
+    PARAM_MODEL = SmaParams
+
+    def __init__(self, fast_period: int = 10, slow_period: int = 30):
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+
+schema = get_strategy_param_schema(SmaStrategy)
+validated = validate_strategy_params(
+    SmaStrategy,
+    {"fast_period": 12, "slow_period": 36},
+)
+
+results = run_grid_search(
+    strategy=SmaStrategy,
+    data=df,
+    param_grid={"fast_period": [5, 10, 15], "slow_period": [20, 30, 60]},
+)
+```
+
+### Parameter Routing Flow (frontend params -> backtest call)
+
+```mermaid
+flowchart TD
+    A[Frontend submits params<br/>for example fast_period/slow_period/date_range] --> B[validate_strategy_params]
+    B --> C[strategy_params<br/>injected into strategy.__init__]
+    A --> D[extract_runtime_kwargs]
+    D --> E[runtime_kwargs<br/>for example start_time/end_time]
+    C --> F[run_backtest]
+    E --> F
+```
+
+Notes:
+
+* `strategy_params` contains strategy construction parameters (strategy-logic related, such as MA periods).
+* `runtime_kwargs` contains runtime backtest parameters (execution-window related, such as `start_time` and `end_time`).
+* Current default mapping rule is `date_range -> start_time/end_time`.
+
+### API Integration Example (HTTP)
+
+1) Fetch schema (frontend uses it to render form fields):
+
+```http
+GET /api/strategies/sma_cross/schema
+```
+
+Example response:
+
+```json
+{
+  "title": "SMACrossParams",
+  "type": "object",
+  "properties": {
+    "fast_period": { "type": "integer", "default": 10, "minimum": 2, "maximum": 200 },
+    "slow_period": { "type": "integer", "default": 30, "minimum": 3, "maximum": 500 },
+    "date_range": {
+      "type": "object",
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}
+```
+
+2) Submit params and start backtest:
+
+```http
+POST /api/backtest
+Content-Type: application/json
+```
+
+```json
+{
+  "strategy_id": "sma_cross",
+  "params": {
+    "fast_period": 12,
+    "slow_period": 36,
+    "date_range": {
+      "start": "2023-01-01T00:00:00",
+      "end": "2023-12-31T00:00:00"
+    }
+  }
+}
+```
+
+Example response (showing parameter routing result):
+
+```json
+{
+  "strategy_params": {
+    "fast_period": 12,
+    "slow_period": 36,
+    "date_range": {
+      "start": "2023-01-01T00:00:00",
+      "end": "2023-12-31T00:00:00"
+    }
+  },
+  "runtime_kwargs": {
+    "start_time": "2023-01-01T00:00:00",
+    "end_time": "2023-12-31T00:00:00"
+  }
+}
+```
+
 ## 2. Advanced Examples
 
 *   **Zipline Style Strategy**: Demonstrates how to write strategies using functional API (`initialize`, `on_bar`), suitable for users migrating from Zipline.

--- a/docs/en/guide/optimization.md
+++ b/docs/en/guide/optimization.md
@@ -48,6 +48,54 @@ results = run_grid_search(
 print(results.head())
 ```
 
+### Parameter-Model-Driven Optimization (Recommended)
+
+When you need to expose strategy parameters in Web UI / API workflows, use a **`PARAM_MODEL + param_grid` dual-layer pattern**:
+
+1. `PARAM_MODEL` (from `akquant.params`) handles **single-run validation and schema export**.
+2. `param_grid` (native `run_grid_search` input) handles **discrete combination search**.
+
+This keeps the optimization engine stable while enabling frontend auto-generated forms.
+
+```python
+from akquant import (
+    IntParam,
+    ParamModel,
+    Strategy,
+    get_strategy_param_schema,
+    validate_strategy_params,
+    run_grid_search,
+)
+
+
+class SmaParams(ParamModel):
+    fast_period: int = IntParam(10, ge=2, le=200, title="Fast Window")
+    slow_period: int = IntParam(30, ge=3, le=500, title="Slow Window")
+
+
+class SmaStrategy(Strategy):
+    PARAM_MODEL = SmaParams
+
+    def __init__(self, fast_period: int = 10, slow_period: int = 30):
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+
+schema = get_strategy_param_schema(SmaStrategy)
+runtime_params = validate_strategy_params(
+    SmaStrategy,
+    {"fast_period": 12, "slow_period": 36},
+)
+
+results = run_grid_search(
+    strategy=SmaStrategy,
+    data=df,
+    param_grid={"fast_period": [5, 10, 15], "slow_period": [20, 30, 60]},
+)
+```
+
+If a strategy does not declare `PARAM_MODEL`, the adapter falls back to `__init__` signature inference for backward compatibility.
+
 ### Multi-Objective Optimization
 
 In real trading, a single metric is often insufficient (e.g., Sharpe Ratio alone might select a survivor that traded only once). AKQuant supports sorting based on multiple metrics:

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -213,6 +213,13 @@ run_backtest(strategy=MyStrategy, data=df, symbol="600000")
 
 For more examples, please refer to the `examples/` directory.
 
+## Parameter Modeling Entry
+
+*   Optimization guide (recommended workflow): [Parameter-Model-Driven Optimization](guide/optimization.md)
+*   Examples guide (UI-driven setup): [UI-Driven Strategy Parameterization (PARAM_MODEL)](guide/examples.md)
+*   API best practices (frontend-backend consistency): [UI-Driven Parameter Input](reference/api.md)
+*   Example script entry: [`examples/02_parameter_optimization.py`](../../examples/02_parameter_optimization.py)
+
 ## Quick Links
 
 *   Phase-5 migration FAQ (quickstart): [Phase-5 Migration FAQ](start/quickstart.md#phase-5-migration-faq)

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -394,6 +394,7 @@ result = run_backtest(
 
 *   **Simple Scripts**: Use flat parameters of `run_backtest` directly (e.g., `initial_cash`, `start_time`).
 *   **Production/Complex Strategies**: Build a complete `BacktestConfig` object for version control and reuse.
+*   **UI-Driven Parameter Input**: Declare `PARAM_MODEL` in strategy classes (`akquant.ParamModel`) and use `get_strategy_param_schema` / `validate_strategy_params` for frontend-backend parameter consistency.
 *   **Parameter Tuning**: When using `run_grid_search`, modify the Config object or pass override parameters as needed.
 
 ### `akquant.RiskConfig`

--- a/docs/en/textbook/index.md
+++ b/docs/en/textbook/index.md
@@ -3,3 +3,7 @@
 *This textbook is currently available in Chinese only. English translation is planned for future releases.*
 
 Please refer to the [Chinese Version](../../textbook/index.md) for the full content.
+
+Latest update in Chinese textbook:
+
+* Chapter 11 now includes the `PARAM_MODEL + param_grid` workflow for UI-driven parameter configuration and optimization.

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -9,6 +9,133 @@
 
 > 数据源约定：除特别标注需要模拟数据外，本页示例默认使用 AKShare 获取真实市场数据。
 
+### 页面化参数配置（PARAM_MODEL）
+
+在 Web UI / API 场景中，建议在策略中声明参数模型，并将优化搜索空间保持为独立的 `param_grid`：
+
+```python
+from akquant import (
+    IntParam,
+    ParamModel,
+    Strategy,
+    get_strategy_param_schema,
+    validate_strategy_params,
+    run_grid_search,
+)
+
+
+class SmaParams(ParamModel):
+    fast_period: int = IntParam(10, ge=2, le=200)
+    slow_period: int = IntParam(30, ge=3, le=500)
+
+
+class SmaStrategy(Strategy):
+    PARAM_MODEL = SmaParams
+
+    def __init__(self, fast_period: int = 10, slow_period: int = 30):
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+
+schema = get_strategy_param_schema(SmaStrategy)
+validated = validate_strategy_params(
+    SmaStrategy,
+    {"fast_period": 12, "slow_period": 36},
+)
+
+results = run_grid_search(
+    strategy=SmaStrategy,
+    data=df,
+    param_grid={"fast_period": [5, 10, 15], "slow_period": [20, 30, 60]},
+)
+```
+
+### 参数分流流程图（前端 params -> 回测调用）
+
+```mermaid
+flowchart TD
+    A[前端提交 params<br/>例如 fast_period/slow_period/date_range] --> B[validate_strategy_params]
+    B --> C[strategy_params<br/>注入 strategy.__init__]
+    A --> D[extract_runtime_kwargs]
+    D --> E[runtime_kwargs<br/>例如 start_time/end_time]
+    C --> F[run_backtest]
+    E --> F
+```
+
+说明：
+
+* `strategy_params` 负责策略构造参数（策略逻辑相关，如均线周期）。
+* `runtime_kwargs` 负责回测运行参数（回测窗口/运行环境相关，如 `start_time`、`end_time`）。
+* 当前默认映射规则是 `date_range -> start_time/end_time`。
+
+### 接口联调示例（HTTP）
+
+1) 获取参数 schema（前端用于自动渲染表单）：
+
+```http
+GET /api/strategies/sma_cross/schema
+```
+
+示例响应：
+
+```json
+{
+  "title": "SMACrossParams",
+  "type": "object",
+  "properties": {
+    "fast_period": { "type": "integer", "default": 10, "minimum": 2, "maximum": 200 },
+    "slow_period": { "type": "integer", "default": 30, "minimum": 3, "maximum": 500 },
+    "date_range": {
+      "type": "object",
+      "properties": {
+        "start": { "type": "string", "format": "date-time" },
+        "end": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}
+```
+
+2) 提交参数并启动回测：
+
+```http
+POST /api/backtest
+Content-Type: application/json
+```
+
+```json
+{
+  "strategy_id": "sma_cross",
+  "params": {
+    "fast_period": 12,
+    "slow_period": 36,
+    "date_range": {
+      "start": "2023-01-01T00:00:00",
+      "end": "2023-12-31T00:00:00"
+    }
+  }
+}
+```
+
+示例响应（展示参数分流结果）：
+
+```json
+{
+  "strategy_params": {
+    "fast_period": 12,
+    "slow_period": 36,
+    "date_range": {
+      "start": "2023-01-01T00:00:00",
+      "end": "2023-12-31T00:00:00"
+    }
+  },
+  "runtime_kwargs": {
+    "start_time": "2023-01-01T00:00:00",
+    "end_time": "2023-12-31T00:00:00"
+  }
+}
+```
+
 ## 2. 进阶示例 (Advanced Examples)
 
 *   **Zipline 风格策略**: 展示了如何使用函数式 API (`initialize`, `on_bar`) 编写策略，适合从 Zipline 迁移的用户。

--- a/docs/zh/guide/optimization.md
+++ b/docs/zh/guide/optimization.md
@@ -48,6 +48,54 @@ results = run_grid_search(
 print(results.head())
 ```
 
+### 参数模型驱动优化（推荐）
+
+当你需要把策略接入页面配置（例如 Web UI / API）时，建议采用 **`PARAM_MODEL + param_grid` 双层结构**：
+
+1. `PARAM_MODEL`（来自 `akquant.params`）用于**单次回测参数校验与 schema 导出**；
+2. `param_grid`（`run_grid_search` 原生接口）用于**离散参数组合搜索**。
+
+这样既保留了优化内核的稳定性，也能让前端自动生成参数表单。
+
+```python
+from akquant import (
+    IntParam,
+    ParamModel,
+    Strategy,
+    get_strategy_param_schema,
+    validate_strategy_params,
+    run_grid_search,
+)
+
+
+class SmaParams(ParamModel):
+    fast_period: int = IntParam(10, ge=2, le=200, title="快线")
+    slow_period: int = IntParam(30, ge=3, le=500, title="慢线")
+
+
+class SmaStrategy(Strategy):
+    PARAM_MODEL = SmaParams
+
+    def __init__(self, fast_period: int = 10, slow_period: int = 30):
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+
+schema = get_strategy_param_schema(SmaStrategy)
+runtime_params = validate_strategy_params(
+    SmaStrategy,
+    {"fast_period": 12, "slow_period": 36},
+)
+
+results = run_grid_search(
+    strategy=SmaStrategy,
+    data=df,
+    param_grid={"fast_period": [5, 10, 15], "slow_period": [20, 30, 60]},
+)
+```
+
+如果策略没有声明 `PARAM_MODEL`，适配层会回退到 `__init__` 签名做基础推断，以兼容历史策略。
+
 ### 多目标优化 (Multi-Objective Optimization)
 
 在实际交易中，单一指标往往存在局限性（例如仅看夏普比率可能选出只交易一次的幸存者）。AKQuant 支持基于多个指标进行排序：

--- a/docs/zh/index.md
+++ b/docs/zh/index.md
@@ -152,6 +152,13 @@ run_backtest(strategy=MyStrategy, data=df, symbol="600000")
 
 更多示例请参考 `examples/` 目录。
 
+## 参数模型化入口
+
+*   参数优化指南（推荐工作流）：[参数模型驱动优化](guide/optimization.md)
+*   示例集合（页面化参数配置）：[页面化参数配置（PARAM_MODEL）](guide/examples.md)
+*   API 最佳实践（前后端联动）：[页面化参数输入](reference/api.md)
+*   示例脚本入口：[`examples/02_parameter_optimization.py`](../../examples/02_parameter_optimization.py)
+
 ## 阶段 5 迁移入口
 
 *   快速查看迁移 FAQ（快速开始）：[快速开始中的阶段 5 迁移 FAQ](start/quickstart.md#阶段-5-迁移-faq)

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -373,6 +373,7 @@ result = run_backtest(
 
 *   **简单脚本**: 直接使用 `run_backtest` 的扁平参数（如 `initial_cash`, `start_time`）。
 *   **生产/复杂策略**: 构建完整的 `BacktestConfig` 对象，以便于版本管理和复用。
+*   **页面化参数输入**: 在策略类中声明 `PARAM_MODEL`（`akquant.ParamModel`），并使用 `get_strategy_param_schema` / `validate_strategy_params` 完成前后端参数联动与校验。
 *   **参数调优**: 使用 `run_grid_search` 时，通常通过修改 Config 对象或传入 override 参数来实现。
 
 ## 2. 策略开发 (Strategy)

--- a/docs/zh/textbook/11_optimization.md
+++ b/docs/zh/textbook/11_optimization.md
@@ -78,13 +78,39 @@ $$ P(\text{至少一次伪显著}) = 1 - (1 - 0.05)^{100} \approx 99.4\% $$
 
 `akquant` 提供了 `run_grid_search` 函数，支持并行计算。
 
-### 11.4.1 代码示例
+### 11.4.1 参数模型驱动（适合页面化）
+
+在面向页面配置、策略市场、研究平台等场景中，推荐采用以下分层：
+
+*   **参数模型层**：在策略类中声明 `PARAM_MODEL`（基于 `akquant.params.ParamModel`）。
+    *   用于参数类型约束、默认值管理、前端 JSON Schema 导出。
+*   **优化搜索层**：继续使用 `run_grid_search(param_grid=...)`。
+    *   `param_grid` 只负责离散候选值，不承担复杂对象校验。
+
+推荐这样做的核心原因是：**运行参数校验**与**参数组合搜索**在职责上是不同问题，拆开后更清晰、更稳健。
+
+策略示意（节选）：
+
+```python
+from akquant import IntParam, ParamModel, Strategy
+
+
+class SmaParams(ParamModel):
+    fast_period: int = IntParam(10, ge=2, le=200)
+    slow_period: int = IntParam(30, ge=3, le=500)
+
+
+class SmaStrategy(Strategy):
+    PARAM_MODEL = SmaParams
+```
+
+### 11.4.2 代码示例
 
 ```python
 --8<-- "examples/textbook/ch11_optimization.py"
 ```
 
-### 11.4.2 结果分析
+### 11.4.3 结果分析
 
 运行上述代码后，我们会得到一个按夏普比率排序的参数表。
 

--- a/examples/02_parameter_optimization.py
+++ b/examples/02_parameter_optimization.py
@@ -8,7 +8,22 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from akquant import Indicator, Strategy, run_grid_search
+from akquant import (
+    Indicator,
+    IntParam,
+    ParamModel,
+    Strategy,
+    get_strategy_param_schema,
+    run_grid_search,
+    validate_strategy_params,
+)
+
+
+class SMACrossParams(ParamModel):
+    """双均线参数模型."""
+
+    fast_period: int = IntParam(10, ge=2, le=200, title="快线周期")
+    slow_period: int = IntParam(30, ge=3, le=500, title="慢线周期")
 
 
 class SMACrossStrategy(Strategy):
@@ -19,6 +34,8 @@ class SMACrossStrategy(Strategy):
         fast_period (int): 快线周期
         slow_period (int): 慢线周期
     """
+
+    PARAM_MODEL = SMACrossParams
 
     def __init__(self, fast_period: int = 10, slow_period: int = 30):
         """初始化策略."""
@@ -74,6 +91,13 @@ if __name__ == "__main__":
 
     # 2. 运行优化
     print("Starting optimization...")
+    schema = get_strategy_param_schema(SMACrossStrategy)
+    print(f"Schema fields: {sorted(schema.get('properties', {}).keys())}")
+    validated = validate_strategy_params(
+        SMACrossStrategy,
+        {"fast_period": 12, "slow_period": 36},
+    )
+    print(f"Validated params demo: {validated}")
 
     # 定义参数网格
     param_grid = {

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,7 @@
 ## 最短执行路径
 
 - 5 分钟入门: [01_quickstart.py](./01_quickstart.py) -> [17_readme_demo.py](./17_readme_demo.py)
+- 页面化参数配置: [02_parameter_optimization.py](./02_parameter_optimization.py) -> `PARAM_MODEL` + `get_strategy_param_schema` + `validate_strategy_params`
 - 报告与分析: [11_plot_visualization.py](./11_plot_visualization.py) -> [33_report_and_analysis_outputs.py](./33_report_and_analysis_outputs.py)
 - 流式监控: [26_streaming_quickstart.py](./26_streaming_quickstart.py) -> [27_streaming_monitoring_console.py](./27_streaming_monitoring_console.py)
 - 实时可视化: [31_streaming_live_console.py](./31_streaming_live_console.py) -> [32_streaming_live_web.py](./32_streaming_live_web.py)
@@ -12,7 +13,7 @@
 ## 基础与能力示例
 
 - [01_quickstart.py](./01_quickstart.py): 多标的快速开始回测。
-- [02_parameter_optimization.py](./02_parameter_optimization.py): 参数优化基础示例。
+- [02_parameter_optimization.py](./02_parameter_optimization.py): 参数优化基础示例（含 `PARAM_MODEL`、schema 导出、参数校验演示）。
 - [03_parameter_optimization_advanced.py](./03_parameter_optimization_advanced.py): 参数优化进阶示例。
 - [04_mixed_assets.py](./04_mixed_assets.py): 混合资产回测示例。
 - [05_live_trading_ctp.py](./05_live_trading_ctp.py): CTP 实盘接口示例。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.65"
+version = "0.1.66"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}
@@ -31,6 +31,7 @@ dependencies = [
     "tqdm>=4.0.0",
     "plotly>=5.0.0",
     "polars>=0.20.0",
+    "pydantic>=2.0.0",
 ]
 
 [project.urls]

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -34,6 +34,22 @@ from .feed_adapter import (
 from .indicator import Indicator, IndicatorSet
 from .log import get_logger, register_logger
 from .optimize import OptimizationResult, run_grid_search, run_walk_forward
+from .params import (
+    BoolParam,
+    ChoiceParam,
+    DateRange,
+    DateRangeParam,
+    FloatParam,
+    IntParam,
+    ParamModel,
+)
+from .params_adapter import (
+    build_param_grid_from_search_space,
+    extract_runtime_kwargs,
+    get_strategy_param_schema,
+    resolve_param_model,
+    validate_strategy_params,
+)
 from .plot import plot_result
 from .sizer import AllInSizer, FixedSize, PercentSizer, Sizer
 from .strategy import Strategy, StrategyRuntimeConfig
@@ -87,6 +103,18 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "ATR",
         "AnalyzerManager",
         "AnalyzerTemplate",
+        "ParamModel",
+        "DateRange",
+        "IntParam",
+        "FloatParam",
+        "BoolParam",
+        "ChoiceParam",
+        "DateRangeParam",
+        "resolve_param_model",
+        "get_strategy_param_schema",
+        "validate_strategy_params",
+        "extract_runtime_kwargs",
+        "build_param_grid_from_search_space",
     ]
 else:
     __all__ = [
@@ -134,6 +162,18 @@ else:
         "ATR",
         "AnalyzerManager",
         "AnalyzerTemplate",
+        "ParamModel",
+        "DateRange",
+        "IntParam",
+        "FloatParam",
+        "BoolParam",
+        "ChoiceParam",
+        "DateRangeParam",
+        "resolve_param_model",
+        "get_strategy_param_schema",
+        "validate_strategy_params",
+        "extract_runtime_kwargs",
+        "build_param_grid_from_search_space",
     ]
 
 

--- a/python/akquant/params.py
+++ b/python/akquant/params.py
@@ -1,0 +1,226 @@
+"""
+策略参数建模与校验工具.
+
+该模块提供轻量的参数 DSL，底层基于 Pydantic。
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any, Mapping, Sequence, cast
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+
+class ParamModel(BaseModel):
+    """
+    策略参数基类.
+
+    :cvar model_config: Pydantic 配置，默认禁止未知字段。
+    """
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+
+class DateRange(BaseModel):
+    """
+    日期区间类型.
+
+    :ivar start: 区间开始
+    :ivar end: 区间结束
+    """
+
+    start: dt.date | dt.datetime
+    end: dt.date | dt.datetime
+
+    @model_validator(mode="after")
+    def _validate_range(self) -> "DateRange":
+        """
+        校验区间有效性.
+
+        :return: 当前对象
+        :raises ValueError: 结束时间早于开始时间
+        """
+        if _as_datetime(self.end) < _as_datetime(self.start):
+            raise ValueError("date_range.end must be >= date_range.start")
+        return self
+
+
+def IntParam(
+    default: int,
+    *,
+    ge: int | None = None,
+    le: int | None = None,
+    title: str | None = None,
+    description: str | None = None,
+) -> Any:
+    """
+    声明整型参数字段.
+
+    :param default: 默认值
+    :param ge: 最小值约束
+    :param le: 最大值约束
+    :param title: 展示标题
+    :param description: 描述
+    :return: Pydantic 字段定义
+    """
+    return Field(default, ge=ge, le=le, title=title, description=description)
+
+
+def FloatParam(
+    default: float,
+    *,
+    ge: float | None = None,
+    le: float | None = None,
+    title: str | None = None,
+    description: str | None = None,
+) -> Any:
+    """
+    声明浮点参数字段.
+
+    :param default: 默认值
+    :param ge: 最小值约束
+    :param le: 最大值约束
+    :param title: 展示标题
+    :param description: 描述
+    :return: Pydantic 字段定义
+    """
+    return Field(default, ge=ge, le=le, title=title, description=description)
+
+
+def BoolParam(
+    default: bool,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+) -> Any:
+    """
+    声明布尔参数字段.
+
+    :param default: 默认值
+    :param title: 展示标题
+    :param description: 描述
+    :return: Pydantic 字段定义
+    """
+    return Field(default, title=title, description=description)
+
+
+def ChoiceParam(
+    default: str,
+    *,
+    choices: Sequence[str],
+    title: str | None = None,
+    description: str | None = None,
+) -> Any:
+    """
+    声明枚举参数字段.
+
+    :param default: 默认值
+    :param choices: 可选值列表
+    :param title: 展示标题
+    :param description: 描述
+    :return: Pydantic 字段定义
+    :raises ValueError: choices 为空
+    """
+    if not choices:
+        raise ValueError("choices cannot be empty")
+    return Field(
+        default,
+        title=title,
+        description=description,
+        json_schema_extra={"enum": list(choices)},
+    )
+
+
+def DateRangeParam(
+    *,
+    default: DateRange | None = None,
+    title: str | None = None,
+    description: str | None = None,
+) -> Any:
+    """
+    声明日期区间参数字段.
+
+    :param default: 默认值
+    :param title: 展示标题
+    :param description: 描述
+    :return: Pydantic 字段定义
+    """
+    return Field(default, title=title, description=description)
+
+
+def model_to_schema(model_cls: type[ParamModel]) -> dict[str, Any]:
+    """
+    导出参数模型 JSON Schema.
+
+    :param model_cls: 参数模型类
+    :return: JSON Schema
+    """
+    return cast(dict[str, Any], model_cls.model_json_schema())
+
+
+def validate_payload(
+    model_cls: type[ParamModel],
+    payload: Mapping[str, Any],
+) -> ParamModel:
+    """
+    校验参数载荷并返回模型实例.
+
+    :param model_cls: 参数模型类
+    :param payload: 输入参数
+    :return: 校验后的模型实例
+    :raises ValidationError: 参数不合法
+    """
+    return cast(ParamModel, model_cls.model_validate(payload))
+
+
+def to_runtime_kwargs(model: ParamModel) -> dict[str, Any]:
+    """
+    将参数模型映射为运行时 kwargs.
+
+    当前规则：
+    - 若存在 ``date_range`` 字段，自动展开为 ``start_time`` / ``end_time``。
+
+    :param model: 参数模型实例
+    :return: 运行时参数字典
+    """
+    runtime_kwargs: dict[str, Any] = {}
+    data = model.model_dump()
+    date_range_obj = data.get("date_range")
+    if isinstance(date_range_obj, dict):
+        start_value = date_range_obj.get("start")
+        end_value = date_range_obj.get("end")
+        if start_value is not None:
+            runtime_kwargs["start_time"] = _to_iso(start_value)
+        if end_value is not None:
+            runtime_kwargs["end_time"] = _to_iso(end_value)
+    return runtime_kwargs
+
+
+def _as_datetime(value: dt.date | dt.datetime) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value
+    return dt.datetime.combine(value, dt.time.min)
+
+
+def _to_iso(value: Any) -> str:
+    if isinstance(value, dt.datetime):
+        return value.isoformat()
+    if isinstance(value, dt.date):
+        return value.isoformat()
+    return str(value)
+
+
+__all__ = [
+    "ParamModel",
+    "DateRange",
+    "IntParam",
+    "FloatParam",
+    "BoolParam",
+    "ChoiceParam",
+    "DateRangeParam",
+    "ValidationError",
+    "model_to_schema",
+    "validate_payload",
+    "to_runtime_kwargs",
+]

--- a/python/akquant/params_adapter.py
+++ b/python/akquant/params_adapter.py
@@ -1,0 +1,214 @@
+"""
+策略参数适配层.
+
+用于连接策略参数模型、前端 schema 与回测入口。
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Mapping, Sequence, cast
+
+from .params import ParamModel, model_to_schema, to_runtime_kwargs, validate_payload
+from .strategy import Strategy
+
+
+def resolve_param_model(strategy_cls: type[Strategy]) -> type[ParamModel] | None:
+    """
+    解析策略的参数模型.
+
+    :param strategy_cls: 策略类
+    :return: ParamModel 子类；若未声明则返回 None
+    :raises TypeError: PARAM_MODEL 类型不合法
+    """
+    model_cls = getattr(strategy_cls, "PARAM_MODEL", None)
+    if model_cls is None:
+        return None
+    if not isinstance(model_cls, type) or not issubclass(model_cls, ParamModel):
+        raise TypeError("PARAM_MODEL must be a subclass of ParamModel")
+    return cast(type[ParamModel], model_cls)
+
+
+def get_strategy_param_schema(strategy_cls: type[Strategy]) -> dict[str, Any]:
+    """
+    获取策略参数 schema.
+
+    :param strategy_cls: 策略类
+    :return: 参数 schema
+    """
+    model_cls = resolve_param_model(strategy_cls)
+    if model_cls is not None:
+        return model_to_schema(model_cls)
+    return _build_signature_schema(strategy_cls)
+
+
+def validate_strategy_params(
+    strategy_cls: type[Strategy],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    校验策略参数.
+
+    :param strategy_cls: 策略类
+    :param payload: 待校验参数
+    :return: 可直接注入 strategy_params 的参数字典
+    """
+    model_cls = resolve_param_model(strategy_cls)
+    if model_cls is not None:
+        model = validate_payload(model_cls, payload)
+        return cast(dict[str, Any], model.model_dump())
+    return _validate_with_signature(strategy_cls, payload)
+
+
+def extract_runtime_kwargs(
+    strategy_cls: type[Strategy],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    提取运行时参数.
+
+    :param strategy_cls: 策略类
+    :param payload: 待校验参数
+    :return: 可透传 run_backtest 的 runtime kwargs
+    """
+    model_cls = resolve_param_model(strategy_cls)
+    if model_cls is None:
+        return {}
+    model = validate_payload(model_cls, payload)
+    return to_runtime_kwargs(model)
+
+
+def build_param_grid_from_search_space(
+    search_space: Mapping[str, Sequence[Any]],
+) -> dict[str, list[Any]]:
+    """
+    将上层 search space 归一化为 param_grid.
+
+    :param search_space: 搜索空间
+    :return: param_grid
+    :raises TypeError: 值不是序列
+    :raises ValueError: 候选为空
+    """
+    grid: dict[str, list[Any]] = {}
+    for key, values in search_space.items():
+        if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+            raise TypeError(f"search_space[{key}] must be a sequence")
+        candidate_values = list(values)
+        if not candidate_values:
+            raise ValueError(f"search_space[{key}] cannot be empty")
+        grid[str(key)] = candidate_values
+    return grid
+
+
+def _build_signature_schema(strategy_cls: type[Strategy]) -> dict[str, Any]:
+    signature = inspect.signature(strategy_cls.__init__)
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for name, param in signature.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        annotation = param.annotation
+        json_type = _annotation_to_json_type(annotation)
+        field_schema: dict[str, Any] = {"type": json_type, "title": name}
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+        else:
+            field_schema["default"] = param.default
+        properties[name] = field_schema
+    return {
+        "title": f"{strategy_cls.__name__}Params",
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }
+
+
+def _validate_with_signature(
+    strategy_cls: type[Strategy],
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    signature = inspect.signature(strategy_cls.__init__)
+    allowed_params: dict[str, inspect.Parameter] = {}
+    for name, param in signature.parameters.items():
+        if name == "self":
+            continue
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        allowed_params[name] = param
+
+    unknown = sorted(set(payload.keys()).difference(set(allowed_params.keys())))
+    if unknown:
+        raise ValueError(f"Unknown strategy params: {unknown}")
+
+    validated: dict[str, Any] = {}
+    for name, param in allowed_params.items():
+        if name in payload:
+            validated[name] = _coerce_value(payload[name], param.annotation)
+        elif param.default is not inspect.Parameter.empty:
+            validated[name] = param.default
+        else:
+            raise ValueError(f"Missing required strategy param: {name}")
+    return validated
+
+
+def _annotation_to_json_type(annotation: Any) -> str:
+    normalized = _normalize_annotation(annotation)
+    if normalized is int:
+        return "integer"
+    if normalized is float:
+        return "number"
+    if normalized is bool:
+        return "boolean"
+    return "string"
+
+
+def _coerce_value(value: Any, annotation: Any) -> Any:
+    normalized = _normalize_annotation(annotation)
+    if normalized is int:
+        return int(value)
+    if normalized is float:
+        return float(value)
+    if normalized is bool:
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"1", "true", "yes", "y", "on"}:
+                return True
+            if lowered in {"0", "false", "no", "n", "off"}:
+                return False
+        return bool(value)
+    if normalized is str:
+        return str(value)
+    return value
+
+
+def _normalize_annotation(annotation: Any) -> Any:
+    if annotation is int:
+        return int
+    if annotation is float:
+        return float
+    if annotation is bool:
+        return bool
+    if annotation is str:
+        return str
+    if isinstance(annotation, str):
+        mapping = {"int": int, "float": float, "bool": bool, "str": str}
+        return mapping.get(annotation, annotation)
+    return annotation
+
+
+__all__ = [
+    "resolve_param_model",
+    "get_strategy_param_schema",
+    "validate_strategy_params",
+    "extract_runtime_kwargs",
+    "build_param_grid_from_search_space",
+]

--- a/tests/test_params_adapter.py
+++ b/tests/test_params_adapter.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from akquant.params import DateRange, DateRangeParam, IntParam, ParamModel
+from akquant.params_adapter import (
+    extract_runtime_kwargs,
+    get_strategy_param_schema,
+    validate_strategy_params,
+)
+from akquant.strategy import Strategy
+
+
+class DemoParams(ParamModel):
+    """用于测试的参数模型."""
+
+    fast_period: int = IntParam(5, ge=2, le=100)
+    slow_period: int = IntParam(20, ge=3, le=300)
+    date_range: DateRange = DateRangeParam()
+
+
+class DemoStrategy(Strategy):
+    """用于测试的带 PARAM_MODEL 策略."""
+
+    PARAM_MODEL = DemoParams
+
+    def __init__(self, fast_period: int = 5, slow_period: int = 20) -> None:
+        """初始化测试策略."""
+        self.fast_period = fast_period
+        self.slow_period = slow_period
+
+    def on_bar(self, bar: Any) -> None:
+        """处理 bar 事件."""
+        return
+
+
+class LegacyStrategy(Strategy):
+    """用于测试签名推断的旧风格策略."""
+
+    def __init__(self, period: int, use_exit: bool = True) -> None:
+        """初始化旧风格测试策略."""
+        self.period = period
+        self.use_exit = use_exit
+
+    def on_bar(self, bar: Any) -> None:
+        """处理 bar 事件."""
+        return
+
+
+def test_get_strategy_param_schema_uses_param_model() -> None:
+    """PARAM_MODEL 策略应返回模型 schema."""
+    schema = get_strategy_param_schema(DemoStrategy)
+    properties = schema.get("properties", {})
+    assert "fast_period" in properties
+    assert "date_range" in properties
+
+
+def test_validate_strategy_params_with_model_and_runtime_kwargs() -> None:
+    """参数模型应完成校验并导出运行时 kwargs."""
+    payload = {
+        "fast_period": 8,
+        "slow_period": 26,
+        "date_range": {"start": "2024-01-01", "end": "2024-12-31"},
+    }
+    validated = validate_strategy_params(DemoStrategy, payload)
+    assert validated["fast_period"] == 8
+    kwargs = extract_runtime_kwargs(DemoStrategy, payload)
+    assert kwargs["start_time"] == "2024-01-01"
+    assert kwargs["end_time"] == "2024-12-31"
+
+
+def test_validate_strategy_params_rejects_unknown_fields() -> None:
+    """未知字段应被拒绝."""
+    payload = {"fast_period": 8, "slow_period": 20, "unknown": 1}
+    with pytest.raises(Exception):
+        validate_strategy_params(DemoStrategy, payload)
+
+
+def test_validate_strategy_params_signature_fallback() -> None:
+    """无参数模型时应回退到 __init__ 签名推断."""
+    validated = validate_strategy_params(LegacyStrategy, {"period": "10"})
+    assert validated["period"] == 10
+    assert validated["use_exit"] is True


### PR DESCRIPTION
新增 `akquant.params` 与 `akquant.params_adapter` 模块，提供基于 Pydantic 的参数建模 DSL。策略类可通过声明 `PARAM_MODEL` 来定义参数类型、约束和默认值，适配层提供 `get_strategy_param_schema` 和 `validate_strategy_params` 等函数，用于前端表单生成与参数校验。同时，`extract_runtime_kwargs` 函数可将模型参数（如 `date_range`）映射为回测运行时参数（如 `start_time`, `end_time`），实现前后端参数联动。

更新文档、示例和测试，以展示 `PARAM_MODEL + param_grid` 的推荐工作流，并升级版本至 0.1.66。