### PR TITLE
chore: 移除不再需要的 __future__ 导入并更新 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,23 +222,13 @@ result = aq.run_backtest(
 )
 ```
 
-`run_backtest` 也支持可选 `on_event`。如果不传，框架会使用内部 no-op 回调，
-保持与传统阻塞调用一致的返回语义；如果传入 `on_event`，即可在保持
-`run_backtest(...)` 调用方式不变的同时接入实时事件。
+`on_event` 为可选参数：不传时保持传统阻塞语义，传入时可实时消费事件。
 
 关键参数：
 
 *   `stream_progress_interval` / `stream_equity_interval`: 进度与权益事件采样间隔
 *   `stream_batch_size` / `stream_max_buffer`: 缓冲与批量刷新控制
 *   `stream_error_mode`: 回调异常策略，支持 `"continue"` 与 `"fail_fast"`
-
-阶段 5 迁移 FAQ：
-
-*   `run_backtest` 是否改名？不改名，调用方式保持不变。
-*   `run_backtest` 是否还能不传 `on_event`？可以，不传时仍返回同样的结果对象语义。
-*   如何回滚？阶段 5 后不再支持 `_engine_mode` 参数级回滚，建议使用版本级回滚。
-*   文档入口在哪里？可从 [中文文档首页的阶段 5 迁移入口](docs/zh/index.md#阶段-5-迁移入口) 快速跳转到 quickstart FAQ 和 API 兼容说明。
-*   英文入口在哪里？可从 [English docs Quick Links](docs/en/index.md#quick-links) 跳转到 Phase-5 Migration FAQ 与 Compatibility Notes。
 
 ## 可视化 (Visualization)
 
@@ -294,20 +284,21 @@ AKQuant 采用严格的测试流程以确保回测引擎的准确性：
 
 运行测试：
 ```bash
-# 1. 安装开发依赖
-pip install -e ".[dev]"
+# 1. 激活本地 conda 环境
+conda activate <env_name>
 
-# 2. 运行所有测试
+# 2. 构建并绑定 Rust 扩展
+maturin develop
+
+# 3. 运行所有测试
 pytest
 
-# 3. 运行 Rust 核心测试（自动处理 macOS + conda 动态库路径）
+# 4. 运行 Rust 核心测试（自动处理 macOS + conda 动态库路径）
 ./scripts/cargo-test.sh -q
 
