### PR TITLE
feat(engine): 添加引擎端 OCO 和 bracket 订单支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.73"
+version = "0.1.74"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.73"
+version = "0.1.74"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 *   **极致性能**：得益于 Rust 的零开销抽象与 **Zero-Copy** 数据架构，回测速度较传统纯 Python 框架（如 Backtrader）提升 **X倍+**。
 *   **原生 ML 支持**：内置 **Walk-forward Validation**（滚动训练）框架，无缝集成 PyTorch/Scikit-learn，让 AI 策略开发从实验到回测一气呵成。
+*   **TA-Lib 指标生态**：内置 `akquant.talib` 双后端（`python/rust`）兼容能力，支持 **103 个指标**。
 *   **因子表达式引擎**：内置 **Polars** 驱动的高性能因子计算引擎，支持 `Rank(Ts_Mean(Close, 5))` 等 Alpha101 风格公式，自动处理并行计算与数据对齐。
 *   **参数优化**：内置多进程网格搜索（Grid Search）框架，支持策略参数的高效并行优化。
 *   **专业级风控**：内置完善的订单流管理与即时风控模块，支持多资产组合回测。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.73"
+version = "0.1.74"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -236,6 +236,19 @@ class Strategy:
     _trading_day_bounds: Dict[str, Tuple[int, int]]
     _oco_groups: Dict[str, set[str]]
     _oco_order_to_group: Dict[str, str]
+    _use_engine_oco: bool
+    _pending_engine_oco_groups: List[Tuple[str, str, str]]
+    _use_engine_bracket: bool
+    _pending_engine_bracket_plans: List[
+        Tuple[
+            str,
+            Optional[float],
+            Optional[float],
+            Optional[TimeInForce],
+            Optional[str],
+            Optional[str],
+        ]
+    ]
     _pending_brackets: Dict[str, Dict[str, Any]]
     _order_group_seq: int
 
@@ -335,6 +348,10 @@ class Strategy:
         instance._trading_day_bounds = {}
         instance._oco_groups = {}
         instance._oco_order_to_group = {}
+        instance._use_engine_oco = False
+        instance._pending_engine_oco_groups = []
+        instance._use_engine_bracket = False
+        instance._pending_engine_bracket_plans = []
         instance._pending_brackets = {}
         instance._order_group_seq = 0
 
@@ -416,6 +433,14 @@ class Strategy:
             self._oco_groups = {}
         if not hasattr(self, "_oco_order_to_group"):
             self._oco_order_to_group = {}
+        if not hasattr(self, "_use_engine_oco"):
+            self._use_engine_oco = False
+        if not hasattr(self, "_pending_engine_oco_groups"):
+            self._pending_engine_oco_groups = []
+        if not hasattr(self, "_use_engine_bracket"):
+            self._use_engine_bracket = False
+        if not hasattr(self, "_pending_engine_bracket_plans"):
+            self._pending_engine_bracket_plans = []
         if not hasattr(self, "_pending_brackets"):
             self._pending_brackets = {}
         if not hasattr(self, "_order_group_seq"):
@@ -1125,6 +1150,18 @@ class Strategy:
             group_id = f"oco-{self._order_group_seq}"
         group_key = str(group_id).strip()
 
+        engine = getattr(self, "_engine", None)
+        register_oco = getattr(engine, "register_oco_group", None)
+        if callable(register_oco):
+            try:
+                register_oco(group_key, first, second)
+                self._use_engine_oco = True
+                return group_key
+            except Exception:
+                self._pending_engine_oco_groups.append((group_key, first, second))
+                self._use_engine_oco = True
+                return group_key
+
         self._detach_oco_order(first)
         self._detach_oco_order(second)
 
@@ -1165,6 +1202,34 @@ class Strategy:
         if not entry_order_id:
             raise RuntimeError("failed to submit bracket entry order")
 
