### PR TITLE
feat: 添加 broker_profile 模板注入与事件统计查询

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.75"
+version = "0.1.76"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.75"
+version = "0.1.76"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/runtime_config.md
+++ b/docs/en/advanced/runtime_config.md
@@ -151,3 +151,40 @@ result = run_backtest(
 
 `run_warm_start(...)` currently restores strategy instance from checkpoint and does not
 reload strategy implementation via `strategy_source` / `strategy_loader`.
+
+## 10. broker_profile Selection Guide
+
+`run_backtest(..., broker_profile=...)` injects a preset of fee/slippage/lot defaults, useful when you want to align execution assumptions quickly before finalizing broker-specific params.
+
+Priority rule:
+
+- Explicit arguments override `broker_profile` template values
+- Template values override system defaults
+
+| Template | Recommended Scenario | Main Characteristics | Typical Risk |
+|---|---|---|---|
+| `cn_stock_miniqmt` | General A-share simulation, baseline MiniQMT alignment | Default commission + stamp duty + transfer fee + minimum commission + 100-share lot | Can be optimistic under extreme impact conditions |
+| `cn_stock_t1_low_fee` | Low-fee account sensitivity tests, net-return stress checks | Lower commission/transfer fee and lower minimum commission | Can overestimate high-turnover strategy performance |
+| `cn_stock_sim_high_slippage` | Intraday impact/liquidity stress scenarios, robustness replay | Higher slippage and more conservative turnover assumptions | Can underestimate low-impact strategy performance |
+
+Template parameter details (current built-in values):
+
+| Template | commission_rate | stamp_tax_rate | transfer_fee_rate | min_commission | slippage | volume_limit_pct | lot_size |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `cn_stock_miniqmt` | 0.0003 | 0.001 | 0.00001 | 5.0 | 0.0002 | 0.2 | 100 |
+| `cn_stock_t1_low_fee` | 0.0002 | 0.001 | 0.000005 | 3.0 | 0.0001 | 0.25 | 100 |
+| `cn_stock_sim_high_slippage` | 0.0003 | 0.001 | 0.00001 | 5.0 | 0.001 | 0.1 | 100 |
+
+Quick example:
+
+```python
+result = run_backtest(
+    data=data,
+    strategy=MyStrategy,
+    symbol="000001.SZ",
+    broker_profile="cn_stock_t1_low_fee",
+    show_progress=False,
+)
+```
+
+If you already have broker-confirmed live parameters, prefer explicit values such as `commission_rate`, `slippage`, and `lot_size` as your final baseline.

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -468,3 +468,7 @@ The `examples/` directory contains more scripts demonstrating AKShare integratio
 *   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
     *   Demonstrates TopN dynamic weights: rank symbols by momentum, select winners, then rebalance with `order_target_weights`.
     *   Shows practical usage of `liquidate_unmentioned` and `rebalance_tolerance`, then prints `selected_history` / `final_positions` / `final_equity`.
+
+*   **[46_broker_profile_demo.py](https://github.com/akfamily/akquant/blob/main/examples/46_broker_profile_demo.py)**:
+    *   Demonstrates template injection with `run_backtest(..., broker_profile=...)` and prints effective fee/lot parameters at strategy startup.
+    *   Useful for quick alignment with built-ins such as `cn_stock_miniqmt`, `cn_stock_t1_low_fee`, and `cn_stock_sim_high_slippage`.

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -52,6 +52,7 @@ def run_backtest(
     risk_budget_mode: Literal["order_notional", "trade_notional"] = "order_notional",
     risk_budget_reset_daily: bool = False,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
+    broker_profile: Optional[str] = None,
     **kwargs: Any,
 ) -> BacktestResult
 ```
@@ -84,6 +85,7 @@ def run_backtest(
 *   `risk_budget_mode` / `risk_budget_reset_daily`: Risk budget accounting mode and reset policy.
 *   `analyzer_plugins`: Optional analyzer plugin list. Plugins receive `on_start/on_bar/on_trade/on_finish` callbacks and final outputs are stored in `result.analyzer_outputs`.
 *   `on_event`: Optional stream callback. When omitted, an internal no-op callback keeps legacy blocking return semantics; when provided, runtime events are emitted.
+*   `broker_profile`: Optional broker template preset for quick defaults (fees/slippage/lot size). Built-ins: `cn_stock_miniqmt`, `cn_stock_t1_low_fee`, `cn_stock_sim_high_slippage`.
 
 ### `akquant.run_warm_start`
 
@@ -471,6 +473,7 @@ Strategy base class. Users should inherit from this class and override callback 
 *   `stop_sell(symbol, trigger_price, quantity, ...)`: Stop sell (Stop Market). Triggers a market sell order when price drops below `trigger_price`.
 *   `submit_order(..., order_type="StopTrail", trail_offset=..., trail_reference_price=None)`: Submit a trailing stop order. `trail_offset` must be greater than 0.
 *   `submit_order(..., order_type="StopTrailLimit", price=..., trail_offset=..., trail_reference_price=None)`: Submit a trailing stop-limit order. `price` and `trail_offset` are required.
+*   `submit_order(..., broker_options={...})`: Optional broker extension fields passthrough (backtest currently records them on `order.broker_options` for debugging/audit).
 *   `place_trailing_stop(symbol, quantity, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: Helper for trailing stop orders, promoted to market order when triggered.
 *   `place_trailing_stop_limit(symbol, quantity, price, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: Helper for trailing stop-limit orders, promoted to limit order when triggered.
 *   `order_target_value(target_value, symbol, price=None)`: Adjust position to target value.
@@ -657,6 +660,7 @@ Backtest result object.
 *   `capacity_df(freq="D")`: Capacity proxy metrics (order count, fill rates, turnover).
 *   `orders_by_strategy()`: Strategy-ownership order aggregation by `owner_strategy_id`.
 *   `executions_by_strategy()`: Strategy-ownership execution aggregation by `owner_strategy_id`.
+*   `get_event_stats()`: Unified stream summary stats (for example `processed_events`, `dropped_event_count`, `callback_error_count`, `backpressure_policy`, `stream_mode`).
 
 ```python
 orders_by_strategy = result.orders_by_strategy()
@@ -671,4 +675,9 @@ executions_by_strategy = result.executions_by_strategy()
 # executions_by_strategy:
 # - owner_strategy_id, execution_count, total_quantity,
 #   total_notional, total_commission, avg_fill_price
+
+event_stats = result.get_event_stats()
+# Common fields:
+# - processed_events, dropped_event_count, callback_error_count,
+#   backpressure_policy, stream_mode, reason
 ```

--- a/docs/en/start/quickstart.md
+++ b/docs/en/start/quickstart.md
@@ -320,6 +320,8 @@ result = run_backtest(
     stream_max_buffer=256,
     stream_error_mode="continue",
 )
+
+print("event_stats:", result.get_event_stats())
 ```
 
 Common streaming options:

--- a/docs/zh/advanced/runtime_config.md
+++ b/docs/zh/advanced/runtime_config.md
@@ -151,3 +151,40 @@ result = run_backtest(
 
 `run_warm_start(...)` 当前从 checkpoint 恢复策略实例，不会通过
 `strategy_source` / `strategy_loader` 重新加载策略实现。
+
+## 10. broker_profile 选择建议
+
+`run_backtest(..., broker_profile=...)` 可快速注入一组费率/滑点/手数默认值，适合在“参数还未完全定稿”阶段快速对齐不同执行风格。
+
+优先级规则：
+
+- 显式参数优先于 `broker_profile` 模板值
+- 模板值优先于系统默认值
+
+| 模板名 | 推荐场景 | 主要特征 | 典型风险 |
+|---|---|---|---|
+| `cn_stock_miniqmt` | A 股常规仿真、对齐 MiniQMT 基础口径 | 默认佣金 + 印花税 + 过户费 + 最小佣金 + 百股一手 | 对极端冲击成本刻画偏保守 |
+| `cn_stock_t1_low_fee` | 低费率账户压力测试、策略净值敏感性分析 | 更低佣金/过户费、较低最小佣金 | 可能高估高换手策略净收益 |
+| `cn_stock_sim_high_slippage` | 盘中冲击/流动性压力场景、稳健性回归 | 较高滑点、较保守成交约束 | 可能低估低冲击策略表现 |
+
+模板参数明细（当前内置值）：
+
+| 模板名 | commission_rate | stamp_tax_rate | transfer_fee_rate | min_commission | slippage | volume_limit_pct | lot_size |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `cn_stock_miniqmt` | 0.0003 | 0.001 | 0.00001 | 5.0 | 0.0002 | 0.2 | 100 |
+| `cn_stock_t1_low_fee` | 0.0002 | 0.001 | 0.000005 | 3.0 | 0.0001 | 0.25 | 100 |
+| `cn_stock_sim_high_slippage` | 0.0003 | 0.001 | 0.00001 | 5.0 | 0.001 | 0.1 | 100 |
+
+快速示例：
+
+```python
+result = run_backtest(
+    data=data,
+    strategy=MyStrategy,
+    symbol="000001.SZ",
+    broker_profile="cn_stock_t1_low_fee",
+    show_progress=False,
+)
+```
+
+如果你已有明确的券商实盘参数，建议直接显式传入 `commission_rate`、`slippage`、`lot_size` 等字段，作为最终基线。

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -469,3 +469,7 @@ class AdjSignal(Strategy):
 *   **[43_target_weights_rebalance.py](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py)**:
     *   演示 TopN 动态权重调仓：先按动量打分选强势标的，再通过 `order_target_weights` 一次性完成组合再平衡。
     *   展示 `liquidate_unmentioned` 与 `rebalance_tolerance` 的组合用法，并输出 `selected_history` / `final_positions` / `final_equity`。
+
+*   **[46_broker_profile_demo.py](https://github.com/akfamily/akquant/blob/main/examples/46_broker_profile_demo.py)**:
+    *   演示 `run_backtest(..., broker_profile=...)` 的模板注入行为，并打印策略启动时实际生效的费率与手数参数。
+    *   适合快速对齐 `cn_stock_miniqmt`、`cn_stock_t1_low_fee`、`cn_stock_sim_high_slippage` 等预设风格。

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -39,6 +39,7 @@ def run_backtest(
     risk_config: Optional[Union[Dict[str, Any], RiskConfig]] = None,
     strategies_by_slot: Optional[Dict[str, Union[Type[Strategy], Strategy, Callable[[Any, Bar], None]]]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
+    broker_profile: Optional[str] = None,
     **kwargs: Any,
 ) -> BacktestResult
 ```
@@ -98,6 +99,7 @@ def run_warm_start(
 *   `strategies_by_slot`: 可选多策略映射。键为 slot id，值为策略类/实例/函数式 on_bar 回调；用于启用 slot 迭代执行。
 *   `analyzer_plugins`: 可选 Analyzer 插件列表。插件接收 `on_start/on_bar/on_trade/on_finish` 生命周期回调，结果汇总到 `result.analyzer_outputs`。
 *   `on_event`: 可选事件回调。不传时内部使用 no-op 回调并保持阻塞返回语义；传入时可实时消费事件。
+*   `broker_profile`: 可选 broker 参数模板，用于快速注入费率/滑点/最小手数等默认值。内置模板：`cn_stock_miniqmt`、`cn_stock_t1_low_fee`、`cn_stock_sim_high_slippage`。
 
 **DataFeedAdapter 用法（多时间框）:**
 
@@ -491,6 +493,7 @@ result = run_backtest(
 *   `sell(symbol, quantity, price=None, trigger_price=None, ...)`: 卖出（平多/开空）。参数同上。
 *   `submit_order(..., order_type="StopTrail", trail_offset=..., trail_reference_price=None)`: 提交跟踪止损单。`trail_offset` 必须大于 0。
 *   `submit_order(..., order_type="StopTrailLimit", price=..., trail_offset=..., trail_reference_price=None)`: 提交跟踪止损限价单。`price` 与 `trail_offset` 必填。
+*   `submit_order(..., broker_options={...})`: 可选 broker 扩展参数透传（回测阶段仅记录在订单对象 `order.broker_options` 上，便于联调与审计）。
 *   `place_trailing_stop(symbol, quantity, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: 跟踪止损助手，触发后按市价执行。
 *   `place_trailing_stop_limit(symbol, quantity, price, trail_offset, side="Sell", trail_reference_price=None, ...) -> str`: 跟踪止损限价助手，触发后按限价执行。
 *   `order_target_weights(target_weights, price_map=None, liquidate_unmentioned=False, allow_leverage=False, rebalance_tolerance=0.0, ...)`: 按多标的目标权重调仓。
@@ -719,6 +722,7 @@ class RiskConfig:
 *   `capacity_df(freq="D")`: 容量代理指标（订单数、成交率、换手）。
 *   `orders_by_strategy()`: 按 `owner_strategy_id` 聚合订单统计。
 *   `executions_by_strategy()`: 按 `owner_strategy_id` 聚合成交流水统计。
+*   `get_event_stats()`: 返回流式事件统计摘要（如 `processed_events`、`dropped_event_count`、`callback_error_count`、`backpressure_policy`、`stream_mode`）。
 
 ```python
 orders_by_strategy = result.orders_by_strategy()
@@ -733,4 +737,9 @@ executions_by_strategy = result.executions_by_strategy()
 # executions_by_strategy:
 # - owner_strategy_id, execution_count, total_quantity,
 #   total_notional, total_commission, avg_fill_price
+
+event_stats = result.get_event_stats()
+# 常见字段:
+# - processed_events, dropped_event_count, callback_error_count,
+#   backpressure_policy, stream_mode, reason
 ```

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -332,6 +332,8 @@ result = run_backtest(
     stream_max_buffer=256,
     stream_error_mode="continue",
 )
+
+print("event_stats:", result.get_event_stats())
 ```
 
 常用流式参数说明：

--- a/examples/46_broker_profile_demo.py
+++ b/examples/46_broker_profile_demo.py
@@ -1,0 +1,61 @@
+import pandas as pd
+from akquant import Bar, Strategy, run_backtest
+
+
+class BrokerProfileDemoStrategy(Strategy):
+    """Print effective broker profile fields at startup."""
+
+    def __init__(self) -> None:
+        """Initialize one-shot submit state."""
+        self.submitted = False
+
+    def on_start(self) -> None:
+        """Display resolved fee and lot parameters."""
+        print(f"strategy_commission_rate={self.commission_rate}")
+        print(f"strategy_stamp_tax_rate={self.stamp_tax_rate}")
+        print(f"strategy_transfer_fee_rate={self.transfer_fee_rate}")
+        print(f"strategy_min_commission={self.min_commission}")
+        print(f"strategy_lot_size={self.lot_size}")
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit one buy order on the first bar."""
+        if not self.submitted:
+            self.buy(symbol=bar.symbol, quantity=self.lot_size)
+            self.submitted = True
+
+
+def _build_data() -> list[Bar]:
+    closes = [10.0, 10.2, 10.1, 10.4, 10.3]
+    rows: list[Bar] = []
+    for i, close in enumerate(closes):
+        ts = pd.Timestamp(f"2024-01-0{i + 1} 15:00:00", tz="UTC").value
+        rows.append(
+            Bar(
+                timestamp=ts,
+                open=close,
+                high=close + 0.1,
+                low=close - 0.1,
+                close=close,
+                volume=10000.0,
+                symbol="PROFILE",
+            )
+        )
+    return rows
+
+
+def run_example() -> None:
+    """Run broker profile demo backtest."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=BrokerProfileDemoStrategy,
+        symbol="PROFILE",
+        execution_mode="current_close",
+        broker_profile="cn_stock_t1_low_fee",
+        show_progress=False,
+    )
+    print(f"orders={len(result.orders_df)}")
+    print("done_broker_profile_demo")
+
+
+if __name__ == "__main__":
+    run_example()

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,7 @@
 - [43_target_weights_rebalance.py](./43_target_weights_rebalance.py): TopN 动态权重调仓示例（横截面动量 + `order_target_weights`）。
 - [44_strategy_source_loader_demo.py](./44_strategy_source_loader_demo.py): strategy_source + strategy_loader 动态加载示例（明文 + 外部解密）。
 - [45_talib_indicator_playbook_demo.py](./45_talib_indicator_playbook_demo.py): TA-Lib 指标组合模板示例（趋势跟随 + 均值回归 + 风险过滤，支持 `--data-source synthetic|akshare`）。
+- [46_broker_profile_demo.py](./46_broker_profile_demo.py): `broker_profile` 模板注入示例（默认费率/滑点/手数一键生效）。
 
 ## 流式回测与实时报告
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.75"
+version = "0.1.76"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -237,6 +237,8 @@ class BacktestResult:
         r"""Get orders as a dictionary of columns for fast DataFrame creation."""
         ...
 
+    def get_event_stats(self) -> dict[str, typing.Any]: ...
+
 class Bar:
     r"""
     K 线数据结构.

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -91,6 +91,7 @@ def run_backtest(
     risk_budget_mode: Literal["order_notional", "trade_notional"] = ...,
     risk_budget_reset_daily: bool = ...,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = ...,
+    broker_profile: Optional[str] = ...,
     stream_mode: Literal["observability", "audit"] = ...,
     **kwargs: Any,
 ) -> BacktestResult: ...

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -64,6 +64,36 @@ BacktestDataInput = Union[
     pd.DataFrame, Dict[str, pd.DataFrame], List[Bar], DataFeed, DataFeedAdapter
 ]
 
+_BROKER_PROFILE_TEMPLATES: Dict[str, Dict[str, Any]] = {
+    "cn_stock_miniqmt": {
+        "commission_rate": 0.0003,
+        "stamp_tax_rate": 0.001,
+        "transfer_fee_rate": 0.00001,
+        "min_commission": 5.0,
+        "slippage": 0.0002,
+        "volume_limit_pct": 0.2,
+        "lot_size": 100,
+    },
+    "cn_stock_t1_low_fee": {
+        "commission_rate": 0.0002,
+        "stamp_tax_rate": 0.001,
+        "transfer_fee_rate": 0.000005,
+        "min_commission": 3.0,
+        "slippage": 0.0001,
+        "volume_limit_pct": 0.25,
+        "lot_size": 100,
+    },
+    "cn_stock_sim_high_slippage": {
+        "commission_rate": 0.0003,
+        "stamp_tax_rate": 0.001,
+        "transfer_fee_rate": 0.00001,
+        "min_commission": 5.0,
+        "slippage": 0.001,
+        "volume_limit_pct": 0.1,
+        "lot_size": 100,
+    },
+}
+
 
 def _parse_positive_int_option(name: str, value: Any) -> int:
     parsed = int(value)
@@ -88,6 +118,20 @@ def _parse_stream_mode(value: Any) -> str:
 
 def _noop_stream_event_handler(_event: BacktestStreamEvent) -> None:
     return None
+
+
+def _resolve_broker_profile(profile: Optional[str]) -> Dict[str, Any]:
+    if profile is None:
+        return {}
+    key = str(profile).strip().lower()
+    if not key:
+        return {}
+    if key not in _BROKER_PROFILE_TEMPLATES:
+        available = ", ".join(sorted(_BROKER_PROFILE_TEMPLATES.keys()))
+        raise ValueError(
+            f"Unknown broker_profile '{profile}', available profiles: {available}"
+        )
+    return dict(_BROKER_PROFILE_TEMPLATES[key])
 
 
 def _parse_asset_type_name(value: Any) -> str:
@@ -509,6 +553,7 @@ def run_backtest(
     risk_budget_reset_daily: bool = False,
     analyzer_plugins: Optional[Sequence[AnalyzerPlugin]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
+    broker_profile: Optional[str] = None,
     **kwargs: Any,
 ) -> BacktestResult:
     """
@@ -588,6 +633,10 @@ def run_backtest(
                              接收 on_start/on_bar/on_trade/on_finish 生命周期事件
     :param on_event: 可选流式事件回调。阶段 5 后 `run_backtest` 始终走统一事件内核；
                      不传时内部使用 no-op 回调并保持返回语义不变。
+    :param broker_profile: 可选 broker 参数模板名称，
+                           如 "cn_stock_miniqmt" / "cn_stock_t1_low_fee" /
+                           "cn_stock_sim_high_slippage"，
+                           用于快速注入一组回测参数默认值。
     故障速查可参考 docs/zh/advanced/runtime_config.md，
     英文文档参考 docs/en/advanced/runtime_config.md
     :param instruments_config: 标的配置列表或字典 (可选)
@@ -697,6 +746,39 @@ def run_backtest(
                 Optional[Dict[str, Any]],
                 getattr(strategy_config, "strategy_loader_options", None),
             )
+    broker_profile_values = _resolve_broker_profile(broker_profile)
+    if broker_profile_values:
+        if initial_cash is None:
+            initial_cash = cast(
+                Optional[float], broker_profile_values.get("initial_cash")
+            )
+        if commission_rate is None:
+            commission_rate = cast(
+                Optional[float], broker_profile_values.get("commission_rate")
+            )
+        if slippage is None:
+            slippage = cast(Optional[float], broker_profile_values.get("slippage"))
+        if volume_limit_pct is None:
+            volume_limit_pct = cast(
+                Optional[float], broker_profile_values.get("volume_limit_pct")
+            )
+        if lot_size is None:
+            lot_size = cast(
+                Optional[Union[int, Dict[str, int]]],
+                broker_profile_values.get("lot_size"),
+            )
+        if stamp_tax_rate == 0.0:
+            stamp_tax_rate = float(
+                broker_profile_values.get("stamp_tax_rate", stamp_tax_rate)
+            )
+        if transfer_fee_rate == 0.0:
+            transfer_fee_rate = float(
+                broker_profile_values.get("transfer_fee_rate", transfer_fee_rate)
+            )
+        if min_commission == 0.0:
+            min_commission = float(
+                broker_profile_values.get("min_commission", min_commission)
+            )
     if strategies_by_slot is not None and not isinstance(strategies_by_slot, dict):
         raise TypeError("strategies_by_slot must be a dict when provided")
     if strategy_max_order_value is not None and not isinstance(
@@ -753,9 +835,25 @@ def run_backtest(
         stream_on_event = _noop_stream_event_handler
     effective_strategy_id = strategy_id or "_default"
     original_stream_handler = stream_on_event
+    event_stats_snapshot: Dict[str, Any] = {}
 
     def wrapped_stream_on_event(event: BacktestStreamEvent) -> None:
         event_type = str(event.get("event_type", ""))
+        if event_type == "finished":
+            payload_obj = event.get("payload", {})
+            if isinstance(payload_obj, dict):
+                for key in (
+                    "processed_events",
+                    "dropped_event_count",
+                    "callback_error_count",
+                    "backpressure_policy",
+                    "stream_mode",
+                    "sampling_enabled",
+                    "sampling_rate",
+                    "reason",
+                ):
+                    if key in payload_obj:
+                        event_stats_snapshot[key] = payload_obj.get(key)
         if event_type in {"order", "trade", "risk"}:
             payload_obj = event.get("payload", {})
             if isinstance(payload_obj, dict):
@@ -2138,8 +2236,9 @@ def run_backtest(
             ):
                 current_strategy._prepare_indicators(data_map_for_indicators)
 
+    engine_summary: str = ""
     try:
-        engine.run(strategy_instance, show_progress)
+        engine_summary = str(engine.run(strategy_instance, show_progress))
     except Exception as e:
         logger.error(f"Backtest failed: {e}")
         raise e
@@ -2178,6 +2277,8 @@ def run_backtest(
         strategy=strategy_instance,
         engine=engine,
     )
+    setattr(result, "_engine_summary", engine_summary)
+    setattr(result, "_event_stats", dict(event_stats_snapshot))
     analyzer_outputs: Dict[str, Dict[str, Any]] = {}
     if analyzer_manager.plugins:
         try:
@@ -2371,6 +2472,29 @@ def run_warm_start(
         raise TypeError("on_event must be callable when provided")
     if stream_on_event is None:
         stream_on_event = _noop_stream_event_handler
+    original_stream_handler = stream_on_event
+    event_stats_snapshot: Dict[str, Any] = {}
+
+    def wrapped_stream_on_event(event: BacktestStreamEvent) -> None:
+        event_type = str(event.get("event_type", ""))
+        if event_type == "finished":
+            payload_obj = event.get("payload", {})
+            if isinstance(payload_obj, dict):
+                for key in (
+                    "processed_events",
+                    "dropped_event_count",
+                    "callback_error_count",
+                    "backpressure_policy",
+                    "stream_mode",
+                    "sampling_enabled",
+                    "sampling_rate",
+                    "reason",
+                ):
+                    if key in payload_obj:
+                        event_stats_snapshot[key] = payload_obj.get(key)
+        original_stream_handler(event)
+
+    stream_on_event = wrapped_stream_on_event
     stream_progress_interval = _parse_positive_int_option(
         "stream_progress_interval", kwargs.pop("stream_progress_interval", 1)
     )
@@ -2946,8 +3070,9 @@ def run_warm_start(
                     logger.error(f"Failed to update indicators for warm start: {e}")
 
     # 4. 运行
+    engine_summary: str = ""
     try:
-        engine.run(strategy_instance, show_progress)
+        engine_summary = str(engine.run(strategy_instance, show_progress))
     except Exception as e:
         logger.error(f"Warm start backtest failed: {e}")
         raise e
@@ -2989,5 +3114,7 @@ def run_warm_start(
         strategy=strategy_instance,
         engine=engine,
     )
+    setattr(result, "_engine_summary", engine_summary)
+    setattr(result, "_event_stats", dict(event_stats_snapshot))
     setattr(result, "_owner_strategy_id", effective_strategy_id)
     return result

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -1,3 +1,4 @@
+import re
 from functools import cached_property
 from typing import (
     Any,
@@ -9,14 +10,8 @@ from typing import (
 
 import pandas as pd
 
-from ..akquant import (
-    BacktestResult as RustBacktestResult,
-)
-from ..akquant import (
-    ClosedTrade,
-    Order,
-    Trade,
-)
+from ..akquant import BacktestResult as RustBacktestResult
+from ..akquant import ClosedTrade, Order, Trade
 
 
 class BacktestResult:
@@ -958,6 +953,79 @@ class BacktestResult:
         )
         grouped = grouped.sort_values("owner_strategy_id").reset_index(drop=True)
         return cast(pd.DataFrame, grouped[columns])
+
+    def get_event_stats(self) -> dict[str, Any]:
+        """Return normalized event stream statistics from payload and run summary."""
+        keys = {
+            "processed_events",
+            "dropped_event_count",
+            "callback_error_count",
+            "backpressure_policy",
+            "stream_mode",
+            "sampling_enabled",
+            "sampling_rate",
+            "reason",
+        }
+        stats: dict[str, Any] = {}
+        direct_stats = getattr(self, "_event_stats", None)
+        if isinstance(direct_stats, dict):
+            stats.update(direct_stats)
+        try:
+            metrics_df = self.metrics_df
+            if not metrics_df.empty:
+                value_col = "value" if "value" in metrics_df.columns else None
+                for key in keys:
+                    if key not in metrics_df.index:
+                        continue
+                    raw_value: Any
+                    if value_col is not None:
+                        raw_value = metrics_df.at[key, value_col]
+                    else:
+                        row = metrics_df.loc[key]
+                        if isinstance(row, pd.Series):
+                            raw_value = row.iloc[0]
+                        else:
+                            raw_value = row
+                    if pd.isna(raw_value):
+                        continue
+                    if hasattr(raw_value, "item"):
+                        try:
+                            stats[key] = raw_value.item()
+                            continue
+                        except Exception:
+                            pass
+                    stats[key] = raw_value
+        except Exception:
+            pass
+
+        summary = getattr(self, "_engine_summary", None)
+        if isinstance(summary, str) and summary:
+            parsed: dict[str, Any] = {}
+            for part in summary.split(","):
+                token = part.strip()
+                if "=" not in token:
+                    continue
+                raw_key, raw_value = token.split("=", 1)
+                key = raw_key.strip()
+                value_text = raw_value.strip()
+                lowered = value_text.lower()
+                if lowered in {"true", "false"}:
+                    parsed[key] = lowered == "true"
+                else:
+                    try:
+                        parsed[key] = int(value_text)
+                    except ValueError:
+                        try:
+                            parsed[key] = float(value_text)
+                        except ValueError:
+                            parsed[key] = value_text
+            matched = re.search(r"Processed\s+(\d+)\s+events", summary, re.IGNORECASE)
+            if matched and "processed_events" not in parsed:
+                parsed["processed_events"] = int(matched.group(1))
+            for key in keys:
+                if key in parsed and key not in stats:
+                    stats[key] = parsed[key]
+        return stats
 
     def _risk_reason_masks(self, rejected: pd.DataFrame) -> dict[str, pd.Series]:
         reason_lower = rejected["reject_reason"].fillna("").astype(str).str.lower()

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -611,7 +611,7 @@ def _build_metrics_html(result: Any) -> str:
         (
             "年化收益率 (CAGR)",
             metrics.annualized_return,
-            f"{metrics.annualized_return:.2f}%",
+            f"{metrics.annualized_return:.2%}",
             get_color_class(metrics.annualized_return),
         ),
         (

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1392,6 +1392,7 @@ class Strategy:
         client_order_id: Optional[str] = None,
         order_type: Optional[str] = None,
         extra: Optional[Dict[str, Any]] = None,
+        broker_options: Optional[Dict[str, Any]] = None,
         trail_offset: Optional[float] = None,
         trail_reference_price: Optional[float] = None,
     ) -> str:
@@ -1412,6 +1413,7 @@ class Strategy:
             client_order_id=client_order_id,
             order_type=order_type,
             extra=extra,
+            broker_options=broker_options,
             trail_offset=trail_offset,
             trail_reference_price=trail_reference_price,
         )

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -69,13 +69,47 @@ def get_open_orders(strategy: Any, symbol: Optional[str] = None) -> List[Any]:
 def get_order(strategy: Any, order_id: str) -> Optional[Any]:
     """获取指定订单详情."""
     if order_id in strategy._known_orders:
-        return strategy._known_orders[order_id]
+        order = strategy._known_orders[order_id]
+        _attach_broker_options(strategy, order_id, order)
+        return order
 
     if strategy.ctx:
         for o in strategy.ctx.active_orders:
             if o.id == order_id:
+                _attach_broker_options(strategy, order_id, o)
                 return o
     return None
+
+
+def _record_broker_options(
+    strategy: Any, order_id: Optional[str], broker_options: Optional[Dict[str, Any]]
+) -> None:
+    if not order_id or not broker_options:
+        return
+    if not isinstance(broker_options, dict):
+        raise TypeError("broker_options must be a dict when provided")
+    store = getattr(strategy, "_broker_options_by_order_id", None)
+    if not isinstance(store, dict):
+        store = {}
+        setattr(strategy, "_broker_options_by_order_id", store)
+    normalized = dict(broker_options)
+    store[str(order_id)] = normalized
+    order = get_order(strategy, str(order_id))
+    if order is not None:
+        _attach_broker_options(strategy, str(order_id), order)
+
+
+def _attach_broker_options(strategy: Any, order_id: str, order: Any) -> None:
+    store = getattr(strategy, "_broker_options_by_order_id", None)
+    if not isinstance(store, dict):
+        return
+    options = store.get(str(order_id))
+    if not isinstance(options, dict):
+        return
+    try:
+        setattr(order, "broker_options", dict(options))
+    except Exception:
+        return
 
 
 def cancel_order(strategy: Any, order_id: str) -> None:
@@ -312,6 +346,7 @@ def submit_order(
     client_order_id: Optional[str] = None,
     order_type: Optional[str] = None,
     extra: Optional[Dict[str, Any]] = None,
+    broker_options: Optional[Dict[str, Any]] = None,
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
 ) -> str:
@@ -338,7 +373,7 @@ def submit_order(
 
     side_text = side.strip().lower()
     if side_text == "buy":
-        return _submit_buy_side(
+        order_id = _submit_buy_side(
             strategy=strategy,
             symbol=symbol,
             quantity=quantity,
@@ -350,8 +385,10 @@ def submit_order(
             trail_offset=trail_offset,
             trail_reference_price=trail_reference_price,
         )
+        _record_broker_options(strategy, order_id, broker_options)
+        return order_id
     if side_text == "sell":
-        return _submit_sell_side(
+        order_id = _submit_sell_side(
             strategy=strategy,
             symbol=symbol,
             quantity=quantity,
@@ -363,6 +400,8 @@ def submit_order(
             trail_offset=trail_offset,
             trail_reference_price=trail_reference_price,
         )
+        _record_broker_options(strategy, order_id, broker_options)
+        return order_id
     raise ValueError(f"Unsupported side: {side}")
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -45,6 +45,25 @@ class NoopStrategy(akquant.Strategy):
         return
 
 
+class ProfileCaptureStrategy(akquant.Strategy):
+    """Capture resolved market profile fields from strategy runtime."""
+
+    def __init__(self) -> None:
+        """Initialize captured snapshot container."""
+        super().__init__()
+        self.snapshot: dict[str, float | int] = {}
+
+    def on_start(self) -> None:
+        """Capture strategy runtime fields after backtest startup."""
+        self.snapshot = {
+            "commission_rate": float(self.commission_rate),
+            "stamp_tax_rate": float(self.stamp_tax_rate),
+            "transfer_fee_rate": float(self.transfer_fee_rate),
+            "min_commission": float(self.min_commission),
+            "lot_size": int(self.lot_size),
+        }
+
+
 class SingleBuyStrategy(akquant.Strategy):
     """Place a single buy order on first bar only."""
 
@@ -2286,6 +2305,106 @@ def test_run_backtest_on_event_audit_mode_latency_budget_benchmark() -> None:
     assert event_counts[5] == event_counts[0]
     assert durations[1] > durations[0]
     assert durations[5] > durations[1]
+
+
+def test_run_backtest_broker_profile_applies_defaults() -> None:
+    """broker_profile should inject template defaults when explicit args are omitted."""
+    result = akquant.run_backtest(
+        data=_build_regression_bars("PROFILE"),
+        strategy=ProfileCaptureStrategy,
+        symbol="PROFILE",
+        execution_mode="current_close",
+        broker_profile="cn_stock_miniqmt",
+        show_progress=False,
+    )
+
+    strategy = cast(ProfileCaptureStrategy, result.strategy)
+    assert strategy.snapshot["commission_rate"] == pytest.approx(0.0003, rel=1e-12)
+    assert strategy.snapshot["stamp_tax_rate"] == pytest.approx(0.001, rel=1e-12)
+    assert strategy.snapshot["transfer_fee_rate"] == pytest.approx(0.00001, rel=1e-12)
+    assert strategy.snapshot["min_commission"] == pytest.approx(5.0, rel=1e-12)
+    assert strategy.snapshot["lot_size"] == 100
+
+
+def test_run_backtest_broker_profile_explicit_args_override_profile() -> None:
+    """Explicit parameters should keep highest precedence over broker_profile values."""
+    result = akquant.run_backtest(
+        data=_build_regression_bars("PROFILE_OVERRIDE"),
+        strategy=ProfileCaptureStrategy,
+        symbol="PROFILE_OVERRIDE",
+        execution_mode="current_close",
+        broker_profile="cn_stock_miniqmt",
+        commission_rate=0.0011,
+        stamp_tax_rate=0.0022,
+        min_commission=1.5,
+        lot_size=10,
+        show_progress=False,
+    )
+
+    strategy = cast(ProfileCaptureStrategy, result.strategy)
+    assert strategy.snapshot["commission_rate"] == pytest.approx(0.0011, rel=1e-12)
+    assert strategy.snapshot["stamp_tax_rate"] == pytest.approx(0.0022, rel=1e-12)
+    assert strategy.snapshot["min_commission"] == pytest.approx(1.5, rel=1e-12)
+    assert strategy.snapshot["lot_size"] == 10
+
+
+def test_run_backtest_broker_profile_rejects_unknown_profile() -> None:
+    """Unknown broker_profile should raise a validation error."""
+    with pytest.raises(ValueError, match="Unknown broker_profile"):
+        akquant.run_backtest(
+            data=_build_regression_bars("PROFILE_BAD"),
+            strategy=NoopStrategy,
+            symbol="PROFILE_BAD",
+            broker_profile="does_not_exist",
+            show_progress=False,
+        )
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected_commission", "expected_min_commission"),
+    [
+        ("cn_stock_t1_low_fee", 0.0002, 3.0),
+        ("cn_stock_sim_high_slippage", 0.0003, 5.0),
+    ],
+)
+def test_run_backtest_broker_profile_additional_templates(
+    profile: str, expected_commission: float, expected_min_commission: float
+) -> None:
+    """Additional built-in broker profiles should be available and injectable."""
+    result = akquant.run_backtest(
+        data=_build_regression_bars("PROFILE_EXTRA"),
+        strategy=ProfileCaptureStrategy,
+        symbol="PROFILE_EXTRA",
+        execution_mode="current_close",
+        broker_profile=profile,
+        show_progress=False,
+    )
+
+    strategy = cast(ProfileCaptureStrategy, result.strategy)
+    assert strategy.snapshot["commission_rate"] == pytest.approx(
+        expected_commission, rel=1e-12
+    )
+    assert strategy.snapshot["min_commission"] == pytest.approx(
+        expected_min_commission, rel=1e-12
+    )
+
+
+def test_backtest_result_get_event_stats_from_finished_payload() -> None:
+    """Result wrapper should expose stream event summary stats in a unified dict."""
+    result = akquant.run_backtest(
+        data=_build_benchmark_data(n=120, symbol="EVENT_STATS"),
+        strategy=NoopStrategy,
+        symbol="EVENT_STATS",
+        show_progress=False,
+        on_event=lambda _event: None,
+        stream_mode="audit",
+    )
+
+    stats = result.get_event_stats()
+    assert isinstance(stats, dict)
+    assert int(stats.get("processed_events", 0)) > 0
+    assert str(stats.get("stream_mode")) == "audit"
+    assert int(stats.get("callback_error_count", 0)) == 0
 
 
 def test_run_backtest_analyzer_plugins_lifecycle_and_output() -> None:

--- a/tests/test_report_helpers.py
+++ b/tests/test_report_helpers.py
@@ -10,7 +10,7 @@ class DummyMetrics:
     """Minimal metrics object for report helper tests."""
 
     total_return_pct = 10.0
-    annualized_return = 5.0
+    annualized_return = 0.05
     sharpe_ratio = 1.2
     max_drawdown_pct = 3.0
     volatility = 0.2
@@ -193,4 +193,6 @@ def test_build_metrics_html_contains_key_labels() -> None:
     """Metrics HTML should contain expected labels and formatted values."""
     html = _build_metrics_html(DummyResult(with_data=True))
     assert "累计收益率 (Total Return)" in html
+    assert "年化收益率 (CAGR)" in html
+    assert "5.00%" in html
     assert "交易次数 (Trades)" in html

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -2483,6 +2483,7 @@ def test_strategy_buy_sell_delegate_to_submit_order() -> None:
             client_order_id: str | None = None,
             order_type: str | None = None,
             extra: dict[str, Any] | None = None,
+            broker_options: dict[str, Any] | None = None,
             trail_offset: float | None = None,
             trail_reference_price: float | None = None,
         ) -> str:
@@ -2493,6 +2494,7 @@ def test_strategy_buy_sell_delegate_to_submit_order() -> None:
             _ = client_order_id
             _ = order_type
             _ = extra
+            _ = broker_options
             _ = trail_offset
             _ = trail_reference_price
             assert symbol is not None
@@ -2531,6 +2533,31 @@ def test_strategy_submit_order_trailing_validation() -> None:
         )
 
 
+def test_strategy_submit_order_records_broker_options_in_backtest_mode() -> None:
+    """submit_order should accept broker_options and attach them to known orders."""
+    strategy = MyStrategy()
+    ctx = MagicMock(spec=StrategyContext)
+    order = SimpleNamespace(id="oid-broker-options")
+    ctx.buy.return_value = order.id
+    ctx.active_orders = [order]
+    strategy.ctx = ctx
+
+    order_id = strategy.submit_order(
+        symbol="AAPL",
+        side="Buy",
+        quantity=1.0,
+        broker_options={"xt_price_type": "LATEST_PRICE", "order_remark": "demo"},
+    )
+
+    assert order_id == "oid-broker-options"
+    queried = strategy.get_order(order_id)
+    assert queried is order
+    assert getattr(queried, "broker_options") == {
+        "xt_price_type": "LATEST_PRICE",
+        "order_remark": "demo",
+    }
+
+
 def test_strategy_trailing_helpers_delegate_to_submit_order() -> None:
     """Trailing helper APIs should call unified submit_order with trailing args."""
 
@@ -2550,6 +2577,7 @@ def test_strategy_trailing_helpers_delegate_to_submit_order() -> None:
             client_order_id: str | None = None,
             order_type: str | None = None,
             extra: dict[str, Any] | None = None,
+            broker_options: dict[str, Any] | None = None,
             trail_offset: float | None = None,
             trail_reference_price: float | None = None,
         ) -> str:
@@ -2557,6 +2585,7 @@ def test_strategy_trailing_helpers_delegate_to_submit_order() -> None:
             _ = trigger_price
             _ = client_order_id
             _ = extra
+            _ = broker_options
             self.calls.append(
                 {
                     "symbol": symbol,


### PR DESCRIPTION
- 新增 `broker_profile` 参数，支持 `cn_stock_miniqmt`、`cn_stock_t1_low_fee`、`cn_stock_sim_high_slippage` 三种预设模板，快速注入费率、滑点、手数等默认值
- 为 `BacktestResult` 添加 `get_event_stats()` 方法，统一返回流式事件处理统计摘要
- 在 `submit_order` 及相关委托方法中新增 `broker_options` 参数，支持回测时记录券商扩展字段以便联调审计
- 修复报告中年化收益率格式化问题，使用百分比格式显示
- 更新中英文文档、示例及测试用例，补充相关 API 说明与使用指南