### PR TITLE
feat(futures): 增加中国期货前缀级配置和校验开关

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `run_backtest_stream` is removed; stream scenarios should call `run_backtest(..., on_event=...)`.
 - `run_backtest` always uses the unified stream core; runtime rollback flag `_engine_mode` is removed.
+- Futures fee Engine API naming is standardized to `set_futures_fee_rules*`; legacy `set_future_fee_rules*` is removed.
 
 ## [0.1.13] - 2026-02-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.72"
+version = "0.1.73"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.72"
+version = "0.1.73"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/textbook/07_futures.md
+++ b/docs/en/textbook/07_futures.md
@@ -8,3 +8,41 @@ This chapter is currently maintained in Chinese first.
   - Primary example: [examples/textbook/ch07_futures.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch07_futures.py)
   - Extended example: [examples/04_mixed_assets.py](https://github.com/akfamily/akquant/blob/main/examples/04_mixed_assets.py)
   - Guide: [Strategy Guide](../guide/strategy.md)
+
+## China futures config highlights
+
+`BacktestConfig.china_futures` supports prefix-level futures templates and validation:
+
+- Prefix template fields: `multiplier`, `margin_ratio`, `tick_size`, `lot_size`
+- Prefix commission override: `commission_rate`
+- Prefix validation switches: `enforce_tick_size`, `enforce_lot_size`
+- Session behavior switch: `enforce_sessions`
+
+The config now validates early during object construction (fail-fast):
+
+- Empty `symbol_prefix` is rejected
+- Invalid numeric ranges (e.g. non-positive `multiplier`) are rejected
+- Duplicate prefixes in the same list are rejected with index-aware messages
+
+For complete examples and explanations, refer to the Chinese chapter section
+“AKQuant 中国期货配置速览”.
+
+### Priority matrix
+
+| Scenario | Highest priority | Secondary priority | Fallback |
+|---|---|---|---|
+| Contract fields (`multiplier`, `margin_ratio`, `tick_size`, `lot_size`) | Explicit `InstrumentConfig` fields | `instrument_templates_by_symbol_prefix` | `run_backtest` defaults |
+| Prefix commission | `fee_by_symbol_prefix` | Template `commission_rate` | `StrategyConfig.commission_rate` |
+| Prefix validation switches | `validation_by_symbol_prefix` | Template `enforce_tick_size` / `enforce_lot_size` | Global `ChinaFuturesConfig.enforce_*` |
+| Market selection | `use_china_futures_market=False` or mixed-asset fallback | `use_china_futures_market=True` with futures-only set | `use_simple_market` |
+
+Notes:
+
+- Within the same layer, explicit prefix rules override template defaults.
+- In order validation matching, a more specific prefix (longer match) wins.
+
+Low-level Engine API naming:
+
+- Futures fee APIs are standardized as `set_futures_fee_rules` and
+  `set_futures_fee_rules_by_prefix`.
+- Legacy singular names `set_future_fee_rules*` are removed.

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -319,6 +319,19 @@ BacktestConfig (回测场景)
     └── commission_rate (资产专用佣金，覆盖 StrategyConfig)
 ```
 
+中国期货扩展配置位于 `BacktestConfig.china_futures`，用于管理前缀级规则：
+
+- `instrument_templates_by_symbol_prefix`: 品种模板（乘数/保证金/tick/手数/费率）
+- `fee_by_symbol_prefix`: 品种费率覆盖
+- `validation_by_symbol_prefix`: 品种撮合校验开关覆盖
+- `enforce_sessions`: 是否严格按交易时段控制成交
+
+配置对象采用“构造即校验”：
+
+- `symbol_prefix` 为空会直接报错
+- 模板数值范围非法（如 `multiplier <= 0`）会直接报错
+- 同一列表内前缀重复会报错并标注冲突项索引
+
 #### 2. 参数优先级 (Priority)
 
 `run_backtest` 函数的参数解析遵循以下优先级（由高到低）：
@@ -333,6 +346,34 @@ BacktestConfig (回测场景)
         `strategy_risk_budget`、`portfolio_risk_budget`）。
 3.  **默认值 (Defaults)**:
     *   如果上述两者都未提供，则使用系统默认值。
+
+中国期货扩展（`BacktestConfig.china_futures`）推荐使用以下优先级口径：
+
+| 配置项 | 高优先级 | 中优先级 | 默认值 |
+|---|---|---|---|
+| 合约参数（乘数/保证金/tick/手数） | `InstrumentConfig` 显式字段 | `instrument_templates_by_symbol_prefix` | `run_backtest` 默认参数 |
+| 品种费率 | `fee_by_symbol_prefix` | 模板 `commission_rate` | `StrategyConfig.commission_rate` |
+| 品种校验开关 | `validation_by_symbol_prefix` | 模板 `enforce_tick_size / enforce_lot_size` | 全局 `ChinaFuturesConfig.enforce_*` |
+| 市场路由 | `use_china_futures_market=False` 或混合资产回落 | `use_china_futures_market=True` 且纯期货 | `use_simple_market` |
+
+口径说明：
+
+*   同级规则冲突时，以显式规则覆盖模板规则。
+*   撮合校验路径按更具体前缀优先（更长匹配优先）。
+
+股票配置推荐使用以下优先级口径：
+
+| 配置项 | 高优先级 | 中优先级 | 默认值 |
+|---|---|---|---|
+| 股票费率（佣金/印花税/过户费/最低佣金） | `InstrumentConfig` 单标的费率字段 | `StrategyConfig` 全局费率字段 | `run_backtest` 内置默认值 |
+| 交易单位（`lot_size`） | `InstrumentConfig.lot_size`（显式设置） | `run_backtest(lot_size=...)` 全局设置 | `1` |
+| 市场制度（T+1） | `run_backtest(t_plus_one=...)` 显式参数 | `Engine.set_t_plus_one(...)` 引擎设置 | `False` |
+| 市场模型 | `use_china_market()` | `use_simple_market()` | 引擎默认市场配置 |
+
+股票侧说明：
+
+*   当前股票没有按代码前缀的模板层（不像期货的 `china_futures` 前缀模板）。
+*   生产场景建议优先用 `InstrumentConfig` 精确配置重点股票，再用 `StrategyConfig` 作为全局兜底。
 
 #### 3. 风控配置合并 (Risk Config Merging)
 
@@ -498,12 +539,20 @@ Tick 数据对象。
 *   `use_china_market()`: 启用中国市场 (股票)。
 *   `use_china_futures_market()`: 启用中国期货市场。
 *   `set_stock_fee_rules(commission, stamp_tax, transfer_fee, min_commission)`: 设置股票费率。
-*   `set_future_fee_rules(commission_rate)`: 设置期货费率。
+*   `set_futures_fee_rules(commission_rate)`: 设置期货费率。
+*   `set_futures_fee_rules_by_prefix(symbol_prefix, commission_rate)`: 设置期货品种前缀费率。
+*   `set_futures_validation_options(enforce_tick_size, enforce_lot_size)`: 设置期货撮合前校验开关。
+*   `set_futures_validation_options_by_prefix(symbol_prefix, enforce_tick_size, enforce_lot_size)`: 设置期货品种前缀校验开关。
 *   `set_fund_fee_rules(...)`: 设置基金费率。
 *   `set_option_fee_rules(...)`: 设置期权费率。
 *   `set_slippage(type, value)`: 设置滑点 (Fixed 或 Percent)。
 *   `set_volume_limit(limit)`: 设置成交量限制 (如 0.1 表示不超过 Bar 成交量的 10%)。
 *   `set_market_sessions(sessions)`: 设置交易时段。
+
+命名约定说明：
+
+*   期货费率接口统一使用复数命名 `set_futures_fee_rules*`。
+*   旧单数命名 `set_future_fee_rules*` 已移除，不再对外暴露。
 
 ### `akquant.gateway` 自定义 Broker 注册
 

--- a/docs/zh/textbook/07_futures.md
+++ b/docs/zh/textbook/07_futures.md
@@ -20,6 +20,82 @@ python examples/textbook/ch07_futures.py
 2. 结果中可体现保证金与杠杆对权益波动的放大效应。
 3. 调整合约参数或杠杆后，策略波动率变化符合预期。
 
+## 7.0 AKQuant 中国期货配置速览
+
+`akquant` 在 `BacktestConfig` 下提供了 `china_futures` 配置入口，可同时管理：
+
+- 品种前缀模板（乘数、保证金、tick、手数）
+- 品种前缀费率覆盖
+- 品种前缀校验开关（tick 对齐、手数整数倍）
+- 会话行为（是否强制交易时段）
+
+示例：
+
+```python
+from akquant import (
+    BacktestConfig,
+    ChinaFuturesConfig,
+    ChinaFuturesInstrumentTemplateConfig,
+    ChinaFuturesValidationConfig,
+    InstrumentConfig,
+    StrategyConfig,
+)
+
+config = BacktestConfig(
+    strategy_config=StrategyConfig(initial_cash=500_000),
+    instruments_config=[
+        InstrumentConfig(symbol="RB2310", asset_type="FUTURES")
+    ],
+    china_futures=ChinaFuturesConfig(
+        enforce_sessions=False,
+        instrument_templates_by_symbol_prefix=[
+            ChinaFuturesInstrumentTemplateConfig(
+                symbol_prefix="RB",
+                multiplier=10.0,
+                margin_ratio=0.1,
+                tick_size=1.0,
+                lot_size=1.0,
+                commission_rate=0.0001,
+            )
+        ],
+        validation_by_symbol_prefix=[
+            ChinaFuturesValidationConfig(
+                symbol_prefix="RB",
+                enforce_tick_size=False,
+                enforce_lot_size=True,
+            )
+        ],
+    ),
+)
+```
+
+构造校验（Fail Fast）：
+
+- `symbol_prefix` 会自动去空格并大写；空值会直接报错
+- 模板里 `multiplier / margin_ratio / tick_size / lot_size` 必须大于 0
+- 模板和前缀规则里的 `commission_rate` 必须大于等于 0
+- `validation_by_symbol_prefix` 每条规则至少设置一个开关
+- 同一列表内前缀重复会报错，并定位到冲突项索引
+
+配置优先级矩阵（从高到低）：
+
+| 场景 | 最高优先级 | 次级优先级 | 兜底 |
+|---|---|---|---|
+| 合约参数（乘数/保证金/tick/手数） | `InstrumentConfig` 显式字段 | `instrument_templates_by_symbol_prefix` | `run_backtest` 默认参数 |
+| 前缀费率 | `fee_by_symbol_prefix` | 模板里的 `commission_rate` | `StrategyConfig.commission_rate` |
+| 前缀校验开关 | `validation_by_symbol_prefix` | 模板里的 `enforce_tick_size / enforce_lot_size` | `ChinaFuturesConfig` 全局 `enforce_*` |
+| 市场选择 | `use_china_futures_market=False` 或混合资产触发中国市场 | `use_china_futures_market=True` 且纯期货资产 | `use_simple_market` |
+
+说明：
+
+- 同一优先级层内按“同名单项覆盖”处理，后定义的显式规则覆盖模板默认。
+- 在撮合校验路径中，前缀匹配采用更具体前缀优先（例如 `RB` 与 `RB2` 同时命中时优先 `RB2`）。
+
+低层引擎 API 命名说明：
+
+- 期货费率相关接口统一为 `set_futures_fee_rules` 与 `set_futures_fee_rules_by_prefix`。
+- 旧命名单数形式 `set_future_fee_rules*` 已移除，迁移时请直接替换为复数接口。
+
 ## 7.1 期货市场机制 (Market Mechanisms)
 
 ### 7.1.1 标准化合约

--- a/examples/textbook/ch07_futures.py
+++ b/examples/textbook/ch07_futures.py
@@ -116,12 +116,19 @@ if __name__ == "__main__":
 
     # 1. 定义期货合约属性 (关键步骤)
     # 螺纹钢：乘数 10，保证金 10%
-    from akquant import BacktestConfig, InstrumentConfig, StrategyConfig
+    from akquant import (
+        BacktestConfig,
+        ChinaFuturesConfig,
+        ChinaFuturesInstrumentTemplateConfig,
+        ChinaFuturesValidationConfig,
+        InstrumentConfig,
+        StrategyConfig,
+    )
 
     rb_config = InstrumentConfig(
         symbol="RB2310",
-        asset_type="future",  # 资产类型
-        multiplier=10,  # 合约乘数 (1手 = 10吨)
+        asset_type="FUTURES",  # 资产类型
+        multiplier=10.0,  # 合约乘数 (1手 = 10吨)
         margin_ratio=0.1,  # 保证金比率 (10%)
     )
 
@@ -130,6 +137,28 @@ if __name__ == "__main__":
     config = BacktestConfig(
         strategy_config=StrategyConfig(initial_cash=500_000, commission_rate=0.0001),
         instruments_config=[rb_config],
+        china_futures=ChinaFuturesConfig(
+            enforce_sessions=False,
+            instrument_templates_by_symbol_prefix=[
+                ChinaFuturesInstrumentTemplateConfig(
+                    symbol_prefix="RB",
+                    multiplier=10.0,
+                    margin_ratio=0.1,
+                    tick_size=1.0,
+                    lot_size=1.0,
+                    commission_rate=0.0001,
+                    enforce_tick_size=False,
+                    enforce_lot_size=True,
+                )
+            ],
+            validation_by_symbol_prefix=[
+                ChinaFuturesValidationConfig(
+                    symbol_prefix="RB",
+                    enforce_tick_size=False,
+                    enforce_lot_size=True,
+                )
+            ],
+        ),
     )
 
     result = aq.run_backtest(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.72"
+version = "0.1.73"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -22,7 +22,17 @@ from .backtest import (  # type: ignore
     run_warm_start,
 )
 from .checkpoint import save_snapshot, warm_start
-from .config import BacktestConfig, InstrumentConfig, StrategyConfig, strategy_config
+from .config import (
+    BacktestConfig,
+    ChinaFuturesConfig,
+    ChinaFuturesFeeConfig,
+    ChinaFuturesInstrumentTemplateConfig,
+    ChinaFuturesSessionConfig,
+    ChinaFuturesValidationConfig,
+    InstrumentConfig,
+    StrategyConfig,
+    strategy_config,
+)
 from .data import DataLoader
 from .feed_adapter import (
     CSVFeedAdapter,
@@ -81,6 +91,11 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "get_logger",
         "register_logger",
         "strategy_config",
+        "ChinaFuturesConfig",
+        "ChinaFuturesFeeConfig",
+        "ChinaFuturesInstrumentTemplateConfig",
+        "ChinaFuturesSessionConfig",
+        "ChinaFuturesValidationConfig",
         "Indicator",
         "IndicatorSet",
         "run_backtest",

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -560,11 +560,48 @@ class Engine:
         """
         ...
 
-    def set_future_fee_rules(self, commission_rate: float) -> None:
+    def set_futures_fee_rules(self, commission_rate: float) -> None:
         r"""
         设置期货费率规则.
 
         :param commission_rate: 佣金率 (如 0.0001)
+        """
+        ...
+
+    def set_futures_fee_rules_by_prefix(
+        self, symbol_prefix: str, commission_rate: float
+    ) -> None:
+        r"""
+        设置期货品种前缀费率规则.
+
+        :param symbol_prefix: 品种前缀 (如 RB, IF)
+        :param commission_rate: 佣金率
+        """
+        ...
+
+    def set_futures_validation_options(
+        self, enforce_tick_size: bool, enforce_lot_size: bool
+    ) -> None:
+        r"""
+        设置期货撮合前校验开关.
+
+        :param enforce_tick_size: 是否启用最小变动价位校验
+        :param enforce_lot_size: 是否启用手数整数倍校验
+        """
+        ...
+
+    def set_futures_validation_options_by_prefix(
+        self,
+        symbol_prefix: str,
+        enforce_tick_size: typing.Optional[bool],
+        enforce_lot_size: typing.Optional[bool],
+    ) -> None:
+        r"""
+        设置期货品种前缀校验开关.
+
+        :param symbol_prefix: 品种前缀 (如 RB, IF)
+        :param enforce_tick_size: 覆盖最小变动价位校验, None 表示沿用默认
+        :param enforce_lot_size: 覆盖手数整数倍校验, None 表示沿用默认
         """
         ...
 

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -25,9 +25,15 @@ from ..akquant import (
     Engine,
     ExecutionMode,
     Instrument,
+    TradingSession,
 )
 from ..analyzer_plugin import AnalyzerManager, AnalyzerPlugin
-from ..config import BacktestConfig, RiskConfig
+from ..config import (
+    BacktestConfig,
+    ChinaFuturesConfig,
+    ChinaFuturesInstrumentTemplateConfig,
+    RiskConfig,
+)
 from ..data import ParquetDataCatalog
 from ..feed_adapter import DataFeedAdapter, FeedSlice
 from ..log import get_logger, register_logger
@@ -81,6 +87,68 @@ def _parse_stream_mode(value: Any) -> str:
 
 def _noop_stream_event_handler(_event: BacktestStreamEvent) -> None:
     return None
+
+
+def _parse_asset_type_name(value: Any) -> str:
+    if isinstance(value, AssetType):
+        if value == AssetType.Futures:
+            return "futures"
+        if value == AssetType.Stock:
+            return "stock"
+        if value == AssetType.Fund:
+            return "fund"
+        if value == AssetType.Option:
+            return "option"
+        return "other"
+    if isinstance(value, str):
+        v_lower = value.lower()
+        if "future" in v_lower:
+            return "futures"
+        if "stock" in v_lower:
+            return "stock"
+        if "fund" in v_lower:
+            return "fund"
+        if "option" in v_lower:
+            return "option"
+    return "stock"
+
+
+def _parse_trading_session(value: Any) -> Any:
+    if isinstance(value, TradingSession):
+        return value
+    call_auction = getattr(
+        TradingSession, "CallAuction", getattr(TradingSession, "Normal", None)
+    )
+    pre_open = getattr(
+        TradingSession, "PreOpen", getattr(TradingSession, "PreMarket", None)
+    )
+    continuous = getattr(
+        TradingSession, "Continuous", getattr(TradingSession, "Normal", None)
+    )
+    break_session = getattr(
+        TradingSession, "Break", getattr(TradingSession, "Normal", None)
+    )
+    post_close = getattr(
+        TradingSession, "PostClose", getattr(TradingSession, "PostMarket", None)
+    )
+    closed = getattr(
+        TradingSession, "Closed", getattr(TradingSession, "PostMarket", None)
+    )
+    v_lower = str(value).strip().lower()
+    mapping = {
+        "call_auction": call_auction,
+        "callauction": call_auction,
+        "pre_open": pre_open,
+        "preopen": pre_open,
+        "continuous": continuous,
+        "break": break_session,
+        "post_close": post_close,
+        "postclose": post_close,
+        "closed": closed,
+    }
+    if v_lower in mapping and mapping[v_lower] is not None:
+        return mapping[v_lower]
+    raise ValueError(f"Unsupported trading session: {value}")
 
 
 def _is_data_feed_adapter(value: Any) -> bool:
@@ -1495,17 +1563,58 @@ def run_backtest(
         engine.set_execution_mode(execution_mode)
 
     # 4.1 市场规则配置
-    # 如果启用了 T+1，必须使用 ChinaMarket
-    if t_plus_one:
-        # T+1 必须使用 ChinaMarket
+    china_futures_config: Optional[ChinaFuturesConfig] = None
+    has_futures_instruments = False
+    has_non_futures_instruments = False
+    if config is not None:
+        china_futures_config = config.china_futures
+        if config.instruments_config:
+            if isinstance(config.instruments_config, list):
+                for inst in config.instruments_config:
+                    asset_name = _parse_asset_type_name(inst.asset_type)
+                    if asset_name == "futures":
+                        has_futures_instruments = True
+                    else:
+                        has_non_futures_instruments = True
+            elif isinstance(config.instruments_config, dict):
+                for inst in config.instruments_config.values():
+                    asset_name = _parse_asset_type_name(inst.asset_type)
+                    if asset_name == "futures":
+                        has_futures_instruments = True
+                    else:
+                        has_non_futures_instruments = True
+    if not has_futures_instruments:
+        default_asset_name = _parse_asset_type_name(
+            kwargs.get("asset_type", AssetType.Stock)
+        )
+        has_futures_instruments = default_asset_name == "futures"
+    if (
+        not has_futures_instruments
+        and china_futures_config
+        and china_futures_config.instrument_templates_by_symbol_prefix
+    ):
+        has_futures_instruments = True
+
+    if china_futures_config and has_futures_instruments:
+        if (
+            not china_futures_config.use_china_futures_market
+            or has_non_futures_instruments
+        ):
+            engine.use_china_market()
+        else:
+            engine.use_china_futures_market()
+        if t_plus_one:
+            engine.set_t_plus_one(True)
+    elif t_plus_one:
         engine.use_china_market()
         engine.set_t_plus_one(True)
     else:
-        # T+0 模式
-        # 使用SimpleMarket（支持佣金率和印花税）
         engine.use_simple_market(commission_rate)
 
-    engine.set_force_session_continuous(True)
+    force_session_continuous = True
+    if china_futures_config and has_futures_instruments:
+        force_session_continuous = not china_futures_config.enforce_sessions
+    engine.set_force_session_continuous(force_session_continuous)
     # 无论使用 SimpleMarket 还是 ChinaMarket，set_stock_fee_rules 都能正确配置费率
     engine.set_stock_fee_rules(
         commission_rate, stamp_tax_rate, transfer_fee_rate, min_commission
@@ -1537,6 +1646,95 @@ def run_backtest(
 
     if "option_commission" in kwargs:
         engine.set_option_fee_rules(kwargs["option_commission"])
+
+    if china_futures_config and has_futures_instruments:
+        template_validation_by_prefix: Dict[
+            str, Tuple[Optional[bool], Optional[bool]]
+        ] = {}
+        template_fee_by_prefix: Dict[str, float] = {}
+        if china_futures_config.instrument_templates_by_symbol_prefix:
+            for template in china_futures_config.instrument_templates_by_symbol_prefix:
+                prefix = template.symbol_prefix.strip().upper()
+                if not prefix:
+                    continue
+                if template.commission_rate is not None:
+                    template_fee_by_prefix[prefix] = float(template.commission_rate)
+                if (
+                    template.enforce_tick_size is not None
+                    or template.enforce_lot_size is not None
+                ):
+                    template_validation_by_prefix[prefix] = (
+                        template.enforce_tick_size,
+                        template.enforce_lot_size,
+                    )
+
+        if hasattr(engine, "set_futures_validation_options"):
+            cast(Any, engine).set_futures_validation_options(
+                bool(china_futures_config.enforce_tick_size),
+                bool(china_futures_config.enforce_lot_size),
+            )
+        else:
+            logger.warning(
+                "set_futures_validation_options is not available "
+                "in current engine binary"
+            )
+        merged_validation_by_prefix = dict(template_validation_by_prefix)
+        if china_futures_config.validation_by_symbol_prefix:
+            for validation_rule in china_futures_config.validation_by_symbol_prefix:
+                prefix = validation_rule.symbol_prefix.strip().upper()
+                if not prefix:
+                    continue
+                merged_validation_by_prefix[prefix] = (
+                    validation_rule.enforce_tick_size,
+                    validation_rule.enforce_lot_size,
+                )
+        if merged_validation_by_prefix:
+            for prefix, (tick_opt, lot_opt) in merged_validation_by_prefix.items():
+                if hasattr(engine, "set_futures_validation_options_by_prefix"):
+                    cast(Any, engine).set_futures_validation_options_by_prefix(
+                        prefix,
+                        tick_opt,
+                        lot_opt,
+                    )
+                else:
+                    logger.warning(
+                        "set_futures_validation_options_by_prefix is not available "
+                        "in current engine binary"
+                    )
+                    break
+
+        merged_fee_by_prefix = dict(template_fee_by_prefix)
+        if china_futures_config.fee_by_symbol_prefix:
+            for fee_rule in china_futures_config.fee_by_symbol_prefix:
+                prefix = fee_rule.symbol_prefix.strip().upper()
+                if not prefix:
+                    continue
+                merged_fee_by_prefix[prefix] = float(fee_rule.commission_rate)
+        if merged_fee_by_prefix:
+            for prefix, commission_rate_value in merged_fee_by_prefix.items():
+                if hasattr(engine, "set_futures_fee_rules_by_prefix"):
+                    cast(Any, engine).set_futures_fee_rules_by_prefix(
+                        prefix,
+                        commission_rate_value,
+                    )
+                else:
+                    logger.warning(
+                        "set_futures_fee_rules_by_prefix is not available "
+                        "in current engine binary"
+                    )
+                    break
+        if china_futures_config.sessions:
+            session_ranges: List[Tuple[str, str, TradingSession]] = []
+            for session_rule in china_futures_config.sessions:
+                session_ranges.append(
+                    (
+                        session_rule.start,
+                        session_rule.end,
+                        _parse_trading_session(session_rule.session),
+                    )
+                )
+            if session_ranges:
+                engine.set_market_sessions(session_ranges)
 
     # Apply Risk Config
 
@@ -1667,6 +1865,26 @@ def run_backtest(
                 pass
         return None
 
+    def _match_futures_template(
+        symbol: str,
+    ) -> Optional[ChinaFuturesInstrumentTemplateConfig]:
+        if (
+            china_futures_config is None
+            or not china_futures_config.instrument_templates_by_symbol_prefix
+        ):
+            return None
+        symbol_upper = symbol.upper()
+        best_template: Optional[ChinaFuturesInstrumentTemplateConfig] = None
+        best_len = 0
+        for tpl in china_futures_config.instrument_templates_by_symbol_prefix:
+            prefix = tpl.symbol_prefix.strip().upper()
+            if not prefix:
+                continue
+            if symbol_upper.startswith(prefix) and len(prefix) > best_len:
+                best_template = tpl
+                best_len = len(prefix)
+        return best_template
+
     for sym in symbols:
         # Priority: Pre-built Instrument > Config > Default
         if sym in prebuilt_instruments:
@@ -1682,6 +1900,7 @@ def run_backtest(
 
         # Check specific config
         i_conf = inst_conf_map.get(sym)
+        futures_template = _match_futures_template(sym)
 
         if i_conf:
             p_asset_type = _parse_asset_type(i_conf.asset_type)
@@ -1689,18 +1908,57 @@ def run_backtest(
             p_margin = i_conf.margin_ratio
             p_tick = i_conf.tick_size
             # If config has lot_size, use it, otherwise use global setting
-            p_lot = i_conf.lot_size if i_conf.lot_size != 1 else (current_lot_size or 1)
+            p_lot = (
+                i_conf.lot_size
+                if i_conf.lot_size != 1
+                else float(current_lot_size or 1.0)
+            )
+            if futures_template and p_asset_type == AssetType.Futures:
+                if i_conf.multiplier == 1 and futures_template.multiplier is not None:
+                    p_multiplier = futures_template.multiplier
+                if (
+                    i_conf.margin_ratio == 1
+                    and futures_template.margin_ratio is not None
+                ):
+                    p_margin = futures_template.margin_ratio
+                if i_conf.tick_size == 0.01 and futures_template.tick_size is not None:
+                    p_tick = futures_template.tick_size
+                if i_conf.lot_size == 1 and futures_template.lot_size is not None:
+                    p_lot = futures_template.lot_size
 
             p_opt_type = _parse_option_type(i_conf.option_type)
             p_strike = i_conf.strike_price
             p_expiry = _parse_expiry(i_conf.expiry_date)
             p_underlying = i_conf.underlying_symbol
         else:
-            p_asset_type = default_asset_type
-            p_multiplier = default_multiplier
-            p_margin = default_margin_ratio
-            p_tick = default_tick_size
-            p_lot = current_lot_size or 1
+            if futures_template:
+                p_asset_type = AssetType.Futures
+                p_multiplier = (
+                    futures_template.multiplier
+                    if futures_template.multiplier is not None
+                    else default_multiplier
+                )
+                p_margin = (
+                    futures_template.margin_ratio
+                    if futures_template.margin_ratio is not None
+                    else default_margin_ratio
+                )
+                p_tick = (
+                    futures_template.tick_size
+                    if futures_template.tick_size is not None
+                    else default_tick_size
+                )
+                p_lot = (
+                    futures_template.lot_size
+                    if futures_template.lot_size is not None
+                    else float(current_lot_size or 1.0)
+                )
+            else:
+                p_asset_type = default_asset_type
+                p_multiplier = default_multiplier
+                p_margin = default_margin_ratio
+                p_tick = default_tick_size
+                p_lot = float(current_lot_size or 1.0)
 
             p_opt_type = default_option_type
             p_strike = default_strike_price

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -119,6 +119,135 @@ class InstrumentConfig:
 
 
 @dataclass
+class ChinaFuturesFeeConfig:
+    """中国期货费率配置."""
+
+    symbol_prefix: str
+    commission_rate: float
+
+    def __post_init__(self) -> None:
+        """Validate and normalize fee config."""
+        self.symbol_prefix = self.symbol_prefix.strip().upper()
+        if not self.symbol_prefix:
+            raise ValueError("symbol_prefix must not be empty")
+        if self.commission_rate < 0:
+            raise ValueError("commission_rate must be >= 0")
+
+
+@dataclass
+class ChinaFuturesSessionConfig:
+    """中国期货交易时段配置."""
+
+    start: str
+    end: str
+    session: str = "continuous"
+
+
+@dataclass
+class ChinaFuturesValidationConfig:
+    """中国期货校验开关配置."""
+
+    symbol_prefix: str
+    enforce_tick_size: Optional[bool] = None
+    enforce_lot_size: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize validation switch config."""
+        self.symbol_prefix = self.symbol_prefix.strip().upper()
+        if not self.symbol_prefix:
+            raise ValueError("symbol_prefix must not be empty")
+        if self.enforce_tick_size is None and self.enforce_lot_size is None:
+            raise ValueError(
+                "must set enforce_tick_size or enforce_lot_size "
+                "in ChinaFuturesValidationConfig"
+            )
+
+
+@dataclass
+class ChinaFuturesInstrumentTemplateConfig:
+    """中国期货品种模板配置."""
+
+    symbol_prefix: str
+    multiplier: Optional[float] = None
+    margin_ratio: Optional[float] = None
+    tick_size: Optional[float] = None
+    lot_size: Optional[float] = None
+    commission_rate: Optional[float] = None
+    enforce_tick_size: Optional[bool] = None
+    enforce_lot_size: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize template config."""
+        self.symbol_prefix = self.symbol_prefix.strip().upper()
+        if not self.symbol_prefix:
+            raise ValueError("symbol_prefix must not be empty")
+        if self.multiplier is not None and self.multiplier <= 0:
+            raise ValueError("multiplier must be > 0")
+        if self.margin_ratio is not None and self.margin_ratio <= 0:
+            raise ValueError("margin_ratio must be > 0")
+        if self.tick_size is not None and self.tick_size <= 0:
+            raise ValueError("tick_size must be > 0")
+        if self.lot_size is not None and self.lot_size <= 0:
+            raise ValueError("lot_size must be > 0")
+        if self.commission_rate is not None and self.commission_rate < 0:
+            raise ValueError("commission_rate must be >= 0")
+
+
+@dataclass
+class ChinaFuturesConfig:
+    """中国期货增强配置."""
+
+    enforce_sessions: bool = True
+    use_china_futures_market: bool = True
+    enforce_tick_size: bool = True
+    enforce_lot_size: bool = True
+    fee_by_symbol_prefix: Optional[List[ChinaFuturesFeeConfig]] = None
+    validation_by_symbol_prefix: Optional[List[ChinaFuturesValidationConfig]] = None
+    instrument_templates_by_symbol_prefix: Optional[
+        List[ChinaFuturesInstrumentTemplateConfig]
+    ] = None
+    sessions: Optional[List[ChinaFuturesSessionConfig]] = None
+
+    def __post_init__(self) -> None:
+        """Validate duplicate prefixes across config lists."""
+        if self.fee_by_symbol_prefix:
+            seen_fee: Dict[str, int] = {}
+            for idx, fee in enumerate(self.fee_by_symbol_prefix):
+                if fee.symbol_prefix in seen_fee:
+                    prev_idx = seen_fee[fee.symbol_prefix]
+                    raise ValueError(
+                        "fee_by_symbol_prefix"
+                        f"[{idx}] duplicates symbol_prefix '{fee.symbol_prefix}' "
+                        f"already used at fee_by_symbol_prefix[{prev_idx}]"
+                    )
+                seen_fee[fee.symbol_prefix] = idx
+        if self.validation_by_symbol_prefix:
+            seen_validation: Dict[str, int] = {}
+            for idx, rule in enumerate(self.validation_by_symbol_prefix):
+                if rule.symbol_prefix in seen_validation:
+                    prev_idx = seen_validation[rule.symbol_prefix]
+                    raise ValueError(
+                        "validation_by_symbol_prefix"
+                        f"[{idx}] duplicates symbol_prefix '{rule.symbol_prefix}' "
+                        "already used at "
+                        f"validation_by_symbol_prefix[{prev_idx}]"
+                    )
+                seen_validation[rule.symbol_prefix] = idx
+        if self.instrument_templates_by_symbol_prefix:
+            seen_template: Dict[str, int] = {}
+            for idx, template in enumerate(self.instrument_templates_by_symbol_prefix):
+                if template.symbol_prefix in seen_template:
+                    prev_idx = seen_template[template.symbol_prefix]
+                    raise ValueError(
+                        "instrument_templates_by_symbol_prefix"
+                        f"[{idx}] duplicates symbol_prefix "
+                        f"'{template.symbol_prefix}' already used at "
+                        f"instrument_templates_by_symbol_prefix[{prev_idx}]"
+                    )
+                seen_template[template.symbol_prefix] = idx
+
+
+@dataclass
 class RiskConfig:
     """
     [Risk Level] Configuration for Risk Management.
@@ -293,6 +422,7 @@ class BacktestConfig:
     instruments_config: Optional[
         Union[List[InstrumentConfig], Dict[str, InstrumentConfig]]
     ] = None  # Detailed props (Overrides defaults)
+    china_futures: Optional[ChinaFuturesConfig] = None
 
     benchmark: Optional[str] = None
     timezone: str = "Asia/Shanghai"

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -58,7 +58,7 @@ mod tests {
         // We can verify via commission calculation if we had a way to invoke it without full run.
 
         // Let's at least verify future fee rules
-        engine.set_future_fee_rules(0.0005);
+        engine.set_futures_fee_rules(0.0005);
     }
 
     #[test]

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -726,8 +726,35 @@ impl Engine {
     /// 设置期货费率规则
     ///
     /// :param commission_rate: 佣金率 (如 0.0001)
-    pub fn set_future_fee_rules(&mut self, commission_rate: f64) {
-        self.market_manager.set_future_fee_rules(commission_rate);
+    pub fn set_futures_fee_rules(&mut self, commission_rate: f64) {
+        self.market_manager.set_futures_fee_rules(commission_rate);
+    }
+
+    pub fn set_futures_fee_rules_by_prefix(
+        &mut self,
+        symbol_prefix: String,
+        commission_rate: f64,
+    ) {
+        self.market_manager
+            .set_futures_fee_rules_by_prefix(symbol_prefix, commission_rate);
+    }
+
+    fn set_futures_validation_options(&mut self, enforce_tick_size: bool, enforce_lot_size: bool) {
+        self.execution_model
+            .set_futures_validation_options(enforce_tick_size, enforce_lot_size);
+    }
+
+    fn set_futures_validation_options_by_prefix(
+        &mut self,
+        symbol_prefix: String,
+        enforce_tick_size: Option<bool>,
+        enforce_lot_size: Option<bool>,
+    ) {
+        self.execution_model.set_futures_validation_options_by_prefix(
+            symbol_prefix,
+            enforce_tick_size,
+            enforce_lot_size,
+        );
     }
 
     /// 设置基金费率规则

--- a/src/execution/futures.rs
+++ b/src/execution/futures.rs
@@ -1,25 +1,370 @@
 use crate::event::Event;
 use crate::execution::common::CommonMatcher;
 use crate::execution::matcher::{ExecutionMatcher, MatchContext};
-use crate::model::Order;
+use crate::model::{Order, OrderStatus, OrderType};
+use rust_decimal::Decimal;
 
-pub struct FuturesMatcher;
+pub struct FuturesMatcher {
+    default_enforce_tick_size: bool,
+    default_enforce_lot_size: bool,
+    validation_by_prefix: Vec<(String, Option<bool>, Option<bool>)>,
+}
+
+impl FuturesMatcher {
+    pub fn new(enforce_tick_size: bool, enforce_lot_size: bool) -> Self {
+        Self {
+            default_enforce_tick_size: enforce_tick_size,
+            default_enforce_lot_size: enforce_lot_size,
+            validation_by_prefix: Vec::new(),
+        }
+    }
+
+    pub fn with_prefix_rules(
+        enforce_tick_size: bool,
+        enforce_lot_size: bool,
+        validation_by_prefix: Vec<(String, Option<bool>, Option<bool>)>,
+    ) -> Self {
+        Self {
+            default_enforce_tick_size: enforce_tick_size,
+            default_enforce_lot_size: enforce_lot_size,
+            validation_by_prefix,
+        }
+    }
+
+    fn reject(order: &mut Order, ctx: &MatchContext, reason: String) -> Option<Event> {
+        order.status = OrderStatus::Rejected;
+        order.reject_reason = reason;
+        match ctx.event {
+            Event::Bar(b) => order.updated_at = b.timestamp,
+            Event::Tick(t) => order.updated_at = t.timestamp,
+            _ => {}
+        }
+        Some(Event::ExecutionReport(order.clone(), None))
+    }
+
+    fn is_multiple(value: Decimal, step: Decimal) -> bool {
+        if step <= Decimal::ZERO {
+            return true;
+        }
+        value % step == Decimal::ZERO
+    }
+
+    fn validation_flags_for_symbol(&self, symbol: &str) -> (bool, bool) {
+        let mut enforce_tick_size = self.default_enforce_tick_size;
+        let mut enforce_lot_size = self.default_enforce_lot_size;
+        let mut best_match_len = 0usize;
+        let symbol_upper = symbol.to_uppercase();
+        for (prefix, tick_opt, lot_opt) in &self.validation_by_prefix {
+            let normalized = prefix.trim().to_uppercase();
+            if normalized.is_empty() {
+                continue;
+            }
+            if symbol_upper.starts_with(&normalized) && normalized.len() > best_match_len {
+                if let Some(tick) = tick_opt {
+                    enforce_tick_size = *tick;
+                }
+                if let Some(lot) = lot_opt {
+                    enforce_lot_size = *lot;
+                }
+                best_match_len = normalized.len();
+            }
+        }
+        (enforce_tick_size, enforce_lot_size)
+    }
+
+    fn validate_order(&self, order: &mut Order, ctx: &MatchContext) -> Option<Event> {
+        let (enforce_tick_size, enforce_lot_size) =
+            self.validation_flags_for_symbol(ctx.instrument.symbol());
+        let lot_size = ctx.instrument.lot_size();
+        if enforce_lot_size
+            && lot_size > Decimal::ZERO
+            && !Self::is_multiple(order.quantity, lot_size)
+        {
+            return Self::reject(
+                order,
+                ctx,
+                format!(
+                    "Quantity {} is not a multiple of lot size {}",
+                    order.quantity, lot_size
+                ),
+            );
+        }
+
+        let tick_size = ctx.instrument.tick_size();
+        if !enforce_tick_size || tick_size <= Decimal::ZERO {
+            return None;
+        }
+
+        let mut prices_to_check: Vec<(&str, Decimal)> = Vec::new();
+        match order.order_type {
+            OrderType::Limit => {
+                if let Some(price) = order.price {
+                    prices_to_check.push(("price", price));
+                }
+            }
+            OrderType::StopMarket => {
+                if let Some(trigger_price) = order.trigger_price {
+                    prices_to_check.push(("trigger_price", trigger_price));
+                }
+            }
+            OrderType::StopLimit => {
+                if let Some(price) = order.price {
+                    prices_to_check.push(("price", price));
+                }
+                if let Some(trigger_price) = order.trigger_price {
+                    prices_to_check.push(("trigger_price", trigger_price));
+                }
+            }
+            OrderType::StopTrail => {
+                if let Some(trigger_price) = order.trigger_price {
+                    prices_to_check.push(("trigger_price", trigger_price));
+                }
+                if let Some(trail_offset) = order.trail_offset {
+                    prices_to_check.push(("trail_offset", trail_offset));
+                }
+            }
+            OrderType::StopTrailLimit => {
+                if let Some(price) = order.price {
+                    prices_to_check.push(("price", price));
+                }
+                if let Some(trigger_price) = order.trigger_price {
+                    prices_to_check.push(("trigger_price", trigger_price));
+                }
+                if let Some(trail_offset) = order.trail_offset {
+                    prices_to_check.push(("trail_offset", trail_offset));
+                }
+            }
+            _ => {}
+        }
+
+        for (field_name, value) in prices_to_check {
+            if !Self::is_multiple(value, tick_size) {
+                return Self::reject(
+                    order,
+                    ctx,
+                    format!(
+                        "{} {} is not aligned with tick size {}",
+                        field_name, value, tick_size
+                    ),
+                );
+            }
+        }
+        None
+    }
+}
 
 impl ExecutionMatcher for FuturesMatcher {
     fn match_order(&self, order: &mut Order, ctx: &MatchContext) -> Option<Event> {
-        // Futures specific logic
-        // Futures typically allow fractional lot sizes or just 1 contract.
-        // We usually don't enforce "Round Lot" for futures in the same way as Stocks (Buy Only 100).
-        // So check_lot_size = false, or true if we want strict multiples of lot_size (usually 1).
-        // Let's set true but assuming lot_size is 1 for futures, or strict multiple check is desired.
-        // Actually, for futures, `quantity` must be integer multiple of `lot_size` (usually 1).
-        // Unlike stocks where you can sell 1 share (odd lot) but buy 100.
-        // Let's assume strict check for both sides? CommonMatcher only checks Buy side if check_lot_size=true.
-        // So for futures, we might want custom check or just rely on CommonMatcher's Buy check if lot_size=1.
+        if let Some(report) = self.validate_order(order, ctx) {
+            return Some(report);
+        }
+        CommonMatcher::match_order(order, ctx, false)
+    }
+}
 
-        CommonMatcher::match_order(
-            order, ctx,
-            false, // Don't enforce "Buy Only Lot Size" rule specific to A-shares. Futures can buy/sell any integer lot.
-        )
+impl Default for FuturesMatcher {
+    fn default() -> Self {
+        Self::new(true, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::instrument::{FuturesInstrument, InstrumentEnum};
+    use crate::model::{
+        AssetType, ExecutionMode, Instrument, OrderRole, OrderSide, TimeInForce,
+    };
+    use rust_decimal::prelude::FromStr;
+    use rust_decimal_macros::dec;
+
+    fn create_futures_instrument() -> Instrument {
+        Instrument {
+            asset_type: AssetType::Futures,
+            inner: InstrumentEnum::Futures(FuturesInstrument {
+                symbol: "RB2310".to_string(),
+                multiplier: dec!(10),
+                margin_ratio: dec!(0.1),
+                tick_size: dec!(0.2),
+                expiry_date: None,
+                settlement_type: None,
+            }),
+        }
+    }
+
+    fn create_order(side: OrderSide) -> Order {
+        Order {
+            id: "1".to_string(),
+            symbol: "RB2310".to_string(),
+            side,
+            order_type: OrderType::Limit,
+            quantity: dec!(1),
+            price: Some(dec!(3500.0)),
+            trigger_price: None,
+            trail_offset: None,
+            trail_reference_price: None,
+            graph_id: None,
+            parent_order_id: None,
+            order_role: OrderRole::Standalone,
+            status: OrderStatus::New,
+            filled_quantity: Decimal::ZERO,
+            average_filled_price: None,
+            time_in_force: TimeInForce::Day,
+            created_at: 0,
+            updated_at: 0,
+            commission: Decimal::ZERO,
+            tag: String::new(),
+            reject_reason: String::new(),
+            owner_strategy_id: None,
+        }
+    }
+
+    fn create_context<'a>(
+        event: &'a Event,
+        instrument: &'a Instrument,
+    ) -> crate::execution::matcher::MatchContext<'a> {
+        crate::execution::matcher::MatchContext {
+            event,
+            instrument,
+            execution_mode: ExecutionMode::NextOpen,
+            slippage: &crate::execution::slippage::ZeroSlippage,
+            volume_limit_pct: Decimal::ZERO,
+            bar_index: 0,
+        }
+    }
+
+    #[test]
+    fn test_futures_reject_non_multiple_lot_size_for_sell() {
+        let matcher = FuturesMatcher::default();
+        let mut order = create_order(OrderSide::Sell);
+        order.quantity = Decimal::from_str("1.5").unwrap();
+        let instrument = create_futures_instrument();
+        let bar = crate::model::Bar {
+            timestamp: 100,
+            symbol: "RB2310".to_string(),
+            open: dec!(3500.0),
+            high: dec!(3510.0),
+            low: dec!(3490.0),
+            close: dec!(3505.0),
+            volume: dec!(1000),
+            extra: Default::default(),
+        };
+        let event = Event::Bar(bar);
+        let ctx = create_context(&event, &instrument);
+        let res = matcher.match_order(&mut order, &ctx);
+        assert!(res.is_some());
+        assert_eq!(order.status, OrderStatus::Rejected);
+        assert!(order.reject_reason.contains("lot size"));
+    }
+
+    #[test]
+    fn test_futures_reject_non_tick_aligned_limit_price() {
+        let matcher = FuturesMatcher::default();
+        let mut order = create_order(OrderSide::Buy);
+        order.price = Some(dec!(3500.1));
+        let instrument = create_futures_instrument();
+        let tick = crate::model::Tick {
+            timestamp: 100,
+            price: dec!(3500.0),
+            volume: dec!(10),
+            symbol: "RB2310".to_string(),
+        };
+        let event = Event::Tick(tick);
+        let ctx = create_context(&event, &instrument);
+        let res = matcher.match_order(&mut order, &ctx);
+        assert!(res.is_some());
+        assert_eq!(order.status, OrderStatus::Rejected);
+        assert!(order.reject_reason.contains("tick size"));
+    }
+
+    #[test]
+    fn test_futures_accept_tick_aligned_prices() {
+        let matcher = FuturesMatcher::default();
+        let mut order = create_order(OrderSide::Buy);
+        order.order_type = OrderType::StopLimit;
+        order.price = Some(dec!(3500.2));
+        order.trigger_price = Some(dec!(3501.0));
+        let instrument = create_futures_instrument();
+        let bar = crate::model::Bar {
+            timestamp: 100,
+            symbol: "RB2310".to_string(),
+            open: dec!(3501.0),
+            high: dec!(3510.0),
+            low: dec!(3490.0),
+            close: dec!(3505.0),
+            volume: dec!(1000),
+            extra: Default::default(),
+        };
+        let event = Event::Bar(bar);
+        let ctx = create_context(&event, &instrument);
+        let _ = matcher.match_order(&mut order, &ctx);
+        assert_ne!(order.status, OrderStatus::Rejected);
+    }
+
+    #[test]
+    fn test_futures_can_disable_tick_validation() {
+        let matcher = FuturesMatcher::new(false, true);
+        let mut order = create_order(OrderSide::Buy);
+        order.price = Some(dec!(3500.1));
+        let instrument = create_futures_instrument();
+        let tick = crate::model::Tick {
+            timestamp: 100,
+            price: dec!(3500.0),
+            volume: dec!(10),
+            symbol: "RB2310".to_string(),
+        };
+        let event = Event::Tick(tick);
+        let ctx = create_context(&event, &instrument);
+        let _ = matcher.match_order(&mut order, &ctx);
+        assert_ne!(order.status, OrderStatus::Rejected);
+    }
+
+    #[test]
+    fn test_futures_can_disable_lot_validation() {
+        let matcher = FuturesMatcher::new(true, false);
+        let mut order = create_order(OrderSide::Sell);
+        order.quantity = Decimal::from_str("1.5").unwrap();
+        let instrument = create_futures_instrument();
+        let bar = crate::model::Bar {
+            timestamp: 100,
+            symbol: "RB2310".to_string(),
+            open: dec!(3500.0),
+            high: dec!(3510.0),
+            low: dec!(3490.0),
+            close: dec!(3505.0),
+            volume: dec!(1000),
+            extra: Default::default(),
+        };
+        let event = Event::Bar(bar);
+        let ctx = create_context(&event, &instrument);
+        let _ = matcher.match_order(&mut order, &ctx);
+        assert_ne!(order.status, OrderStatus::Rejected);
+    }
+
+    #[test]
+    fn test_futures_prefix_rules_override_default_validation() {
+        let matcher = FuturesMatcher::with_prefix_rules(
+            true,
+            true,
+            vec![("RB".to_string(), Some(false), Some(false))],
+        );
+        let mut order = create_order(OrderSide::Sell);
+        order.quantity = Decimal::from_str("1.5").unwrap();
+        order.price = Some(dec!(3500.1));
+        let instrument = create_futures_instrument();
+        let bar = crate::model::Bar {
+            timestamp: 100,
+            symbol: "RB2310".to_string(),
+            open: dec!(3500.0),
+            high: dec!(3510.0),
+            low: dec!(3490.0),
+            close: dec!(3505.0),
+            volume: dec!(1000),
+            extra: Default::default(),
+        };
+        let event = Event::Bar(bar);
+        let ctx = create_context(&event, &instrument);
+        let _ = matcher.match_order(&mut order, &ctx);
+        assert_ne!(order.status, OrderStatus::Rejected);
     }
 }

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -46,6 +46,21 @@ pub trait ExecutionClient: Send + Sync {
     ) {
     }
 
+    fn set_futures_validation_options(
+        &mut self,
+        _enforce_tick_size: bool,
+        _enforce_lot_size: bool,
+    ) {
+    }
+
+    fn set_futures_validation_options_by_prefix(
+        &mut self,
+        _symbol_prefix: String,
+        _enforce_tick_size: Option<bool>,
+        _enforce_lot_size: Option<bool>,
+    ) {
+    }
+
     /// 是否为实盘模式
     #[allow(dead_code)]
     fn is_live(&self) -> bool {

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -18,14 +18,35 @@ pub struct SimulatedExecutionClient {
     order_queue: Vec<String>,
     // Matchers
     matchers: HashMap<AssetType, Box<dyn ExecutionMatcher>>,
+    futures_enforce_tick_size: bool,
+    futures_enforce_lot_size: bool,
+    futures_validation_by_prefix: Vec<(String, Option<bool>, Option<bool>)>,
 }
 
 impl SimulatedExecutionClient {
+    fn rebuild_futures_matcher(&mut self) {
+        self.matchers.insert(
+            AssetType::Futures,
+            Box::new(futures::FuturesMatcher::with_prefix_rules(
+                self.futures_enforce_tick_size,
+                self.futures_enforce_lot_size,
+                self.futures_validation_by_prefix.clone(),
+            )),
+        );
+    }
+
     pub fn new() -> Self {
         let mut matchers: HashMap<AssetType, Box<dyn ExecutionMatcher>> = HashMap::new();
         matchers.insert(AssetType::Stock, Box::new(stock::StockMatcher));
         matchers.insert(AssetType::Fund, Box::new(stock::StockMatcher)); // Fund uses StockMatcher
-        matchers.insert(AssetType::Futures, Box::new(futures::FuturesMatcher));
+        matchers.insert(
+            AssetType::Futures,
+            Box::new(futures::FuturesMatcher::with_prefix_rules(
+                true,
+                true,
+                Vec::new(),
+            )),
+        );
         matchers.insert(AssetType::Option, Box::new(option::OptionMatcher));
         matchers.insert(AssetType::Crypto, Box::new(crypto::CryptoMatcher));
         matchers.insert(AssetType::Forex, Box::new(forex::ForexMatcher));
@@ -36,6 +57,9 @@ impl SimulatedExecutionClient {
             orders: HashMap::new(),
             order_queue: Vec::new(),
             matchers,
+            futures_enforce_tick_size: true,
+            futures_enforce_lot_size: true,
+            futures_validation_by_prefix: Vec::new(),
         }
     }
 }
@@ -60,6 +84,42 @@ impl ExecutionClient for SimulatedExecutionClient {
 
     fn register_matcher(&mut self, asset_type: AssetType, matcher: Box<dyn ExecutionMatcher>) {
         self.matchers.insert(asset_type, matcher);
+    }
+
+    fn set_futures_validation_options(
+        &mut self,
+        enforce_tick_size: bool,
+        enforce_lot_size: bool,
+    ) {
+        self.futures_enforce_tick_size = enforce_tick_size;
+        self.futures_enforce_lot_size = enforce_lot_size;
+        self.rebuild_futures_matcher();
+    }
+
+    fn set_futures_validation_options_by_prefix(
+        &mut self,
+        symbol_prefix: String,
+        enforce_tick_size: Option<bool>,
+        enforce_lot_size: Option<bool>,
+    ) {
+        let normalized = symbol_prefix.trim().to_uppercase();
+        if normalized.is_empty() {
+            return;
+        }
+        let mut updated = false;
+        for (prefix, tick_opt, lot_opt) in &mut self.futures_validation_by_prefix {
+            if prefix == &normalized {
+                *tick_opt = enforce_tick_size;
+                *lot_opt = enforce_lot_size;
+                updated = true;
+                break;
+            }
+        }
+        if !updated {
+            self.futures_validation_by_prefix
+                .push((normalized, enforce_tick_size, enforce_lot_size));
+        }
+        self.rebuild_futures_matcher();
     }
 
     fn on_order(&mut self, order: Order) {

--- a/src/market/china.rs
+++ b/src/market/china.rs
@@ -20,6 +20,7 @@ pub struct ChinaMarketConfig {
     pub fund: Option<fund::FundConfig>,
     pub option: Option<option::OptionConfig>,
     pub sessions: Vec<SessionRange>,
+    pub futures_fee_by_prefix: Vec<(String, futures::FuturesConfig)>,
 }
 
 fn default_sessions() -> Vec<SessionRange> {
@@ -72,6 +73,7 @@ impl Default for ChinaMarketConfig {
             fund: None,
             option: None,
             sessions: default_sessions(),
+            futures_fee_by_prefix: Vec::new(),
         }
     }
 }
@@ -95,6 +97,23 @@ impl ChinaMarket {
     }
     pub fn from_config(config: ChinaMarketConfig) -> Self {
         Self { config }
+    }
+
+    fn futures_config_for_symbol(&self, symbol: &str) -> Option<&futures::FuturesConfig> {
+        let mut best_match: Option<&futures::FuturesConfig> = None;
+        let mut best_len = 0usize;
+        let symbol_upper = symbol.to_uppercase();
+        for (prefix, cfg) in &self.config.futures_fee_by_prefix {
+            let normalized = prefix.trim().to_uppercase();
+            if normalized.is_empty() {
+                continue;
+            }
+            if symbol_upper.starts_with(&normalized) && normalized.len() > best_len {
+                best_match = Some(cfg);
+                best_len = normalized.len();
+            }
+        }
+        best_match
     }
 }
 
@@ -131,7 +150,10 @@ impl MarketModel for ChinaMarket {
                 }
             }
             AssetType::Futures => {
-                if let Some(config) = &self.config.futures {
+                if let Some(config) = self
+                    .futures_config_for_symbol(instrument.symbol())
+                    .or(self.config.futures.as_ref())
+                {
                     futures::calculate_commission(
                         config,
                         instrument,

--- a/src/market/manager.rs
+++ b/src/market/manager.rs
@@ -122,12 +122,41 @@ impl MarketManager {
     /// 设置期货费率规则
     ///
     /// :param commission_rate: 佣金率 (如 0.0001)
-    pub fn set_future_fee_rules(&mut self, commission_rate: f64) {
+    pub fn set_futures_fee_rules(&mut self, commission_rate: f64) {
         if let MarketConfig::China(ref mut c) = self.config {
             let futures = c
                 .futures
                 .get_or_insert_with(futures::FuturesConfig::default);
             futures.commission_rate = Decimal::from_f64(commission_rate).unwrap_or(Decimal::ZERO);
+            self.model = self.config.create_model();
+        }
+    }
+
+    pub fn set_futures_fee_rules_by_prefix(
+        &mut self,
+        symbol_prefix: String,
+        commission_rate: f64,
+    ) {
+        if let MarketConfig::China(ref mut c) = self.config {
+            let prefix = symbol_prefix.trim().to_uppercase();
+            if prefix.is_empty() {
+                return;
+            }
+            let mut updated = false;
+            for (existing_prefix, cfg) in &mut c.futures_fee_by_prefix {
+                if existing_prefix == &prefix {
+                    cfg.commission_rate =
+                        Decimal::from_f64(commission_rate).unwrap_or(Decimal::ZERO);
+                    updated = true;
+                    break;
+                }
+            }
+            if !updated {
+                let cfg = futures::FuturesConfig {
+                    commission_rate: Decimal::from_f64(commission_rate).unwrap_or(Decimal::ZERO),
+                };
+                c.futures_fee_by_prefix.push((prefix, cfg));
+            }
             self.model = self.config.create_model();
         }
     }

--- a/src/market/mod.rs
+++ b/src/market/mod.rs
@@ -80,4 +80,40 @@ mod tests {
             Decimal::from(1),
         );
     }
+
+    #[test]
+    fn test_china_market_futures_fee_by_prefix() {
+        let mut config = ChinaMarketConfig {
+            futures: Some(futures::FuturesConfig::default()),
+            ..Default::default()
+        };
+        config.futures_fee_by_prefix.push((
+            "RB".to_string(),
+            futures::FuturesConfig {
+                commission_rate: Decimal::from_str("0.0005").unwrap(),
+            },
+        ));
+
+        let market = ChinaMarket::from_config(config);
+        use crate::model::instrument::{FuturesInstrument, InstrumentEnum};
+        let instr = Instrument {
+            asset_type: AssetType::Futures,
+            inner: InstrumentEnum::Futures(FuturesInstrument {
+                symbol: "RB2310".to_string(),
+                multiplier: Decimal::from(10),
+                tick_size: Decimal::from_str("1").unwrap(),
+                margin_ratio: Decimal::from_str("0.1").unwrap(),
+                expiry_date: None,
+                settlement_type: None,
+            }),
+        };
+
+        let commission = market.calculate_commission(
+            &instr,
+            OrderSide::Buy,
+            Decimal::from(3500),
+            Decimal::from(2),
+        );
+        assert_eq!(commission, Decimal::from_str("35").unwrap());
+    }
 }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2262,3 +2262,285 @@ def test_run_backtest_analyzer_plugins_multi_slot_owner_context() -> None:
     assert "owner_aware" in outputs
     assert outputs["owner_aware"]["bar_owner_ids"] == ["alpha", "beta"]
     assert outputs["owner_aware"]["trade_owner_ids"] == ["alpha", "beta"]
+
+
+def test_run_backtest_china_futures_validation_prefix_override() -> None:
+    """Prefix validation config should override default futures lot validation."""
+    probe = akquant.Engine()
+    if not hasattr(probe, "set_futures_validation_options_by_prefix"):
+        pytest.skip("Engine binary does not expose futures prefix validation methods")
+
+    class FractionalFuturesBuyStrategy(akquant.Strategy):
+        def __init__(self) -> None:
+            super().__init__()
+            self._submitted = False
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            if self._submitted:
+                return
+            self.buy(symbol=bar.symbol, quantity=1.5)
+            self._submitted = True
+
+    symbol = "RB2310"
+    bars = _build_regression_bars(symbol)
+    config_reject = akquant.BacktestConfig(
+        strategy_config=akquant.StrategyConfig(initial_cash=1_000_000.0),
+        instruments_config=[
+            akquant.InstrumentConfig(
+                symbol=symbol,
+                asset_type="FUTURES",
+                multiplier=10.0,
+                margin_ratio=0.1,
+                tick_size=0.2,
+            )
+        ],
+        china_futures=akquant.ChinaFuturesConfig(
+            enforce_lot_size=True,
+            enforce_tick_size=True,
+        ),
+    )
+    result_reject = akquant.run_backtest(
+        data=bars,
+        strategy=FractionalFuturesBuyStrategy,
+        symbol=symbol,
+        show_progress=False,
+        execution_mode="current_close",
+        config=config_reject,
+    )
+    reject_reasons = (
+        result_reject.orders_df["reject_reason"].fillna("").astype(str).tolist()
+    )
+    assert any("lot size" in reason for reason in reject_reasons)
+
+    config_accept = akquant.BacktestConfig(
+        strategy_config=akquant.StrategyConfig(initial_cash=1_000_000.0),
+        instruments_config=[
+            akquant.InstrumentConfig(
+                symbol=symbol,
+                asset_type="FUTURES",
+                multiplier=10.0,
+                margin_ratio=0.1,
+                tick_size=0.2,
+            )
+        ],
+        china_futures=akquant.ChinaFuturesConfig(
+            enforce_lot_size=True,
+            enforce_tick_size=True,
+            validation_by_symbol_prefix=[
+                akquant.ChinaFuturesValidationConfig(
+                    symbol_prefix="RB",
+                    enforce_lot_size=False,
+                )
+            ],
+        ),
+    )
+    result_accept = akquant.run_backtest(
+        data=bars,
+        strategy=FractionalFuturesBuyStrategy,
+        symbol=symbol,
+        show_progress=False,
+        execution_mode="current_close",
+        config=config_accept,
+    )
+    accept_reject_reasons = (
+        result_accept.orders_df["reject_reason"].fillna("").astype(str).tolist()
+    )
+    assert not any("lot size" in reason for reason in accept_reject_reasons)
+
+
+def test_run_backtest_china_futures_instrument_template_multiplier() -> None:
+    """Instrument template should inject futures multiplier by symbol prefix."""
+
+    class BuyAndHoldOnceStrategy(akquant.Strategy):
+        def __init__(self) -> None:
+            super().__init__()
+            self._submitted = False
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            if self._submitted:
+                return
+            self.buy(symbol=bar.symbol, quantity=1.0)
+            self._submitted = True
+
+    symbol = "RB_TMPL_01"
+    bars = _build_regression_bars(symbol)
+    config = akquant.BacktestConfig(
+        strategy_config=akquant.StrategyConfig(
+            initial_cash=1_000_000.0,
+            commission_rate=0.0,
+            slippage=0.0,
+            min_commission=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+        ),
+        china_futures=akquant.ChinaFuturesConfig(
+            enforce_sessions=False,
+            instrument_templates_by_symbol_prefix=[
+                akquant.ChinaFuturesInstrumentTemplateConfig(
+                    symbol_prefix="RB",
+                    multiplier=10.0,
+                    margin_ratio=0.1,
+                    tick_size=0.2,
+                    lot_size=1.0,
+                )
+            ],
+        ),
+    )
+    result = akquant.run_backtest(
+        data=bars,
+        strategy=BuyAndHoldOnceStrategy,
+        symbol=symbol,
+        show_progress=False,
+        execution_mode="current_close",
+        config=config,
+    )
+    final_equity = float(result.equity_curve.iloc[-1])
+    assert final_equity == pytest.approx(1_000_009.9977, rel=0.0, abs=1e-6)
+
+
+def test_run_backtest_china_futures_template_commission_prefix() -> None:
+    """Template commission should be merged into prefix fee rules."""
+    probe = akquant.Engine()
+    if not hasattr(probe, "set_futures_fee_rules_by_prefix"):
+        pytest.skip("Engine binary does not expose futures prefix fee methods")
+
+    class BuyAndHoldOnceStrategy(akquant.Strategy):
+        def __init__(self) -> None:
+            super().__init__()
+            self._submitted = False
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            if self._submitted:
+                return
+            self.buy(symbol=bar.symbol, quantity=1.0)
+            self._submitted = True
+
+    symbol = "RB_TMPL_FEE_01"
+    bars = _build_regression_bars(symbol)
+    base_config = akquant.BacktestConfig(
+        strategy_config=akquant.StrategyConfig(
+            initial_cash=1_000_000.0,
+            commission_rate=0.0,
+            slippage=0.0,
+            min_commission=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+        ),
+        china_futures=akquant.ChinaFuturesConfig(
+            enforce_sessions=False,
+            instrument_templates_by_symbol_prefix=[
+                akquant.ChinaFuturesInstrumentTemplateConfig(
+                    symbol_prefix="RB",
+                    multiplier=10.0,
+                    margin_ratio=0.1,
+                    tick_size=0.2,
+                    lot_size=1.0,
+                )
+            ],
+        ),
+    )
+    high_fee_config = akquant.BacktestConfig(
+        strategy_config=akquant.StrategyConfig(
+            initial_cash=1_000_000.0,
+            commission_rate=0.0,
+            slippage=0.0,
+            min_commission=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+        ),
+        china_futures=akquant.ChinaFuturesConfig(
+            enforce_sessions=False,
+            instrument_templates_by_symbol_prefix=[
+                akquant.ChinaFuturesInstrumentTemplateConfig(
+                    symbol_prefix="RB",
+                    multiplier=10.0,
+                    margin_ratio=0.1,
+                    tick_size=0.2,
+                    lot_size=1.0,
+                    commission_rate=0.001,
+                )
+            ],
+        ),
+    )
+    result_base = akquant.run_backtest(
+        data=bars,
+        strategy=BuyAndHoldOnceStrategy,
+        symbol=symbol,
+        show_progress=False,
+        execution_mode="current_close",
+        config=base_config,
+    )
+    result_high_fee = akquant.run_backtest(
+        data=bars,
+        strategy=BuyAndHoldOnceStrategy,
+        symbol=symbol,
+        show_progress=False,
+        execution_mode="current_close",
+        config=high_fee_config,
+    )
+    assert float(result_high_fee.equity_curve.iloc[-1]) < float(
+        result_base.equity_curve.iloc[-1]
+    )
+
+
+def test_run_backtest_china_futures_rejects_duplicate_template_prefix() -> None:
+    """Duplicate template prefixes should fail fast."""
+    bars = _build_regression_bars("RB_DUP_TPL")
+    with pytest.raises(
+        ValueError,
+        match=(
+            "instrument_templates_by_symbol_prefix\\[1\\] duplicates symbol_prefix 'RB'"
+        ),
+    ):
+        akquant.run_backtest(
+            data=bars,
+            strategy=NoopStrategy,
+            symbol="RB_DUP_TPL",
+            show_progress=False,
+            config=akquant.BacktestConfig(
+                strategy_config=akquant.StrategyConfig(),
+                china_futures=akquant.ChinaFuturesConfig(
+                    instrument_templates_by_symbol_prefix=[
+                        akquant.ChinaFuturesInstrumentTemplateConfig(
+                            symbol_prefix="RB",
+                            multiplier=10.0,
+                        ),
+                        akquant.ChinaFuturesInstrumentTemplateConfig(
+                            symbol_prefix="rb",
+                            multiplier=20.0,
+                        ),
+                    ]
+                ),
+            ),
+        )
+
+
+def test_run_backtest_china_futures_rejects_negative_template_multiplier() -> None:
+    """Negative template multiplier should fail fast."""
+    bars = _build_regression_bars("RB_BAD_MULT")
+    with pytest.raises(ValueError, match="multiplier must be > 0"):
+        akquant.run_backtest(
+            data=bars,
+            strategy=NoopStrategy,
+            symbol="RB_BAD_MULT",
+            show_progress=False,
+            config=akquant.BacktestConfig(
+                strategy_config=akquant.StrategyConfig(),
+                china_futures=akquant.ChinaFuturesConfig(
+                    instrument_templates_by_symbol_prefix=[
+                        akquant.ChinaFuturesInstrumentTemplateConfig(
+                            symbol_prefix="RB",
+                            multiplier=-1.0,
+                        )
+                    ]
+                ),
+            ),
+        )
+
+
+def test_china_futures_validation_config_requires_at_least_one_switch() -> None:
+    """Validation config should fail if both switches are omitted."""
+    with pytest.raises(
+        ValueError, match="must set enforce_tick_size or enforce_lot_size"
+    ):
+        akquant.ChinaFuturesValidationConfig(symbol_prefix="RB")


### PR DESCRIPTION
- 新增 `BacktestConfig.china_futures` 配置入口，支持按品种前缀设置合约模板、费率覆盖和撮合校验开关
- 新增期货撮合校验开关 API：`set_futures_validation_options` 和 `set_futures_validation_options_by_prefix`
- 新增期货前缀费率 API：`set_futures_fee_rules_by_prefix`
- 标准化期货费率 API 命名为复数形式，移除旧的单数命名 `set_future_fee_rules*`
- 在 Python 配置层实现构造时校验，确保前缀非空、数值范围合法且无重复前缀
- 更新期货撮合器以支持前缀级校验规则，包括最小变动价位对齐和手数整数倍检查
- 完善文档和测试用例，涵盖配置优先级、前缀匹配逻辑和边界情况