### PR TITLE
style: 允许非驼峰命名的指标类型

### DIFF
--- a/src/indicators/moving_average_transforms.rs
+++ b/src/indicators/moving_average_transforms.rs
@@ -5,6 +5,7 @@ macro_rules! define_unary_indicator {
     ($name:ident, $calc:expr) => {
         #[gen_stub_pyclass]
         #[pyclass(from_py_object)]
+        #[allow(non_camel_case_types)]
         #[derive(Debug, Clone)]
         pub struct $name {
             current_value: Option<f64>,


### PR DESCRIPTION
为了消除编译警告，在定义一元指标的结构体上添加 #[allow(non_camel_case_types)] 属性。