### PR TITLE
fix(backtest): 修复多品种DataFrame回测时bar.symbol不正确的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.70"
+version = "0.1.71"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.70"
+version = "0.1.71"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.70"
+version = "0.1.71"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -1016,27 +1016,36 @@ def run_backtest(
                 else:
                     df_input = df_input[df_input.index <= ts_end]
 
-            # Try to infer symbol from DataFrame if not explicitly provided or default
-            if (
-                not symbols or symbols == ["BENCHMARK"]
-            ) and "symbol" in df_input.columns:
-                unique_symbols = df_input["symbol"].unique()
-                if len(unique_symbols) == 1:
-                    inferred = unique_symbols[0]
-                    if symbols == ["BENCHMARK"]:
-                        symbols = [inferred]
-                    else:
-                        if inferred not in symbols:
-                            symbols.append(inferred)
-
-            target_symbol = symbols[0] if symbols else "BENCHMARK"
             df = prepare_dataframe(df_input)
-            data_map_for_indicators[target_symbol] = df
-            arrays = df_to_arrays(df, symbol=target_symbol)
-            feed.add_arrays(*arrays)  # type: ignore
-            feed.sort()
-            if target_symbol not in symbols:
-                symbols = [target_symbol]
+            if "symbol" in df.columns:
+                df = df.copy()
+                df["symbol"] = df["symbol"].astype(str)
+                filter_symbols = bool(symbols and "BENCHMARK" not in symbols)
+                if filter_symbols:
+                    df = df[df["symbol"].isin(symbols)]
+                if not df.empty:
+                    arrays = df_to_arrays(df)
+                    feed.add_arrays(*arrays)  # type: ignore
+                    grouped = df.groupby("symbol", sort=False)
+                    for grouped_symbol, grouped_df in grouped:
+                        sym = str(grouped_symbol)
+                        data_map_for_indicators[sym] = grouped_df.copy()
+                    detected_symbols = [str(s) for s in df["symbol"].unique().tolist()]
+                    if not symbols or symbols == ["BENCHMARK"]:
+                        symbols = detected_symbols
+                    else:
+                        for sym in detected_symbols:
+                            if sym not in symbols:
+                                symbols.append(sym)
+                feed.sort()
+            else:
+                target_symbol = symbols[0] if symbols else "BENCHMARK"
+                data_map_for_indicators[target_symbol] = df
+                arrays = df_to_arrays(df, symbol=target_symbol)
+                feed.add_arrays(*arrays)  # type: ignore
+                feed.sort()
+                if target_symbol not in symbols:
+                    symbols = [target_symbol]
         elif isinstance(data, dict):
             # If explicit symbols are provided (i.e., not just the default "BENCHMARK"),
             # we filter the data dictionary to only include requested symbols.
@@ -1155,11 +1164,15 @@ def run_backtest(
         day_bounds: Dict[str, Tuple[int, int]] = {}
         for df in data_map_for_indicators.values():
             if not df.empty and isinstance(df.index, pd.DatetimeIndex):
-                dates = df.index.normalize().unique()
+                normalized_index = cast(pd.DatetimeIndex, df.index.normalize())
+                dates = normalized_index.unique()
                 all_dates.update(dates)
-                grouped = df.groupby(df.index.normalize())
-                for day_ts, day_df in grouped:
-                    day_key = pd.Timestamp(day_ts).date().isoformat()
+                for raw_day_ts in dates:
+                    day_ts = pd.Timestamp(raw_day_ts)
+                    day_df = df[normalized_index == day_ts]
+                    if day_df.empty:
+                        continue
+                    day_key = day_ts.date().isoformat()
                     start_ns = int(day_df.index.min().value)
                     end_ns = int(day_df.index.max().value)
                     if day_key in day_bounds:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -237,6 +237,86 @@ def test_run_backtest_accepts_data_feed_adapter() -> None:
     assert set(result.orders_df["symbol"].astype(str)) == {symbol}
 
 
+def test_run_backtest_dataframe_multisymbol_preserves_bar_symbol() -> None:
+    """Keep bar.symbol aligned with per-row symbol values in DataFrame mode."""
+
+    class CollectSymbolsStrategy(akquant.Strategy):
+        """Collect symbols observed in on_bar callbacks."""
+
+        def __init__(self) -> None:
+            """Initialize the collected symbol container."""
+            super().__init__()
+            self.seen_symbols: list[str] = []
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            """Record callback symbol for later assertions."""
+            self.seen_symbols.append(str(bar.symbol))
+
+    rows = [
+        {
+            "timestamp": "2024-01-02",
+            "symbol": "IF2401.CFX",
+            "open": 10.0,
+            "high": 11.0,
+            "low": 9.0,
+            "close": 10.5,
+            "volume": 1000.0,
+        },
+        {
+            "timestamp": "2024-01-02",
+            "symbol": "IF2402.CFX",
+            "open": 20.0,
+            "high": 21.0,
+            "low": 19.0,
+            "close": 20.5,
+            "volume": 1000.0,
+        },
+        {
+            "timestamp": "2024-01-03",
+            "symbol": "IF2401.CFX",
+            "open": 11.0,
+            "high": 12.0,
+            "low": 10.0,
+            "close": 11.5,
+            "volume": 1000.0,
+        },
+        {
+            "timestamp": "2024-01-03",
+            "symbol": "IF2402.CFX",
+            "open": 21.0,
+            "high": 22.0,
+            "low": 20.0,
+            "close": 21.5,
+            "volume": 1000.0,
+        },
+    ]
+    df = pd.DataFrame(rows)
+    df["timestamp"] = pd.to_datetime(df["timestamp"])
+    df = df.set_index("timestamp")
+
+    result = akquant.run_backtest(
+        data=df,
+        strategy=CollectSymbolsStrategy,
+        symbol=["IF2401.CFX", "IF2402.CFX"],
+        start_time="2024-01-02",
+        end_time="2024-01-03",
+        execution_mode="current_close",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    strategy = cast(CollectSymbolsStrategy, result.strategy)
+    assert len(strategy.seen_symbols) == len(df)
+    assert set(strategy.seen_symbols) == {"IF2401.CFX", "IF2402.CFX"}
+    assert strategy.seen_symbols.count("IF2401.CFX") == 2
+    assert strategy.seen_symbols.count("IF2402.CFX") == 2
+
+
 def test_engine_run_empty() -> None:
     """Test running engine with no data."""
     engine = akquant.Engine()


### PR DESCRIPTION
修复当传入包含多品种的DataFrame数据时，回测引擎中on_bar回调的bar.symbol与数据行实际symbol不匹配的问题。 现在会正确按symbol分组处理数据，确保每个bar事件携带正确的品种标识。