+        engine = getattr(self, "_engine", None)
+        register_bracket = getattr(engine, "register_bracket_plan", None)
+        if callable(register_bracket):
+            try:
+                register_bracket(
+                    entry_order_id,
+                    stop_trigger_price,
+                    take_profit_price,
+                    time_in_force,
+                    stop_tag,
+                    take_profit_tag,
+                )
+                self._use_engine_bracket = True
+                return entry_order_id
+            except Exception:
+                self._pending_engine_bracket_plans.append(
+                    (
+                        entry_order_id,
+                        stop_trigger_price,
+                        take_profit_price,
+                        time_in_force,
+                        stop_tag,
+                        take_profit_tag,
+                    )
+                )
+                self._use_engine_bracket = True
+                return entry_order_id
+
         self._pending_brackets[entry_order_id] = {
             "symbol": symbol,
             "quantity": float(quantity),
@@ -1181,6 +1246,8 @@ class Strategy:
         self._process_oco_trade(trade)
 
     def _process_pending_bracket(self, trade: Any) -> None:
+        if self._use_engine_bracket:
+            return
         order_id = str(getattr(trade, "order_id", "") or "")
         if not order_id:
             return
@@ -1226,6 +1293,8 @@ class Strategy:
             self.create_oco_order_group(stop_order_id, take_order_id)
 
     def _process_oco_trade(self, trade: Any) -> None:
+        if self._use_engine_oco:
+            return
         order_id = str(getattr(trade, "order_id", "") or "")
         if not order_id:
             return

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_NAME="${AKQUANT_CONDA_ENV:-akquant}"
+
+conda run -n "${ENV_NAME}" maturin develop
+conda run -n "${ENV_NAME}" ruff check python/akquant tests
+conda run -n "${ENV_NAME}" mypy python/akquant
+conda run -n "${ENV_NAME}" pytest tests/test_engine.py -k "engine_oco_avoids_same_batch_double_fill"
+conda run -n "${ENV_NAME}" pytest tests/test_engine.py -k "engine_bracket_activates_exit_orders"
+conda run -n "${ENV_NAME}" pytest tests/test_strategy_extras.py -k "oco_group_prefers_engine_registration_when_available or oco_group_falls_back_to_deferred_engine_queue_on_runtime_error"
+conda run -n "${ENV_NAME}" pytest tests/test_strategy_extras.py -k "bracket_prefers_engine_registration_when_available or bracket_falls_back_to_deferred_engine_queue_on_runtime_error"

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -115,6 +115,39 @@ impl Engine {
         self.default_strategy_id.clone()
     }
 
+    fn register_oco_group(
+        &mut self,
+        group_id: String,
+        first_order_id: String,
+        second_order_id: String,
+    ) {
+        self.state
+            .order_manager
+            .register_oco_group(group_id, first_order_id, second_order_id);
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn register_bracket_plan(
+        &mut self,
+        entry_order_id: String,
+        stop_trigger_price: Option<f64>,
+        take_profit_price: Option<f64>,
+        time_in_force: Option<crate::model::TimeInForce>,
+        stop_tag: Option<String>,
+        take_profit_tag: Option<String>,
+    ) {
+        let stop_trigger_decimal = stop_trigger_price.and_then(rust_decimal::Decimal::from_f64);
+        let take_profit_decimal = take_profit_price.and_then(rust_decimal::Decimal::from_f64);
+        self.state.order_manager.register_bracket_plan(
+            entry_order_id,
+            stop_trigger_decimal,
+            take_profit_decimal,
+            time_in_force.unwrap_or(crate::model::TimeInForce::GTC),
+            stop_tag,
+            take_profit_tag,
+        );
+    }
+
     fn get_strategy_slot_ids(&self) -> Vec<String> {
         self.strategy_slots
             .iter()

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -1,13 +1,16 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::analysis::TradeTracker;
 use crate::history::HistoryBuffer;
 use crate::market::MarketModel;
-use crate::model::{Instrument, Order, OrderStatus, Trade};
+use crate::model::{
+    Instrument, Order, OrderRole, OrderSide, OrderStatus, OrderType, TimeInForce, Trade,
+};
 use crate::portfolio::Portfolio;
 
 /// 订单管理器
@@ -24,6 +27,24 @@ pub struct OrderManager {
     pub current_step_trades: Vec<Trade>,
     /// 交易追踪器 (用于计算 PnL 和统计)
     pub trade_tracker: TradeTracker,
+    /// OCO 订单组映射: group_id -> {order_id}
+    #[serde(default)]
+    pub oco_groups: HashMap<String, HashSet<String>>,
+    /// OCO 订单反向索引: order_id -> group_id
+    #[serde(default)]
+    pub oco_order_to_group: HashMap<String, String>,
+    /// Bracket 激活计划: entry_order_id -> plan
+    #[serde(default)]
+    pub pending_bracket_plans: HashMap<String, PendingBracketPlan>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PendingBracketPlan {
+    pub stop_trigger_price: Option<Decimal>,
+    pub take_profit_price: Option<Decimal>,
+    pub time_in_force: TimeInForce,
+    pub stop_tag: String,
+    pub take_profit_tag: String,
 }
 
 impl OrderManager {
@@ -34,7 +55,176 @@ impl OrderManager {
             trades: Vec::new(),
             current_step_trades: Vec::new(),
             trade_tracker: TradeTracker::new(),
+            oco_groups: HashMap::new(),
+            oco_order_to_group: HashMap::new(),
+            pending_bracket_plans: HashMap::new(),
         }
+    }
+
+    pub fn register_oco_group(
+        &mut self,
+        group_id: String,
+        first_order_id: String,
+        second_order_id: String,
+    ) {
+        let first = first_order_id.trim().to_string();
+        let second = second_order_id.trim().to_string();
+        let group_key = group_id.trim().to_string();
+        if first.is_empty() || second.is_empty() || first == second || group_key.is_empty() {
+            return;
+        }
+
+        self.detach_oco_order(&first);
+        self.detach_oco_order(&second);
+
+        let mut members = HashSet::new();
+        members.insert(first.clone());
+        members.insert(second.clone());
+        self.oco_groups.insert(group_key.clone(), members);
+        self.oco_order_to_group.insert(first, group_key.clone());
+        self.oco_order_to_group.insert(second, group_key);
+    }
+
+    pub fn consume_oco_peer_cancels_on_fill(&mut self, order_id: &str) -> Vec<String> {
+        let Some(group_id) = self.oco_order_to_group.get(order_id).cloned() else {
+            return Vec::new();
+        };
+        let Some(group_members) = self.oco_groups.remove(&group_id) else {
+            self.oco_order_to_group.remove(order_id);
+            return Vec::new();
+        };
+
+        let mut peers = Vec::new();
+        for member in group_members {
+            self.oco_order_to_group.remove(&member);
+            if member != order_id {
+                peers.push(member);
+            }
+        }
+        peers
+    }
+
+    pub fn cancel_active_order(&mut self, order_id: &str, updated_at: i64) -> Option<Order> {
+        let order = self.active_orders.iter_mut().find(|o| o.id == order_id)?;
+        if order.status == OrderStatus::New
+            || order.status == OrderStatus::Submitted
+            || order.status == OrderStatus::PartiallyFilled
+        {
+            order.status = OrderStatus::Cancelled;
+            order.updated_at = updated_at;
+            let snapshot = order.clone();
+            self.handle_oco_terminal_without_fill(order_id);
+            return Some(snapshot);
+        }
+        None
+    }
+
+    pub fn register_bracket_plan(
+        &mut self,
+        entry_order_id: String,
+        stop_trigger_price: Option<Decimal>,
+        take_profit_price: Option<Decimal>,
+        time_in_force: TimeInForce,
+        stop_tag: Option<String>,
+        take_profit_tag: Option<String>,
+    ) {
+        let entry_id = entry_order_id.trim().to_string();
+        if entry_id.is_empty() {
+            return;
+        }
+        if stop_trigger_price.is_none() && take_profit_price.is_none() {
+            return;
+        }
+        self.pending_bracket_plans.insert(
+            entry_id,
+            PendingBracketPlan {
+                stop_trigger_price,
+                take_profit_price,
+                time_in_force,
+                stop_tag: stop_tag.unwrap_or_default(),
+                take_profit_tag: take_profit_tag.unwrap_or_default(),
+            },
+        );
+    }
+
+    pub fn consume_bracket_activation_on_fill(&mut self, filled_order: &Order) -> Vec<Order> {
+        let Some(plan) = self.pending_bracket_plans.remove(&filled_order.id) else {
+            return Vec::new();
+        };
+
+        let quantity = if filled_order.filled_quantity > Decimal::ZERO {
+            filled_order.filled_quantity
+        } else {
+            filled_order.quantity
+        };
+        if quantity <= Decimal::ZERO {
+            return Vec::new();
+        }
+
+        let created_at = filled_order.updated_at;
+        let graph_id = format!("bracket-{}", filled_order.id);
+        let mut created_orders: Vec<Order> = Vec::new();
+
+        if let Some(stop_trigger_price) = plan.stop_trigger_price {
+            created_orders.push(Order {
+                id: Uuid::new_v4().to_string(),
+                symbol: filled_order.symbol.clone(),
+                side: OrderSide::Sell,
+                order_type: OrderType::StopMarket,
+                quantity,
+                price: None,
+                time_in_force: plan.time_in_force,
+                trigger_price: Some(stop_trigger_price),
+                trail_offset: None,
+                trail_reference_price: None,
+                graph_id: Some(graph_id.clone()),
+                parent_order_id: Some(filled_order.id.clone()),
+                order_role: OrderRole::StopLoss,
+                status: OrderStatus::New,
+                filled_quantity: Decimal::ZERO,
+                average_filled_price: None,
+                created_at,
+                updated_at: created_at,
+                commission: Decimal::ZERO,
+                tag: plan.stop_tag.clone(),
+                reject_reason: String::new(),
+                owner_strategy_id: filled_order.owner_strategy_id.clone(),
+            });
+        }
+
+        if let Some(take_profit_price) = plan.take_profit_price {
+            created_orders.push(Order {
+                id: Uuid::new_v4().to_string(),
+                symbol: filled_order.symbol.clone(),
+                side: OrderSide::Sell,
+                order_type: OrderType::Limit,
+                quantity,
+                price: Some(take_profit_price),
+                time_in_force: plan.time_in_force,
+                trigger_price: None,
+                trail_offset: None,
+                trail_reference_price: None,
+                graph_id: Some(graph_id.clone()),
+                parent_order_id: Some(filled_order.id.clone()),
+                order_role: OrderRole::TakeProfit,
+                status: OrderStatus::New,
+                filled_quantity: Decimal::ZERO,
+                average_filled_price: None,
+                created_at,
+                updated_at: created_at,
+                commission: Decimal::ZERO,
+                tag: plan.take_profit_tag.clone(),
+                reject_reason: String::new(),
+                owner_strategy_id: filled_order.owner_strategy_id.clone(),
+            });
+        }
+
+        if created_orders.len() == 2 {
+            let first = created_orders[0].id.clone();
+            let second = created_orders[1].id.clone();
+            self.register_oco_group(format!("{}-exit-oco", graph_id), first, second);
+        }
+        created_orders
     }
 
     /// 添加新订单 (例如从 OrderValidated 事件)
@@ -45,6 +235,7 @@ impl OrderManager {
     /// 处理执行报告 (ExecutionReport)
     /// 更新活跃订单状态
     pub fn on_execution_report(&mut self, report: Order) {
+        let mut terminal_without_fill_id: Option<String> = None;
         // Find existing order
         if let Some(existing) = self.active_orders.iter_mut().find(|o| o.id == report.id) {
             existing.status = report.status;
@@ -52,6 +243,13 @@ impl OrderManager {
             existing.average_filled_price = report.average_filled_price;
             existing.updated_at = report.updated_at;
             existing.reject_reason = report.reject_reason;
+            if existing.status != OrderStatus::Filled
+                && (existing.status == OrderStatus::Cancelled
+                    || existing.status == OrderStatus::Expired
+                    || existing.status == OrderStatus::Rejected)
+            {
+                terminal_without_fill_id = Some(existing.id.clone());
+            }
         } else {
             // If it's a new order report (e.g. Rejected immediately), add to active so it can be moved to history later
             if report.status == OrderStatus::Rejected
@@ -59,8 +257,15 @@ impl OrderManager {
                 || report.status == OrderStatus::PartiallyFilled
                 || report.status == OrderStatus::Submitted
             {
+                if report.status == OrderStatus::Rejected {
+                    terminal_without_fill_id = Some(report.id.clone());
+                }
                 self.active_orders.push(report);
             }
+        }
+        if let Some(order_id) = terminal_without_fill_id {
+            self.handle_oco_terminal_without_fill(&order_id);
+            self.pending_bracket_plans.remove(&order_id);
         }
     }
 
@@ -75,6 +280,12 @@ impl OrderManager {
                     || o.status == OrderStatus::Rejected
             });
 
+        for order in &finished {
+            if order.status != OrderStatus::Filled {
+                self.handle_oco_terminal_without_fill(&order.id);
+                self.pending_bracket_plans.remove(&order.id);
+            }
+        }
         self.orders.extend(finished);
         self.active_orders = active;
     }
@@ -185,10 +396,96 @@ impl OrderManager {
             self.current_step_trades.push(trade);
         }
     }
+
+    fn detach_oco_order(&mut self, order_id: &str) {
+        let Some(old_group) = self.oco_order_to_group.remove(order_id) else {
+            return;
+        };
+        if let Some(group_orders) = self.oco_groups.get_mut(&old_group) {
+            group_orders.remove(order_id);
+            if group_orders.len() <= 1 {
+                let leftovers: Vec<String> = group_orders.iter().cloned().collect();
+                self.oco_groups.remove(&old_group);
+                for oid in leftovers {
+                    self.oco_order_to_group.remove(&oid);
+                }
+            }
+        }
+    }
+
+    fn handle_oco_terminal_without_fill(&mut self, order_id: &str) {
+        self.detach_oco_order(order_id);
+    }
 }
 
 impl Default for OrderManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{OrderRole, OrderSide, OrderType, TimeInForce};
+    use rust_decimal_macros::dec;
+
+    fn make_order(id: &str, status: OrderStatus) -> Order {
+        Order {
+            id: id.to_string(),
+            symbol: "TEST".to_string(),
+            side: OrderSide::Buy,
+            order_type: OrderType::Limit,
+            quantity: dec!(10),
+            price: Some(dec!(100)),
+            time_in_force: TimeInForce::Day,
+            trigger_price: None,
+            trail_offset: None,
+            trail_reference_price: None,
+            graph_id: None,
+            parent_order_id: None,
+            order_role: OrderRole::Standalone,
+            status,
+            filled_quantity: Decimal::ZERO,
+            average_filled_price: None,
+            created_at: 0,
+            updated_at: 0,
+            commission: Decimal::ZERO,
+            tag: String::new(),
+            reject_reason: String::new(),
+            owner_strategy_id: None,
+        }
+    }
+
+    #[test]
+    fn test_register_oco_group_and_consume_on_fill() {
+        let mut manager = OrderManager::new();
+        manager.register_oco_group(
+            "oco-1".to_string(),
+            "order-a".to_string(),
+            "order-b".to_string(),
+        );
+
+        let peer_ids = manager.consume_oco_peer_cancels_on_fill("order-a");
+        assert_eq!(peer_ids, vec!["order-b".to_string()]);
+        assert!(manager.oco_groups.is_empty());
+        assert!(manager.oco_order_to_group.is_empty());
+    }
+
+    #[test]
+    fn test_cancel_active_order_updates_status_and_cleans_oco_mapping() {
+        let mut manager = OrderManager::new();
+        manager.active_orders.push(make_order("order-a", OrderStatus::Submitted));
+        manager.active_orders.push(make_order("order-b", OrderStatus::Submitted));
+        manager.register_oco_group(
+            "oco-1".to_string(),
+            "order-a".to_string(),
+            "order-b".to_string(),
+        );
+
+        let cancelled = manager.cancel_active_order("order-b", 123).expect("cancelled");
+        assert_eq!(cancelled.status, OrderStatus::Cancelled);
+        assert_eq!(cancelled.updated_at, 123);
+        assert!(!manager.oco_order_to_group.contains_key("order-b"));
     }
 }

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -5,6 +5,7 @@ use crate::event::Event;
 use crate::model::{Bar, ExecutionMode, Order, OrderStatus, TradingSession};
 use crate::pipeline::processor::{Processor, ProcessorResult};
 use pyo3::prelude::*;
+use rust_decimal::prelude::*;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -116,6 +117,7 @@ impl Processor for ChannelProcessor {
     ) -> PyResult<ProcessorResult> {
         let mut trades_to_process = Vec::new();
         let mut pending_order_requests = Vec::new();
+        let mut oco_suppressed_fill_order_ids: HashSet<String> = HashSet::new();
         loop {
             let mut drained_event = false;
             while let Some(event) = engine.event_manager.try_recv() {
@@ -127,8 +129,21 @@ impl Processor for ChannelProcessor {
                         engine.state.order_manager.add_active_order(order);
                     }
                     Event::ExecutionReport(order, trade) => {
+                        if order.status == OrderStatus::Filled
+                            && oco_suppressed_fill_order_ids.contains(&order.id)
+                        {
+                            continue;
+                        }
+                        let report_order_id = order.id.clone();
+                        let report_status = order.status;
+                        let report_updated_at = order.updated_at;
                         engine.state.order_manager.on_execution_report(order);
-                        let updated_order = engine.state.order_manager.orders.last().cloned();
+                        let updated_order = engine
+                            .state
+                            .order_manager
+                            .get_all_orders()
+                            .into_iter()
+                            .find(|o| o.id == report_order_id);
                         if let Some(order_snapshot) = updated_order {
                             let mut order_payload = HashMap::new();
                             order_payload.insert("order_id", order_snapshot.id.clone());
@@ -147,6 +162,68 @@ impl Processor for ChannelProcessor {
                                 "info",
                                 order_payload,
                             );
+                        }
+
+                        if report_status == OrderStatus::Filled {
+                            let peer_ids = engine
+                                .state
+                                .order_manager
+                                .consume_oco_peer_cancels_on_fill(&report_order_id);
+                            for peer_id in peer_ids {
+                                oco_suppressed_fill_order_ids.insert(peer_id.clone());
+                                engine.execution_model.on_cancel(&peer_id);
+                                let cancelled_order_snapshot = engine
+                                    .state
+                                    .order_manager
+                                    .cancel_active_order(&peer_id, report_updated_at);
+                                if let Some(cancelled_order_snapshot) = cancelled_order_snapshot {
+                                    let mut cancel_payload = HashMap::new();
+                                    cancel_payload
+                                        .insert("order_id", cancelled_order_snapshot.id.clone());
+                                    cancel_payload.insert(
+                                        "status",
+                                        format!("{:?}", cancelled_order_snapshot.status),
+                                    );
+                                    cancel_payload.insert(
+                                        "filled_qty",
+                                        cancelled_order_snapshot.filled_quantity.to_string(),
+                                    );
+                                    cancel_payload.insert(
+                                        "symbol",
+                                        cancelled_order_snapshot.symbol.clone(),
+                                    );
+                                    cancel_payload.insert(
+                                        "owner_strategy_id",
+                                        cancelled_order_snapshot
+                                            .owner_strategy_id
+                                            .clone()
+                                            .unwrap_or_default(),
+                                    );
+                                    engine.emit_stream_event(
+                                        py,
+                                        "order",
+                                        Some(cancelled_order_snapshot.symbol.as_str()),
+                                        "info",
+                                        cancel_payload,
+                                    );
+                                }
+                            }
+
+                            if let Some(filled_order_snapshot) = engine
+                                .state
+                                .order_manager
+                                .get_all_orders()
+                                .into_iter()
+                                .find(|o| o.id == report_order_id)
+                            {
+                                let bracket_exit_orders = engine
+                                    .state
+                                    .order_manager
+                                    .consume_bracket_activation_on_fill(&filled_order_snapshot);
+                                for bracket_order in bracket_exit_orders {
+                                    let _ = engine.event_manager.send(Event::OrderRequest(bracket_order));
+                                }
+                            }
                         }
 
                         if let Some(t) = trade {
@@ -420,6 +497,76 @@ impl Processor for DataProcessor {
 
 pub struct StrategyProcessor;
 
+fn flush_pending_engine_oco_groups(
+    engine: &mut Engine,
+    strategy_obj: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    let pending_any = match strategy_obj.getattr("_pending_engine_oco_groups") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let pending_groups: Vec<(String, String, String)> = pending_any.extract().unwrap_or_default();
+    if pending_groups.is_empty() {
+        return Ok(());
+    }
+    for (group_id, first_order_id, second_order_id) in pending_groups {
+        engine
+            .state
+            .order_manager
+            .register_oco_group(group_id, first_order_id, second_order_id);
+    }
+    strategy_obj.setattr(
+        "_pending_engine_oco_groups",
+        Vec::<(String, String, String)>::new(),
+    )?;
+    Ok(())
+}
+
+fn flush_pending_engine_bracket_plans(
+    engine: &mut Engine,
+    strategy_obj: &Bound<'_, PyAny>,
+) -> PyResult<()> {
+    let pending_any = match strategy_obj.getattr("_pending_engine_bracket_plans") {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let pending_plans: Vec<(
+        String,
+        Option<f64>,
+        Option<f64>,
+        Option<crate::model::TimeInForce>,
+        Option<String>,
+        Option<String>,
+    )> = pending_any.extract().unwrap_or_default();
+    if pending_plans.is_empty() {
+        return Ok(());
+    }
+    for (entry_order_id, stop_trigger_price, take_profit_price, time_in_force, stop_tag, take_profit_tag) in pending_plans {
+        let stop_trigger_decimal = stop_trigger_price.and_then(rust_decimal::Decimal::from_f64);
+        let take_profit_decimal = take_profit_price.and_then(rust_decimal::Decimal::from_f64);
+        engine.state.order_manager.register_bracket_plan(
+            entry_order_id,
+            stop_trigger_decimal,
+            take_profit_decimal,
+            time_in_force.unwrap_or(crate::model::TimeInForce::GTC),
+            stop_tag,
+            take_profit_tag,
+        );
+    }
+    strategy_obj.setattr(
+        "_pending_engine_bracket_plans",
+        Vec::<(
+            String,
+            Option<f64>,
+            Option<f64>,
+            Option<crate::model::TimeInForce>,
+            Option<String>,
+            Option<String>,
+        )>::new(),
+    )?;
+    Ok(())
+}
+
 impl Processor for StrategyProcessor {
     fn process(
         &mut self,
@@ -443,21 +590,27 @@ impl Processor for StrategyProcessor {
                 let (new_orders, new_timers, canceled_ids) =
                     if let Some(ref slot_py) = slot_strategy {
                         let slot_bound = slot_py.bind(py);
-                        engine.call_strategy_for_slot(
+                        let result = engine.call_strategy_for_slot(
                             slot_bound,
                             &event,
                             slot_index,
                             active_orders.clone(),
                             step_trades.clone(),
-                        )?
+                        )?;
+                        flush_pending_engine_oco_groups(engine, slot_bound)?;
+                        flush_pending_engine_bracket_plans(engine, slot_bound)?;
+                        result
                     } else {
-                        engine.call_strategy_for_slot(
+                        let result = engine.call_strategy_for_slot(
                             strategy,
                             &event,
                             slot_index,
                             active_orders.clone(),
                             step_trades.clone(),
-                        )?
+                        )?;
+                        flush_pending_engine_oco_groups(engine, strategy)?;
+                        flush_pending_engine_bracket_plans(engine, strategy)?;
+                        result
                     };
 
                 for id in canceled_ids {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -479,6 +479,127 @@ def test_backtest_performance_baseline() -> None:
     assert result.metrics.initial_market_value == pytest.approx(100000.0, rel=1e-9)
 
 
+def test_run_backtest_engine_oco_avoids_same_batch_double_fill() -> None:
+    """Engine OCO should avoid double fill when both legs are matchable in one bar."""
+
+    class OcoSameBarStrategy(akquant.Strategy):
+        """Submit two same-bar matchable orders and bind them as OCO."""
+
+        def __init__(self) -> None:
+            """Initialize submit-once state."""
+            super().__init__()
+            self.submitted = False
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            """Submit OCO legs on first bar."""
+            if self.submitted:
+                return
+            first = self.buy(symbol=bar.symbol, quantity=1, price=bar.close)
+            second = self.buy(symbol=bar.symbol, quantity=1, price=bar.close)
+            self.create_oco_order_group(first, second)
+            self.submitted = True
+
+    symbol = "OCO_SAME_BAR"
+    bars = [
+        akquant.Bar(
+            _ns(datetime(2023, 1, 2, 15, 0, tzinfo=timezone.utc)),
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            1000.0,
+            symbol,
+        )
+    ]
+    result = akquant.run_backtest(
+        data=bars,
+        strategy=OcoSameBarStrategy,
+        symbol=symbol,
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert len(result.orders_df) == 2
+    total_filled_qty = float(result.orders_df["filled_quantity"].sum())
+    assert total_filled_qty == pytest.approx(1.0, rel=1e-9)
+    filled_quantities = sorted(
+        float(v) for v in result.orders_df["filled_quantity"].tolist()
+    )
+    assert filled_quantities == [0.0, 1.0]
+
+
+def test_run_backtest_engine_bracket_activates_exit_orders() -> None:
+    """Engine bracket plan should activate exit orders after entry fill."""
+
+    class BracketEngineStrategy(akquant.Strategy):
+        """Submit one bracket and rely on engine-side activation."""
+
+        def __init__(self) -> None:
+            """Initialize one-shot state."""
+            super().__init__()
+            self.submitted = False
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            """Submit bracket on first bar only."""
+            if self.submitted:
+                return
+            self.place_bracket_order(
+                symbol=bar.symbol,
+                quantity=1.0,
+                entry_price=100.0,
+                stop_trigger_price=95.0,
+                take_profit_price=110.0,
+                entry_tag="entry",
+                stop_tag="stop",
+                take_profit_tag="take",
+            )
+            self.submitted = True
+
+    symbol = "BRACKET_ENGINE"
+    bars = [
+        akquant.Bar(
+            _ns(datetime(2023, 1, 2, 15, 0, tzinfo=timezone.utc)),
+            100.0,
+            100.0,
+            100.0,
+            100.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            _ns(datetime(2023, 1, 3, 15, 0, tzinfo=timezone.utc)),
+            110.0,
+            111.0,
+            100.0,
+            110.0,
+            1000.0,
+            symbol,
+        ),
+    ]
+    result = akquant.run_backtest(
+        data=bars,
+        strategy=BracketEngineStrategy,
+        symbol=symbol,
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+    )
+
+    tags = set(result.orders_df["tag"].astype(str))
+    assert {"entry", "stop", "take"}.issubset(tags)
+
+
 def test_run_backtest_on_event_emits_ordered_events() -> None:
     """Stream API should emit ordered lifecycle events."""
     data = _build_benchmark_data(n=20, symbol="STREAM")

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -2656,6 +2656,214 @@ def test_oco_group_rebind_detaches_old_group() -> None:
     assert strategy._oco_order_to_group == {"order-b": "oco-2", "order-c": "oco-2"}
 
 
+def test_oco_group_prefers_engine_registration_when_available() -> None:
+    """Engine OCO registration should be preferred when capability exists."""
+
+    class _FakeEngine:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str, str]] = []
+
+        def register_oco_group(
+            self, group_id: str, first_order_id: str, second_order_id: str
+        ) -> None:
+            self.calls.append((group_id, first_order_id, second_order_id))
+
+    strategy = MyStrategy()
+    fake_engine = _FakeEngine()
+    setattr(strategy, "_engine", fake_engine)
+
+    group_id = strategy.create_oco_order_group("order-a", "order-b")
+
+    assert group_id == "oco-1"
+    assert strategy._use_engine_oco is True
+    assert fake_engine.calls == [("oco-1", "order-a", "order-b")]
+    assert strategy._oco_groups == {}
+    assert strategy._oco_order_to_group == {}
+
+
+def test_oco_trade_processing_skips_python_fallback_when_engine_enabled() -> None:
+    """Python OCO fallback should not run after engine OCO is enabled."""
+
+    class _OcoSpyStrategy(Strategy):
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+
+        def cancel_order(self, order_id: str) -> None:
+            self.cancelled.append(order_id)
+
+    strategy = _OcoSpyStrategy()
+    strategy._use_engine_oco = True
+    strategy._oco_groups = {"oco-1": {"order-a", "order-b"}}
+    strategy._oco_order_to_group = {"order-a": "oco-1", "order-b": "oco-1"}
+
+    strategy._process_oco_trade(SimpleNamespace(order_id="order-a"))
+
+    assert strategy.cancelled == []
+    assert strategy._oco_groups == {"oco-1": {"order-a", "order-b"}}
+    assert strategy._oco_order_to_group == {"order-a": "oco-1", "order-b": "oco-1"}
+
+
+def test_oco_group_falls_back_to_deferred_engine_queue_on_runtime_error() -> None:
+    """OCO should queue engine registration when immediate call raises."""
+
+    class _FailingEngine:
+        def register_oco_group(
+            self, group_id: str, first_order_id: str, second_order_id: str
+        ) -> None:
+            raise RuntimeError("engine borrow conflict")
+
+    strategy = MyStrategy()
+    setattr(strategy, "_engine", _FailingEngine())
+
+    group_id = strategy.create_oco_order_group("order-a", "order-b")
+
+    assert group_id == "oco-1"
+    assert strategy._use_engine_oco is True
+    assert strategy._pending_engine_oco_groups == [("oco-1", "order-a", "order-b")]
+    assert strategy._oco_groups == {}
+    assert strategy._oco_order_to_group == {}
+
+
+def test_bracket_prefers_engine_registration_when_available() -> None:
+    """Bracket plan should be registered to engine when capability exists."""
+
+    class _FakeEngine:
+        def __init__(self) -> None:
+            self.calls: list[
+                tuple[
+                    str,
+                    float | None,
+                    float | None,
+                    Any,
+                    str | None,
+                    str | None,
+                ]
+            ] = []
+
+        def register_bracket_plan(
+            self,
+            entry_order_id: str,
+            stop_trigger_price: float | None,
+            take_profit_price: float | None,
+            time_in_force: Any,
+            stop_tag: str | None,
+            take_profit_tag: str | None,
+        ) -> None:
+            self.calls.append(
+                (
+                    entry_order_id,
+                    stop_trigger_price,
+                    take_profit_price,
+                    time_in_force,
+                    stop_tag,
+                    take_profit_tag,
+                )
+            )
+
+    class _BracketEngineStrategy(Strategy):
+        def __init__(self) -> None:
+            self.buy_calls: list[dict[str, Any]] = []
+
+        def buy(
+            self,
+            symbol: str | None = None,
+            quantity: float | None = None,
+            price: float | None = None,
+            time_in_force: Any = None,
+            trigger_price: float | None = None,
+            tag: str | None = None,
+        ) -> str:
+            self.buy_calls.append(
+                {
+                    "symbol": symbol,
+                    "quantity": quantity,
+                    "price": price,
+                    "time_in_force": time_in_force,
+                    "trigger_price": trigger_price,
+                    "tag": tag,
+                }
+            )
+            return "entry-1"
+
+    strategy = _BracketEngineStrategy()
+    fake_engine = _FakeEngine()
+    setattr(strategy, "_engine", fake_engine)
+
+    entry_id = strategy.place_bracket_order(
+        symbol="AAPL",
+        quantity=2.0,
+        entry_price=100.0,
+        stop_trigger_price=95.0,
+        take_profit_price=110.0,
+        entry_tag="entry",
+        stop_tag="stop",
+        take_profit_tag="take",
+    )
+
+    assert entry_id == "entry-1"
+    assert strategy._use_engine_bracket is True
+    assert strategy._pending_brackets == {}
+    assert fake_engine.calls == [("entry-1", 95.0, 110.0, None, "stop", "take")]
+
+
+def test_bracket_falls_back_to_deferred_engine_queue_on_runtime_error() -> None:
+    """Bracket plan should queue deferred registration when engine call raises."""
+
+    class _FailingEngine:
+        def register_bracket_plan(
+            self,
+            entry_order_id: str,
+            stop_trigger_price: float | None,
+            take_profit_price: float | None,
+            time_in_force: Any,
+            stop_tag: str | None,
+            take_profit_tag: str | None,
+        ) -> None:
+            _ = (
+                entry_order_id,
+                stop_trigger_price,
+                take_profit_price,
+                time_in_force,
+                stop_tag,
+                take_profit_tag,
+            )
+            raise RuntimeError("engine borrow conflict")
+
+    class _BracketEngineStrategy(Strategy):
+        def buy(
+            self,
+            symbol: str | None = None,
+            quantity: float | None = None,
+            price: float | None = None,
+            time_in_force: Any = None,
+            trigger_price: float | None = None,
+            tag: str | None = None,
+        ) -> str:
+            _ = (symbol, quantity, price, time_in_force, trigger_price, tag)
+            return "entry-1"
+
+    strategy = _BracketEngineStrategy()
+    setattr(strategy, "_engine", _FailingEngine())
+
+    entry_id = strategy.place_bracket_order(
+        symbol="AAPL",
+        quantity=2.0,
+        entry_price=100.0,
+        stop_trigger_price=95.0,
+        take_profit_price=110.0,
+        entry_tag="entry",
+        stop_tag="stop",
+        take_profit_tag="take",
+    )
+
+    assert entry_id == "entry-1"
+    assert strategy._use_engine_bracket is True
+    assert strategy._pending_brackets == {}
+    assert strategy._pending_engine_bracket_plans == [
+        ("entry-1", 95.0, 110.0, None, "stop", "take")
+    ]
+
+
 def test_bracket_places_exit_orders_and_builds_oco() -> None:
     """Bracket entry fill should create stop/take exits and bind OCO."""
 


### PR DESCRIPTION
- 在 Rust 引擎中实现 OCO 组和 bracket 计划注册
- 在 Python 策略层添加引擎能力检测和回退机制
- 新增引擎端 OCO 组管理，避免同一批次双成交问题
- 新增引擎端 bracket 计划，在入场单成交后自动激活止损止盈单
- 添加相关单元测试验证引擎端功能
- 更新版本号至 0.1.74 并添加开发检查脚本