### PR TITLE
docs: 补充 PyCharm 进度条不可见的排查与解决方法

### DIFF
--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -133,6 +133,7 @@ result = aq.run_backtest(
 
 *   推荐逐步将实时 UI / 日志 / 告警接入迁移到 `run_backtest(..., on_event=...)`。
 *   流式场景统一使用 `run_backtest(..., on_event=...)`。
+*   在 PyCharm 中若未开启终端仿真，原生进度条可能不可见；可开启 `Emulate terminal in output console` 或改用 `on_event` 的 `progress` 事件输出文本进度。
 *   阶段 5 后不再提供运行时参数级回滚开关；如需回滚请使用版本级回滚策略。
 *   阶段 4 观察窗口与推进门槛请参考：[流式统一内核观察清单](../advanced/stream_observability.md)。
 
@@ -140,6 +141,7 @@ result = aq.run_backtest(
 
 *   `run_backtest` 是否改名？不改名，调用方式保持不变。
 *   `run_backtest` 是否仍可不传 `on_event`？可以，不传时仍返回同样的结果对象语义。
+*   PyCharm 看不到进度条怎么办？先确认 `show_progress=True`，并在 Run 配置中开启 `Emulate terminal in output console`；若仍不可见，使用 `on_event` 消费 `progress` 事件打印文本进度。
 *   线上出现问题如何回退？使用版本级回滚，不再支持 `_engine_mode` 参数级回切。
 
 ### 流式参数与事件 (`run_backtest`)

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -346,6 +346,42 @@ print("event_stats:", result.get_event_stats())
   - `"continue"`：回调报错后继续回测，并在 `finished.payload` 给出错误统计
   - `"fail_fast"`：回调报错后立即终止并抛出异常
 
+### 4.1 PyCharm 下进度条不显示的排查与解决
+
+在 PyCharm 的 Run 窗口中，如果未开启终端仿真，`stderr` 可能不是 TTY，导致原生进度条不可见。
+
+推荐按以下顺序处理：
+
+1. 在 `Run/Debug Configurations` 中勾选 `Emulate terminal in output console`。
+2. 确认回测参数中未关闭进度条（即 `show_progress=True`）。
+3. 若你更希望跨 IDE 稳定显示进度，建议使用 `on_event` 消费 `progress` 事件。
+
+示例（不依赖原生进度条）：
+
+```python
+from akquant import run_backtest
+
+progress_events = 0
+
+
+def on_event(event):
+    global progress_events
+    if event.get("event_type") == "progress":
+        progress_events += 1
+        if progress_events % 10 == 0:
+            print(f"[progress] events={progress_events}", flush=True)
+
+
+result = run_backtest(
+    data=df,
+    strategy=MyStrategy,
+    symbol="sh600000",
+    on_event=on_event,
+    show_progress=False,
+    stream_progress_interval=5,
+)
+```
+
 流式事件公共字段：
 
 - `run_id`: 本次流式回测 ID
@@ -360,5 +396,6 @@ print("event_stats:", result.get_event_stats())
 
 - `run_backtest` 是否改名？不改名，调用方式保持不变。
 - `run_backtest` 是否还能不传 `on_event`？可以，不传时仍返回同样的结果对象语义。
+- PyCharm 看不到进度条怎么办？开启 `Emulate terminal in output console`，或使用 `on_event + progress` 事件输出文本进度。
 - 如何回滚？阶段 5 后不再支持 `_engine_mode` 参数级回滚，建议使用版本级回滚。
 - 首页导航入口：见 [文档首页的阶段 5 迁移入口](../index.md)。


### PR DESCRIPTION
在快速入门和 API 参考文档中，新增关于 PyCharm 等 IDE 因终端仿真未开启导致进度条不可见的说明。 提供两种解决方案：在 Run 配置中开启 `Emulate terminal in output console`，或使用 `on_event` 回调消费 `progress` 事件输出文本进度。