-# 4. 仅运行黄金测试
+# 5. 仅运行黄金测试
 pytest tests/golden/test_golden.py
 ```
-
-## 贡献指南
 
 ## Citation
 

--- a/examples/23_functional_callbacks_demo.py
+++ b/examples/23_functional_callbacks_demo.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """Function-style callbacks demo."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import akquant as aq

--- a/examples/24_functional_tick_simulation_demo.py
+++ b/examples/24_functional_tick_simulation_demo.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """Function-style tick callback simulation demo."""
 
-from __future__ import annotations
-
 from types import SimpleNamespace
 from typing import Any, cast
 

--- a/examples/25_streaming_backtest_demo.py
+++ b/examples/25_streaming_backtest_demo.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 """Streaming backtest demo for continue and fail-fast callback modes."""
 
-from __future__ import annotations
-
 import akquant as aq
 import pandas as pd
 from akquant import Bar, Strategy

--- a/examples/27_streaming_monitoring_console.py
+++ b/examples/27_streaming_monitoring_console.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from collections import Counter
 from dataclasses import dataclass

--- a/examples/28_streaming_alerts_and_persist.py
+++ b/examples/28_streaming_alerts_and_persist.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import csv
 import math
 from dataclasses import dataclass

--- a/examples/29_streaming_event_report.py
+++ b/examples/29_streaming_event_report.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib
 from pathlib import Path
 from typing import cast

--- a/examples/30_streaming_report_oneclick.py
+++ b/examples/30_streaming_report_oneclick.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import subprocess
 import sys

--- a/examples/31_streaming_live_console.py
+++ b/examples/31_streaming_live_console.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import math
 from dataclasses import dataclass, field
 

--- a/examples/32_streaming_live_web.py
+++ b/examples/32_streaming_live_web.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import json
 import math

--- a/examples/33_report_and_analysis_outputs.py
+++ b/examples/33_report_and_analysis_outputs.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from pathlib import Path
 
 import akquant as aq

--- a/examples/34_multi_strategy_migration_demo.py
+++ b/examples/34_multi_strategy_migration_demo.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import akquant as aq

--- a/examples/35_custom_broker_registry_demo.py
+++ b/examples/35_custom_broker_registry_demo.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import annotations
 
 from typing import Any, Callable, Sequence
 

--- a/examples/38_live_functional_strategy_demo.py
+++ b/examples/38_live_functional_strategy_demo.py
@@ -8,8 +8,6 @@ LiveRunner 函数式策略入口示例.
 - 默认参数为占位示例，请替换为你自己的网关地址与账户信息。
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from akquant import AssetType, Instrument

--- a/examples/39_live_broker_submit_order_demo.py
+++ b/examples/39_live_broker_submit_order_demo.py
@@ -8,8 +8,6 @@ LiveRunner broker_live + 函数式 submit_order 最小闭环示例.
 - 默认地址与账户参数为占位，请替换为实际网关配置。
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from akquant import AssetType, Instrument

--- a/examples/40_functional_multi_slot_risk_demo.py
+++ b/examples/40_functional_multi_slot_risk_demo.py
@@ -8,8 +8,6 @@
 - 通过策略级风险限制让 alpha 被拒单、beta 正常下单
 """
 
-from __future__ import annotations
-
 from datetime import datetime, timezone
 from typing import Any, List
 

--- a/examples/41_live_multi_slot_orchestration_demo.py
+++ b/examples/41_live_multi_slot_orchestration_demo.py
@@ -8,8 +8,6 @@ LiveRunner 多策略 slot 编排示例.
 - 使用 paper 模式进行编排验证。
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from akquant import AssetType, Bar, Instrument, Strategy

--- a/examples/42_live_broker_event_audit_demo.py
+++ b/examples/42_live_broker_event_audit_demo.py
@@ -7,8 +7,6 @@ LiveRunner broker 事件审计示例.
 - 输出 owner_strategy_id 便于多 slot 归因
 """
 
-from __future__ import annotations
-
 from typing import Any
 
 from akquant import AssetType, Instrument

--- a/examples/43_target_weights_rebalance.py
+++ b/examples/43_target_weights_rebalance.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections import defaultdict
 
 import akquant as aq

--- a/examples/44_strategy_source_loader_demo.py
+++ b/examples/44_strategy_source_loader_demo.py
@@ -1,7 +1,5 @@
 """Dynamic strategy loading demo for strategy_source and strategy_loader."""
 
-from __future__ import annotations
-
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/examples/45_talib_indicator_playbook_demo.py
+++ b/examples/45_talib_indicator_playbook_demo.py
@@ -1,7 +1,5 @@
 """TA-Lib indicator playbook demo with strategy-level signal combinations."""
 
-from __future__ import annotations
-
 import argparse
 from typing import cast
 

--- a/examples/textbook/ch15_strategy_loader.py
+++ b/examples/textbook/ch15_strategy_loader.py
@@ -5,8 +5,6 @@
 在运行时加载策略实现。
 """
 
-from __future__ import annotations
-
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/python/akquant/analyzer_plugin.py
+++ b/python/akquant/analyzer_plugin.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 

--- a/python/akquant/feed_adapter.py
+++ b/python/akquant/feed_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Mapping, Protocol, cast

--- a/python/akquant/gateway/base.py
+++ b/python/akquant/gateway/base.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Callable, Protocol, Sequence
 

--- a/python/akquant/gateway/ctp_adapter.py
+++ b/python/akquant/gateway/ctp_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import time
 from typing import Any, Callable, Sequence
 

--- a/python/akquant/gateway/factory.py
+++ b/python/akquant/gateway/factory.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Sequence
 
 from ..akquant import DataFeed

--- a/python/akquant/gateway/mapper.py
+++ b/python/akquant/gateway/mapper.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any
 

--- a/python/akquant/gateway/miniqmt.py
+++ b/python/akquant/gateway/miniqmt.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import time
 from typing import Any, Callable, Sequence
 

--- a/python/akquant/gateway/models.py
+++ b/python/akquant/gateway/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
 from enum import Enum
 

--- a/python/akquant/gateway/ptrade.py
+++ b/python/akquant/gateway/ptrade.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import time
 from typing import Any, Callable, Sequence
 

--- a/python/akquant/gateway/registry.py
+++ b/python/akquant/gateway/registry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Callable, Dict, Sequence
 
 from ..akquant import DataFeed

--- a/python/akquant/params.py
+++ b/python/akquant/params.py
@@ -4,8 +4,6 @@
 该模块提供轻量的参数 DSL，底层基于 Pydantic。
 """
 
-from __future__ import annotations
-
 import datetime as dt
 from typing import Any, Mapping, Sequence, cast
 

--- a/python/akquant/params_adapter.py
+++ b/python/akquant/params_adapter.py
@@ -4,8 +4,6 @@
 用于连接策略参数模型、前端 schema 与回测入口。
 """
 
-from __future__ import annotations
-
 import inspect
 from typing import Any, Mapping, Sequence, cast
 

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import numpy as np

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, Optional, Tuple, cast
 
 import pandas as pd

--- a/python/akquant/strategy_history.py
+++ b/python/akquant/strategy_history.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Optional, cast
 
 import numpy as np

--- a/python/akquant/strategy_logging.py
+++ b/python/akquant/strategy_logging.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/python/akquant/strategy_ml.py
+++ b/python/akquant/strategy_ml.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from .utils import parse_duration_to_bars

--- a/python/akquant/strategy_order_events.py
+++ b/python/akquant/strategy_order_events.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Tuple
 
 from .akquant import OrderStatus

--- a/python/akquant/strategy_position.py
+++ b/python/akquant/strategy_position.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from .akquant import StrategyContext
 
 

--- a/python/akquant/strategy_scheduler.py
+++ b/python/akquant/strategy_scheduler.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime as dt
 from typing import Any, Union
 

--- a/python/akquant/strategy_time.py
+++ b/python/akquant/strategy_time.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Optional, cast
 
 import pandas as pd

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .akquant import OrderStatus, OrderType, TimeInForce

--- a/python/akquant/talib/backend.py
+++ b/python/akquant/talib/backend.py
@@ -1,7 +1,5 @@
 """Backend selection for TA-Lib compatibility layer."""
 
-from __future__ import annotations
-
 BackendKind = str
 _SUPPORTED_BACKENDS = {"auto", "python", "rust"}
 

--- a/python/akquant/talib/core.py
+++ b/python/akquant/talib/core.py
@@ -1,7 +1,5 @@
 """TA-Lib compatibility core helpers."""
 
-from __future__ import annotations
-
 from collections.abc import Sequence
 from typing import Union, cast
 

--- a/python/akquant/talib/funcs.py
+++ b/python/akquant/talib/funcs.py
@@ -1,7 +1,5 @@
 """TA-Lib style indicator functions."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from typing import cast
 

--- a/scripts/check_docs_api_examples.py
+++ b/scripts/check_docs_api_examples.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import ast
 import re

--- a/scripts/check_docs_links.py
+++ b/scripts/check_docs_links.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import argparse
 import re
 import subprocess

--- a/tests/test_docs_api_examples.py
+++ b/tests/test_docs_api_examples.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib.util
 import subprocess
 from pathlib import Path

--- a/tests/test_docs_links.py
+++ b/tests/test_docs_links.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import importlib.util
 import subprocess
 from pathlib import Path

--- a/tests/test_gateway_registry.py
+++ b/tests/test_gateway_registry.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Callable, Sequence
 
 from akquant import DataFeed

--- a/tests/test_params_adapter.py
+++ b/tests/test_params_adapter.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/test_talib_backend.py
+++ b/tests/test_talib_backend.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 import pytest
 from akquant import talib as ta

--- a/tests/test_talib_compat.py
+++ b/tests/test_talib_compat.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import numpy as np
 import pandas as pd
 from akquant import talib as ta


### PR DESCRIPTION
移除代码库中所有 `from __future__ import annotations` 导入，因为 Python 3.7+ 已原生支持类型注解的延迟求值。同时更新 README 中的测试运行说明，简化安装步骤并移除过时的迁移 FAQ 内容。