### PR TITLE
feat: 添加交易日调仓钩子与批量历史数据获取

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.76"
+version = "0.1.77"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.76"
+version = "0.1.77"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -31,6 +31,7 @@
 * `on_reject`: 订单进入 `Rejected` 状态时触发。
 * `on_session_start` / `on_session_end`: 会话切换时触发。
 * `before_trading` / `after_trading`: 交易日级钩子。
+* `on_daily_rebalance`: 交易日调仓钩子（每天最多一次，适合横截面轮动）。
 * `on_portfolio_update`: 账户快照变化时触发。
 * `on_error`: 用户回调抛异常时触发，默认触发后继续抛出异常。
 * `on_timer`: 定时器触发时调用 (需手动注册)。
@@ -49,6 +50,7 @@
 
 * `on_reject` 对同一订单 id 只触发一次。
 * `before_trading` 在本地交易日首次进入 Normal 会话时触发一次。
+* `on_daily_rebalance` 与 `before_trading` 同一阶段触发，每个交易日最多触发一次。
 * `after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `after_trading`。
 * 若需要更精确的交易日边界触发，可在策略中设置 `self.enable_precise_day_boundary_hooks = True`。
 * `on_portfolio_update` 采用增量触发：初始化时触发一次，后续仅在订单/成交或持仓相关价格变化时触发。
@@ -199,13 +201,13 @@ def on_timer(self, payload):
 
 ### 3.4 横截面策略推荐范式 (Cross-Section Pattern)
 
-AKQuant 的 `on_bar` 按“单事件流”逐条触发。若你要做多标的横截面比较（轮动、排序、打分），推荐把决策统一放在 `on_timer`。
+AKQuant 的 `on_bar` 按“单事件流”逐条触发。若你要做多标的横截面比较（轮动、排序、打分），推荐优先使用 `on_daily_rebalance`，由框架保证“每天最多一次”的触发语义。
 
 推荐步骤：
 
-1. 在 `on_start` 中定义 `universe` 并注册每日定时器。
-2. 在 `on_timer` 中遍历 `universe` 计算分数。
-3. 在 `on_timer` 中统一选股与调仓，确保每个时点只执行一次。
+1. 在 `on_start` 中定义 `universe` 并订阅标的。
+2. 在 `on_daily_rebalance` 中遍历 `universe` 计算分数。
+3. 在 `on_daily_rebalance` 中统一选股与调仓。
 
 ```python
 class CrossSectionStrategy(Strategy):
@@ -215,22 +217,31 @@ class CrossSectionStrategy(Strategy):
         self.warmup_period = lookback + 1
 
     def on_start(self):
-        self.add_daily_timer("14:55:00", "rebalance")
-
-    def on_timer(self, payload):
-        if payload != "rebalance":
-            return
-        scores = {}
         for symbol in self.universe:
-            closes = self.get_history(count=self.lookback, symbol=symbol, field="close")
+            self.subscribe(symbol)
+
+    def on_daily_rebalance(self, trading_date, timestamp):
+        history_map = self.get_history_map(
+            count=self.lookback,
+            symbols=self.universe,
+            field="close",
+        )
+        scores = {}
+        for symbol, closes in history_map.items():
             if len(closes) < self.lookback:
-                return
+                continue
             scores[symbol] = (closes[-1] - closes[0]) / closes[0]
-        best = max(scores, key=scores.get)
-        self.order_target_percent(target_percent=0.95, symbol=best)
+        if not scores:
+            return
+        self.rebalance_to_topn(
+            scores=scores,
+            top_n=2,
+            weight_mode="score",
+            long_only=False,
+        )
 ```
 
-完整示例见：`examples/strategies/05_stock_momentum_rotation_timer.py`。
+完整示例见：`examples/strategies/05_stock_momentum_rotation_timer.py`（on_daily_rebalance）与 `examples/strategies/07_stock_momentum_rotation_on_timer.py`（on_timer 固定时点）。
 
 ### 3.5 横截面方案 B：收齐同 timestamp 后执行
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -466,6 +466,7 @@ result = run_backtest(
 *   `on_session_start(session, timestamp)`: 会话切换开始时触发。
 *   `on_session_end(session, timestamp)`: 会话切换结束时触发。
 *   `before_trading(trading_date, timestamp)`: 每个本地交易日首次进入 Normal 会话时触发一次。
+*   `on_daily_rebalance(trading_date, timestamp)`: 交易日调仓钩子，每个交易日最多触发一次。
 *   `after_trading(trading_date, timestamp)`: 离开 Normal 会话时触发；若先跨日则在下一事件补发。
 *   `on_portfolio_update(snapshot)`: 账户快照变化时触发。
 *   `on_error(error, source, payload=None)`: 用户回调抛异常时触发，默认触发后继续抛出。
@@ -511,6 +512,8 @@ result = run_backtest(
 **数据与工具:**
 
 *   `get_history(count, symbol, field="close") -> np.ndarray`: 获取历史数据数组 (Zero-Copy)。
+*   `get_history_map(count, symbols, field="close") -> Dict[str, np.ndarray]`: 批量获取多个标的历史数据。
+*   `rebalance_to_topn(scores, top_n, weight_mode="equal", ...) -> List[str]`: 根据打分选取 TopN 并执行调仓，支持等权或按分数归一化。
 *   `get_history_df(count, symbol) -> pd.DataFrame`: 获取历史数据 DataFrame (OHLCV)。
 *   `get_position(symbol) -> float`: 获取当前持仓量。
 *   `get_available_position(symbol) -> float`: 获取可用持仓量。

--- a/examples/11_plot_visualization.py
+++ b/examples/11_plot_visualization.py
@@ -15,6 +15,7 @@ from akquant import (
     Strategy,
     run_backtest,
 )
+from akquant.utils import format_metric_value
 
 
 # --------------------------------------------------------------------------------
@@ -82,11 +83,21 @@ if __name__ == "__main__":
     # 3. Print Metrics
     print("\nPerformance Metrics:")
     metrics = result.metrics
-    print(f"  Total Return:      {metrics.total_return_pct:>6.2f}%")
-    print(f"  Annualized Return: {metrics.annualized_return:>6.2f}%")
+    total_return_display = format_metric_value(
+        "total_return_pct", metrics.total_return_pct, width=6
+    )
+    annualized_return_display = format_metric_value(
+        "annualized_return", metrics.annualized_return, width=6
+    )
+    max_drawdown_display = format_metric_value(
+        "max_drawdown_pct", metrics.max_drawdown_pct, width=6
+    )
+    win_rate_display = format_metric_value("win_rate", metrics.win_rate, width=6)
+    print(f"  Total Return:      {total_return_display}")
+    print(f"  Annualized Return: {annualized_return_display}")
     print(f"  Sharpe Ratio:      {metrics.sharpe_ratio:>6.2f}")
-    print(f"  Max Drawdown:      {metrics.max_drawdown_pct:>6.2f}%")
-    print(f"  Win Rate:          {metrics.win_rate:>6.2f}%")
+    print(f"  Max Drawdown:      {max_drawdown_display}")
+    print(f"  Win Rate:          {win_rate_display}")
     print(f"  Total Trades:      {len(result.trades_df)}")
 
     # 4. Visualization

--- a/examples/15_plot_intraday.py
+++ b/examples/15_plot_intraday.py
@@ -17,6 +17,7 @@ from akquant import (
     Strategy,
     run_backtest,
 )
+from akquant.utils import format_metric_value
 
 
 # --------------------------------------------------------------------------------
@@ -144,15 +145,25 @@ if __name__ == "__main__":
         initial_cash=1_000_000.0,
         show_progress=True,
     )
-
+    print(result)
     # 3. Print Metrics
     print("\nPerformance Metrics:")
     metrics = result.metrics
-    print(f"  Total Return:      {metrics.total_return_pct:>6.2f}%")
-    print(f"  Annualized Return: {metrics.annualized_return:>6.2f}%")
+    total_return_display = format_metric_value(
+        "total_return_pct", metrics.total_return_pct, width=6
+    )
+    annualized_return_display = format_metric_value(
+        "annualized_return", metrics.annualized_return, width=6
+    )
+    max_drawdown_display = format_metric_value(
+        "max_drawdown_pct", metrics.max_drawdown_pct, width=6
+    )
+    win_rate_display = format_metric_value("win_rate", metrics.win_rate, width=6)
+    print(f"  Total Return:      {total_return_display}")
+    print(f"  Annualized Return: {annualized_return_display}")
     print(f"  Sharpe Ratio:      {metrics.sharpe_ratio:>6.2f}")
-    print(f"  Max Drawdown:      {metrics.max_drawdown_pct:>6.2f}%")
-    print(f"  Win Rate:          {metrics.win_rate:>6.2f}%")
+    print(f"  Max Drawdown:      {max_drawdown_display}")
+    print(f"  Win Rate:          {win_rate_display}")
     print(f"  Total Trades:      {len(result.trades_df)}")
 
     # 4. Visualization

--- a/examples/strategies/07_stock_momentum_rotation_on_timer.py
+++ b/examples/strategies/07_stock_momentum_rotation_on_timer.py
@@ -1,4 +1,4 @@
-"""多股票轮动策略示例（on_daily_rebalance 版本）."""
+"""多股票轮动策略示例（on_timer 固定时点版本）."""
 
 from typing import Any
 
@@ -45,21 +45,13 @@ def make_data() -> dict[str, pd.DataFrame]:
         pd.date_range("2022-01-04 10:00:00", periods=240, freq="B", tz="Asia/Shanghai")
     )
     return {
-        "AAA": _build_symbol_df(
-            "AAA",
-            timestamps,
-            [aaa_close(i) for i in range(240)],
-        ),
-        "BBB": _build_symbol_df(
-            "BBB",
-            timestamps,
-            [bbb_close(i) for i in range(240)],
-        ),
+        "AAA": _build_symbol_df("AAA", timestamps, [aaa_close(i) for i in range(240)]),
+        "BBB": _build_symbol_df("BBB", timestamps, [bbb_close(i) for i in range(240)]),
     }
 
 
-class TimerMomentumRotationStrategy(Strategy):
-    """使用 on_daily_rebalance 执行横截面轮动."""
+class OnTimerMomentumRotationStrategy(Strategy):
+    """使用 on_timer 在固定时点执行横截面轮动."""
 
     def __init__(self, lookback_period: int = 5, **kwargs: Any) -> None:
         """初始化策略参数."""
@@ -70,15 +62,21 @@ class TimerMomentumRotationStrategy(Strategy):
         self.warmup_period = lookback_period + 1
 
     def on_start(self) -> None:
-        """策略启动时订阅轮动标的."""
+        """策略启动时注册固定时点调仓定时器."""
         for symbol in self.symbols:
             self.subscribe(symbol)
-        self.log(f"on_start subscribe={self.symbols} lookback={self.lookback_period}")
+        self.add_daily_timer("10:00:00", "rebalance")
+        self.log(
+            "on_start "
+            f"subscribe={self.symbols} "
+            "timer=10:00:00 "
+            f"lookback={self.lookback_period}"
+        )
 
-    def on_daily_rebalance(self, trading_date: Any, timestamp: int) -> None:
-        """交易日调仓回调."""
-        _ = timestamp
-        self.log(f"on_daily_rebalance date={trading_date}")
+    def on_timer(self, payload: str) -> None:
+        """固定时点触发调仓."""
+        if payload != "rebalance":
+            return
         history_map = self.get_history_map(
             count=self.lookback_period,
             symbols=self.symbols,
@@ -93,33 +91,24 @@ class TimerMomentumRotationStrategy(Strategy):
             if start <= 0:
                 continue
             scores[symbol] = (end - start) / start
-
         if not scores:
             return
-
-        ranking = sorted(scores.items(), key=lambda item: item[1], reverse=True)
-        self.log(
-            "rebalance ranking="
-            + ", ".join(f"{symbol}:{score:.2%}" for symbol, score in ranking)
-        )
         selected = self.rebalance_to_topn(
             scores=scores,
-            top_n=2,
+            top_n=1,
             weight_mode="score",
             long_only=False,
             liquidate_unmentioned=True,
         )
-        self.log(f"action=rebalance selected={selected}")
+        self.log(f"on_timer action=rebalance selected={selected}")
 
 
 if __name__ == "__main__":
-    symbols = ["AAA", "BBB"]
     data_map = make_data()
-
     result = aq.run_backtest(
         data=data_map,
-        strategy=TimerMomentumRotationStrategy,
-        symbol=symbols,
+        strategy=OnTimerMomentumRotationStrategy,
+        symbol=["AAA", "BBB"],
         initial_cash=1_000_000.0,
         commission_rate=0.0003,
         stamp_tax_rate=0.001,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.76"
+version = "0.1.77"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -68,7 +68,12 @@ from .plot import plot_result
 from .sizer import AllInSizer, FixedSize, PercentSizer, Sizer
 from .strategy import Strategy, StrategyRuntimeConfig
 from .strategy_loader import register_strategy_loader, resolve_strategy_input
-from .utils import fetch_akshare_symbol, load_bar_from_df, prepare_dataframe
+from .utils import (
+    fetch_akshare_symbol,
+    format_metric_value,
+    load_bar_from_df,
+    prepare_dataframe,
+)
 
 __doc__ = _akquant.__doc__
 if hasattr(_akquant, "__all__"):  # noqa: F405
@@ -76,6 +81,7 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "load_bar_from_df",
         "prepare_dataframe",
         "fetch_akshare_symbol",
+        "format_metric_value",
         "Sizer",
         "FixedSize",
         "PercentSizer",
@@ -144,6 +150,7 @@ else:
         "load_bar_from_df",
         "prepare_dataframe",
         "fetch_akshare_symbol",
+        "format_metric_value",
         "Sizer",
         "FixedSize",
         "PercentSizer",

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -928,7 +928,7 @@ class PerformanceMetrics:
 
     :ivar total_return: 总收益 (数值)
     :ivar annualized_return: 年化收益率
-    :ivar max_drawdown: 最大回撤 (百分比, 如 0.15 表示 15%)
+    :ivar max_drawdown: 最大回撤比率 (小数, 如 0.15 表示 15%)
     :ivar max_drawdown_value: 最大回撤金额
     :ivar max_drawdown_pct: 最大回撤百分比 (如 15.0 表示 15%)
     :ivar sharpe_ratio: 夏普比率
@@ -939,7 +939,7 @@ class PerformanceMetrics:
     :ivar upi: 溃疡绩效指数 (UPI)
     :ivar equity_r2: 权益曲线 R^2 (拟合度)
     :ivar std_error: 标准误差
-    :ivar win_rate: 胜率 (0.0-1.0)
+    :ivar win_rate: 胜率 (%)
     :ivar initial_market_value: 初始市值
     :ivar end_market_value: 结束市值
     :ivar total_return_pct: 总收益率 (%)
@@ -2606,8 +2606,8 @@ class TradePnL:
     :ivar lost_count: 亏损次数
     :ivar won_pnl: 盈利总额
     :ivar lost_pnl: 亏损总额
-    :ivar win_rate: 胜率 (0.0-1.0)
-    :ivar loss_rate: 亏损率 (0.0-1.0)
+    :ivar win_rate: 胜率 (%)
+    :ivar loss_rate: 亏损率 (%)
     :ivar unrealized_pnl: 未实现盈亏
     :ivar avg_pnl: 平均单笔盈亏
     :ivar avg_return_pct: 平均单笔收益率 (%)

--- a/python/akquant/backtest/plot.py
+++ b/python/akquant/backtest/plot.py
@@ -2,6 +2,8 @@ from typing import Any, Optional
 
 import pandas as pd
 
+from ..utils import format_metric_value
+
 
 def plot_result(
     result: Any,
@@ -125,13 +127,23 @@ def plot_result(
     # Add Metrics Text Box
     metrics = result.metrics
     trade_metrics = result.trade_metrics
+    total_return_display = format_metric_value(
+        "total_return_pct", metrics.total_return_pct, width=8
+    )
+    annualized_display = format_metric_value(
+        "annualized_return", metrics.annualized_return, width=8
+    )
+    max_drawdown_display = format_metric_value(
+        "max_drawdown_pct", metrics.max_drawdown_pct, width=8
+    )
+    win_rate_display = format_metric_value("win_rate", metrics.win_rate, width=8)
 
     metrics_text = [
-        f"Total Return: {metrics.total_return_pct:>8.2f}%",
-        f"Annualized:   {metrics.annualized_return:>8.2%}",
+        f"Total Return: {total_return_display}",
+        f"Annualized:   {annualized_display}",
         f"Sharpe Ratio: {metrics.sharpe_ratio:>8.2f}",
-        f"Max Drawdown: {metrics.max_drawdown_pct:>8.2f}%",
-        f"Win Rate:     {metrics.win_rate:>8.2%}",
+        f"Max Drawdown: {max_drawdown_display}",
+        f"Win Rate:     {win_rate_display}",
     ]
 
     if hasattr(trade_metrics, "total_closed_trades"):

--- a/python/akquant/live.py
+++ b/python/akquant/live.py
@@ -8,6 +8,7 @@ from .gateway.factory import create_gateway_bundle
 from .gateway.models import UnifiedOrderRequest
 from .strategy import Strategy
 from .strategy_loader import resolve_strategy_input
+from .utils import format_metric_value
 
 
 class _StrategyCallbackFanout:
@@ -1045,11 +1046,21 @@ class LiveRunner:
             print("\n" + "=" * 50)
             print("TRADING SUMMARY (Manual Stop)")
             print("=" * 50)
-            print(f"Total Return: {results.metrics.total_return_pct:.2%}")
-            print(f"Annualized Return: {results.metrics.annualized_return:.2%}")
-            print(f"Max Drawdown: {results.metrics.max_drawdown_pct:.2%}")
+            total_return_display = format_metric_value(
+                "total_return_pct", results.metrics.total_return_pct
+            )
+            annualized_return_display = format_metric_value(
+                "annualized_return", results.metrics.annualized_return
+            )
+            max_drawdown_display = format_metric_value(
+                "max_drawdown_pct", results.metrics.max_drawdown_pct
+            )
+            win_rate_display = format_metric_value("win_rate", results.metrics.win_rate)
+            print(f"Total Return: {total_return_display}")
+            print(f"Annualized Return: {annualized_return_display}")
+            print(f"Max Drawdown: {max_drawdown_display}")
             print(f"Sharpe Ratio: {results.metrics.sharpe_ratio:.4f}")
-            print(f"Win Rate: {results.metrics.win_rate:.2%}")
+            print(f"Win Rate: {win_rate_display}")
             print(f"Total Trades: {len(results.trades)}")
             print("=" * 50)
 

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import pandas as pd
 
+from ..utils import format_metric_value
 from .analysis import (
     plot_pnl_vs_duration,
     plot_returns_distribution,
@@ -605,13 +606,13 @@ def _build_metrics_html(result: Any) -> str:
         (
             "累计收益率 (Total Return)",
             metrics.total_return_pct,
-            f"{metrics.total_return_pct:.2f}%",
+            format_metric_value("total_return_pct", metrics.total_return_pct),
             get_color_class(metrics.total_return_pct),
         ),
         (
             "年化收益率 (CAGR)",
             metrics.annualized_return,
-            f"{metrics.annualized_return:.2%}",
+            format_metric_value("annualized_return", metrics.annualized_return),
             get_color_class(metrics.annualized_return),
         ),
         (
@@ -641,19 +642,19 @@ def _build_metrics_html(result: Any) -> str:
         (
             "最大回撤 (Max DD)",
             metrics.max_drawdown_pct,
-            f"{metrics.max_drawdown_pct:.2f}%",
+            format_metric_value("max_drawdown_pct", metrics.max_drawdown_pct),
             "negative",
         ),
         (
             "波动率 (Volatility)",
             metrics.volatility,
-            f"{metrics.volatility:.2%}",
+            format_metric_value("volatility", metrics.volatility),
             "",
         ),
         (
             "胜率 (Win Rate)",
             metrics.win_rate,
-            f"{metrics.win_rate:.2f}%",
+            format_metric_value("win_rate", metrics.win_rate),
             "",
         ),
         (
@@ -665,7 +666,10 @@ def _build_metrics_html(result: Any) -> str:
         (
             "凯利公式 (Kelly)",
             _get_metric_value(result, metrics, "kelly_criterion"),
-            f"{_get_metric_value(result, metrics, 'kelly_criterion'):.2%}",
+            format_metric_value(
+                "kelly_criterion",
+                _get_metric_value(result, metrics, "kelly_criterion"),
+            ),
             "",
         ),
         ("交易次数 (Trades)", len(result.trades_df), f"{len(result.trades_df)}", ""),

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -251,6 +251,8 @@ class Strategy:
     ]
     _pending_brackets: Dict[str, Dict[str, Any]]
     _order_group_seq: int
+    _pending_schedules: List[Tuple[Union[str, dt.datetime, pd.Timestamp], str]]
+    _pending_daily_timers: List[Tuple[str, str]]
 
     _trading_days: List[pd.Timestamp]
 
@@ -354,6 +356,8 @@ class Strategy:
         instance._pending_engine_bracket_plans = []
         instance._pending_brackets = {}
         instance._order_group_seq = 0
+        instance._pending_schedules = []
+        instance._pending_daily_timers = []
 
         return instance
 
@@ -445,6 +449,10 @@ class Strategy:
             self._pending_brackets = {}
         if not hasattr(self, "_order_group_seq"):
             self._order_group_seq = 0
+        if not hasattr(self, "_pending_schedules"):
+            self._pending_schedules = []
+        if not hasattr(self, "_pending_daily_timers"):
+            self._pending_daily_timers = []
         _ensure_framework_state_impl(self)
 
     @property
@@ -745,6 +753,125 @@ class Strategy:
         """
         return _get_history_impl(self, count, symbol, field)
 
+    def get_history_map(
+        self,
+        count: int,
+        symbols: Union[str, List[str], Tuple[str, ...], set[str]],
+        field: str = "close",
+    ) -> Dict[str, np.ndarray]:
+        """
+        批量获取多个标的的历史数据.
+
+        :param count: 获取的数据长度
+        :param symbols: 标的代码或标的列表
+        :param field: 字段名 (open, high, low, close, volume)
+        :return: {symbol: np.ndarray}
+        """
+        normalized = self._normalize_indicator_symbols(symbols)
+        if normalized is None:
+            raise ValueError("symbols cannot be None")
+        normalized_symbols = sorted(normalized)
+        history_map: Dict[str, np.ndarray] = {}
+        for symbol in normalized_symbols:
+            history_map[symbol] = self.get_history(
+                count=count,
+                symbol=symbol,
+                field=field,
+            )
+        return history_map
+
+    def rebalance_to_topn(
+        self,
+        scores: Dict[str, float],
+        top_n: int,
+        *,
+        weight_mode: Literal["equal", "score"] = "equal",
+        long_only: bool = True,
+        min_score: Optional[float] = None,
+        liquidate_unmentioned: bool = True,
+        allow_leverage: bool = False,
+        rebalance_tolerance: float = 0.0,
+        **kwargs: Any,
+    ) -> List[str]:
+        """
+        根据打分结果选取 TopN 并执行调仓.
+
+        :param scores: 打分字典 {symbol: score}
+        :param top_n: 选取数量
+        :param weight_mode: 权重模式，"equal" 为等权，"score" 为按分数归一化
+        :param long_only: 是否仅允许做多（默认仅保留正分）
+        :param min_score: 最低分数阈值（None 时 long_only=True 默认阈值为 0）
+        :param liquidate_unmentioned: 是否清仓未入选标的
+        :param allow_leverage: 是否允许总权重超过 1.0
+        :param rebalance_tolerance: 调仓容忍阈值（按组合市值比例）
+        :param kwargs: 透传到 order_target_weights 的下单参数
+        :return: 入选标的列表（按分数从高到低）
+        """
+        if top_n <= 0:
+            raise ValueError("top_n must be greater than 0")
+        if weight_mode not in {"equal", "score"}:
+            raise ValueError("weight_mode must be one of: equal, score")
+
+        if not scores:
+            if liquidate_unmentioned:
+                self.order_target_weights(
+                    target_weights={},
+                    liquidate_unmentioned=True,
+                    allow_leverage=allow_leverage,
+                    rebalance_tolerance=rebalance_tolerance,
+                    **kwargs,
+                )
+            return []
+
+        ranking = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        threshold = min_score
+        if threshold is None and long_only:
+            threshold = 0.0
+
+        selected: List[str] = []
+        for symbol, score in ranking:
+            if threshold is not None and score < threshold:
+                continue
+            selected.append(symbol)
+            if len(selected) >= top_n:
+                break
+
+        if not selected:
+            if liquidate_unmentioned:
+                self.order_target_weights(
+                    target_weights={},
+                    liquidate_unmentioned=True,
+                    allow_leverage=allow_leverage,
+                    rebalance_tolerance=rebalance_tolerance,
+                    **kwargs,
+                )
+            return []
+
+        target_weights: Dict[str, float]
+        if weight_mode == "equal":
+            target_weight = 1.0 / float(len(selected))
+            target_weights = {symbol: target_weight for symbol in selected}
+        else:
+            clipped_scores = {
+                symbol: max(float(scores[symbol]), 0.0) for symbol in selected
+            }
+            score_sum = float(sum(clipped_scores.values()))
+            if score_sum <= 0:
+                target_weight = 1.0 / float(len(selected))
+                target_weights = {symbol: target_weight for symbol in selected}
+            else:
+                target_weights = {
+                    symbol: clipped_scores[symbol] / score_sum for symbol in selected
+                }
+        self.order_target_weights(
+            target_weights=target_weights,
+            liquidate_unmentioned=liquidate_unmentioned,
+            allow_leverage=allow_leverage,
+            rebalance_tolerance=rebalance_tolerance,
+            **kwargs,
+        )
+        return selected
+
     def get_history_df(self, count: int, symbol: Optional[str] = None) -> pd.DataFrame:
         """
         获取历史数据 DataFrame (Open, High, Low, Close, Volume).
@@ -931,6 +1058,10 @@ class Strategy:
 
     def before_trading(self, trading_date: dt.date, timestamp: int) -> None:
         """交易日开始前回调."""
+        pass
+
+    def on_daily_rebalance(self, trading_date: dt.date, timestamp: int) -> None:
+        """交易日调仓回调（每天最多一次）."""
         pass
 
     def after_trading(self, trading_date: dt.date, timestamp: int) -> None:

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -13,12 +13,14 @@ from .strategy_framework_hooks import (
     mark_portfolio_dirty,
     register_boundary_timers,
 )
+from .strategy_scheduler import flush_pending_schedules
 
 
 def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     """引擎调用的 Bar 回调 (Internal)."""
     ensure_framework_state(strategy)
     strategy.ctx = ctx
+    flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
     strategy._last_event_type = "bar"
 
@@ -87,6 +89,7 @@ def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
     """引擎调用的 Tick 回调 (Internal)."""
     ensure_framework_state(strategy)
     strategy.ctx = ctx
+    flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
     strategy._last_event_type = "tick"
     strategy._check_order_events()
@@ -106,6 +109,7 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
     """引擎调用的 Timer 回调 (Internal)."""
     ensure_framework_state(strategy)
     strategy.ctx = ctx
+    flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
     strategy._check_order_events()
     dispatch_time_hooks(strategy)

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -51,6 +51,21 @@ def _should_reraise_on_error(strategy: Any) -> bool:
     return bool(_runtime_option(strategy, "re_raise_on_error"))
 
 
+def _dispatch_daily_rebalance_if_needed(
+    strategy: Any, trading_date: Any, timestamp: int
+) -> None:
+    if getattr(strategy, "_framework_daily_rebalance_done_date", None) == trading_date:
+        return
+    call_user_callback(
+        strategy,
+        "on_daily_rebalance",
+        trading_date,
+        timestamp,
+        payload={"trading_date": trading_date, "timestamp": timestamp},
+    )
+    strategy._framework_daily_rebalance_done_date = trading_date
+
+
 def call_user_callback(
     strategy: Any, callback_name: str, *args: Any, payload: Optional[Any] = None
 ) -> Any:
@@ -84,6 +99,9 @@ def dispatch_time_hooks(strategy: Any) -> None:
     ts = pd.to_datetime(current_time, unit="ns", utc=True).tz_convert(strategy.timezone)
     current_date = ts.date()
     current_session = getattr(strategy.ctx, "session", None)
+
+    if getattr(strategy, "_framework_daily_rebalance_done_date", None) != current_date:
+        _dispatch_daily_rebalance_if_needed(strategy, current_date, current_time)
 
     last_date = getattr(strategy, "_framework_last_local_date", None)
     before_done_date = getattr(strategy, "_framework_before_trading_done_date", None)
@@ -338,6 +356,8 @@ def ensure_framework_state(strategy: Any) -> None:
         strategy._framework_last_local_date = None
     if not hasattr(strategy, "_framework_before_trading_done_date"):
         strategy._framework_before_trading_done_date = None
+    if not hasattr(strategy, "_framework_daily_rebalance_done_date"):
+        strategy._framework_daily_rebalance_done_date = None
     if not hasattr(strategy, "_framework_after_trading_done_date"):
         strategy._framework_after_trading_done_date = None
     if not hasattr(strategy, "_framework_last_portfolio_state"):

--- a/python/akquant/strategy_scheduler.py
+++ b/python/akquant/strategy_scheduler.py
@@ -9,7 +9,12 @@ def schedule(
 ) -> None:
     """注册单次定时任务."""
     if strategy.ctx is None:
-        raise RuntimeError("Context not ready")
+        pending = getattr(strategy, "_pending_schedules", None)
+        if pending is None:
+            pending = []
+            strategy._pending_schedules = pending
+        pending.append((trigger_time, payload))
+        return
 
     ts_ns = 0
     if isinstance(trigger_time, str):
@@ -34,8 +39,34 @@ def schedule(
         strategy.ctx.schedule(ts_ns, payload)
 
 
+def flush_pending_schedules(strategy: Any) -> None:
+    """在上下文就绪后刷出缓存的定时任务."""
+    if strategy.ctx is None:
+        return
+    pending_daily = getattr(strategy, "_pending_daily_timers", None)
+    if pending_daily:
+        queued_daily = list(pending_daily)
+        pending_daily.clear()
+        for time_str, payload in queued_daily:
+            add_daily_timer(strategy, time_str, payload)
+    pending = getattr(strategy, "_pending_schedules", None)
+    if not pending:
+        return
+    queued = list(pending)
+    pending.clear()
+    for trigger_time, payload in queued:
+        schedule(strategy, trigger_time, payload)
+
+
 def add_daily_timer(strategy: Any, time_str: str, payload: str) -> None:
     """注册每日定时任务."""
+    if strategy.ctx is None:
+        pending_daily = getattr(strategy, "_pending_daily_timers", None)
+        if pending_daily is None:
+            pending_daily = []
+            strategy._pending_daily_timers = pending_daily
+        pending_daily.append((time_str, payload))
+        return
     wrapped_payload = f"__daily__|{time_str}|{payload}"
 
     if not strategy._trading_days:

--- a/python/akquant/utils/__init__.py
+++ b/python/akquant/utils/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
@@ -502,3 +502,83 @@ def prepare_dataframe(
         pass
 
     return df
+
+
+_RATIO_PERCENT_METRICS = frozenset(
+    {
+        "annualized_return",
+        "volatility",
+        "kelly_criterion",
+    }
+)
+
+_PERCENT_VALUE_METRICS = frozenset(
+    {
+        "total_return_pct",
+        "max_drawdown_pct",
+        "win_rate",
+        "loss_rate",
+        "exposure_time_pct",
+    }
+)
+
+
+def format_percentage(
+    value: float,
+    source: Literal["ratio", "pct_value"] = "ratio",
+    precision: int = 2,
+    width: Optional[int] = None,
+) -> str:
+    r"""
+    Format a value as percentage with explicit source unit.
+
+    :param value: Numeric value to format.
+    :param source: "ratio" 表示 0.1 -> 10%，"pct_value" 表示 10 -> 10%。
+    :param precision: Decimal places.
+    :param width: Optional width for right alignment.
+    :return: Formatted percentage text.
+    """
+    if source == "ratio":
+        text = f"{float(value):.{precision}%}"
+    else:
+        text = f"{float(value):.{precision}f}%"
+    if width is None:
+        return text
+    return f"{text:>{width}}"
+
+
+def format_metric_value(
+    metric_name: str,
+    value: float,
+    precision: int = 2,
+    width: Optional[int] = None,
+) -> str:
+    r"""
+    Format metric display text using AKQuant metric unit mapping.
+
+    :param metric_name: Metric field name.
+    :param value: Raw metric value.
+    :param precision: Decimal places.
+    :param width: Optional width for right alignment.
+    :return: Formatted metric text.
+    """
+    name = str(metric_name)
+    numeric = float(value)
+    if name in _RATIO_PERCENT_METRICS:
+        return format_percentage(
+            numeric,
+            source="ratio",
+            precision=precision,
+            width=width,
+        )
+    if name in _PERCENT_VALUE_METRICS:
+        return format_percentage(
+            numeric,
+            source="pct_value",
+            precision=precision,
+            width=width,
+        )
+    text = f"{numeric:.{precision}f}"
+    if width is None:
+        return text
+    return f"{text:>{width}}"

--- a/src/analysis/tests.rs
+++ b/src/analysis/tests.rs
@@ -263,3 +263,30 @@ fn test_ulcer_index_logic() {
     let expected_ui = 0.004f64.sqrt();
     assert!((result.metrics.ulcer_index - expected_ui).abs() < 1e-9);
 }
+
+#[test]
+fn test_calmar_uses_raw_drawdown_ratio_not_pct() {
+    let empty_pnl = TradeTracker::new().calculate_pnl(None);
+    let equity_curve = vec![
+        (0, Decimal::from(100)),
+        (15_768_000_000_000_000, Decimal::from(110)),
+        (31_536_000_000_000_000, Decimal::from(105)),
+    ];
+
+    let result = BacktestResult::calculate(crate::analysis::CalculatorInput {
+        equity_curve_decimal: equity_curve,
+        cash_curve_decimal: vec![],
+        snapshots: vec![],
+        trade_pnl: empty_pnl,
+        trades: vec![],
+        initial_cash: Decimal::from(100),
+        orders: vec![],
+        executions: vec![],
+    });
+
+    let expected_raw_calmar = result.metrics.annualized_return / result.metrics.max_drawdown;
+    let wrong_pct_calmar = result.metrics.annualized_return / result.metrics.max_drawdown_pct;
+
+    assert!((result.metrics.calmar_ratio - expected_raw_calmar).abs() < 1e-12);
+    assert!((result.metrics.calmar_ratio - wrong_pct_calmar).abs() > 1e-3);
+}

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -82,7 +82,7 @@ impl ClosedTrade {
 ///
 /// :ivar total_return: 总收益 (数值)
 /// :ivar annualized_return: 年化收益率
-/// :ivar max_drawdown: 最大回撤 (百分比, 如 0.15 表示 15%)
+/// :ivar max_drawdown: 最大回撤比率 (小数, 如 0.15 表示 15%)
 /// :ivar max_drawdown_value: 最大回撤金额
 /// :ivar max_drawdown_pct: 最大回撤百分比 (如 15.0 表示 15%)
 /// :ivar sharpe_ratio: 夏普比率
@@ -93,7 +93,7 @@ impl ClosedTrade {
 /// :ivar upi: 溃疡绩效指数 (UPI)
 /// :ivar equity_r2: 权益曲线 R^2 (拟合度)
 /// :ivar std_error: 标准误差
-/// :ivar win_rate: 胜率 (0.0-1.0)
+/// :ivar win_rate: 胜率 (%)
 /// :ivar initial_market_value: 初始市值
 /// :ivar end_market_value: 结束市值
 /// :ivar total_return_pct: 总收益率 (%)
@@ -116,7 +116,7 @@ pub struct PerformanceMetrics {
     #[pyo3(get)]
     pub max_drawdown_value: f64,
     #[pyo3(get)]
-    pub max_drawdown_pct: f64, // Same as max_drawdown but explicit
+    pub max_drawdown_pct: f64, // max_drawdown * 100
     #[pyo3(get)]
     pub sharpe_ratio: f64,
     #[pyo3(get)]
@@ -312,8 +312,8 @@ impl PerformanceMetrics {
 /// :ivar lost_count: 亏损次数
 /// :ivar won_pnl: 盈利总额
 /// :ivar lost_pnl: 亏损总额
-/// :ivar win_rate: 胜率 (0.0-1.0)
-/// :ivar loss_rate: 亏损率 (0.0-1.0)
+/// :ivar win_rate: 胜率 (%)
+/// :ivar loss_rate: 亏损率 (%)
 /// :ivar unrealized_pnl: 未实现盈亏
 /// :ivar avg_pnl: 平均单笔盈亏
 /// :ivar avg_return_pct: 平均单笔收益率 (%)

--- a/tests/test_report_helpers.py
+++ b/tests/test_report_helpers.py
@@ -4,13 +4,14 @@ from akquant.plot.report import (
     _build_metrics_html,
     _build_summary_context,
 )
+from akquant.utils import format_metric_value
 
 
 class DummyMetrics:
     """Minimal metrics object for report helper tests."""
 
     total_return_pct = 10.0
-    annualized_return = 0.05
+    annualized_return = 0.021184
     sharpe_ratio = 1.2
     max_drawdown_pct = 3.0
     volatility = 0.2
@@ -194,5 +195,12 @@ def test_build_metrics_html_contains_key_labels() -> None:
     html = _build_metrics_html(DummyResult(with_data=True))
     assert "累计收益率 (Total Return)" in html
     assert "年化收益率 (CAGR)" in html
-    assert "5.00%" in html
+    assert "2.12%" in html
     assert "交易次数 (Trades)" in html
+
+
+def test_format_metric_value_uses_metric_unit_mapping() -> None:
+    """Metric formatter should distinguish ratio and pct-value metrics."""
+    assert format_metric_value("annualized_return", 0.021184) == "2.12%"
+    assert format_metric_value("max_drawdown_pct", 1.07) == "1.07%"
+    assert format_metric_value("calmar_ratio", 22.473305) == "22.47"

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
+import numpy as np
 import pandas as pd
 import pytest
 from akquant import (
@@ -97,6 +98,140 @@ def test_strategy_properties() -> None:
     assert strategy.open == 0.0
     assert strategy.high == 0.0
     assert strategy.low == 0.0
+
+
+class HistoryMapStrategy(Strategy):
+    """Strategy for get_history_map tests."""
+
+    def __init__(self) -> None:
+        """Initialize captured calls."""
+        self.calls: list[tuple[int, str | None, str]] = []
+
+    def get_history(
+        self, count: int, symbol: str | None = None, field: str = "close"
+    ) -> np.ndarray:
+        """Return deterministic history and record invocation."""
+        self.calls.append((count, symbol, field))
+        return np.array([1.0, 2.0, 3.0], dtype=float)
+
+
+def test_get_history_map_normalizes_symbols_and_batches() -> None:
+    """get_history_map should normalize symbols and call get_history per symbol."""
+    strategy = HistoryMapStrategy()
+
+    history_map = strategy.get_history_map(
+        count=3,
+        symbols=["BBB", "AAA", "AAA"],
+        field="close",
+    )
+
+    assert set(history_map.keys()) == {"AAA", "BBB"}
+    assert strategy.calls == [(3, "AAA", "close"), (3, "BBB", "close")]
+
+
+def test_get_history_map_supports_single_symbol() -> None:
+    """get_history_map should support single symbol inputs."""
+    strategy = HistoryMapStrategy()
+
+    history_map = strategy.get_history_map(count=2, symbols="AAA", field="open")
+
+    assert list(history_map.keys()) == ["AAA"]
+    assert strategy.calls == [(2, "AAA", "open")]
+
+
+class TopNRebalanceStrategy(Strategy):
+    """Strategy for rebalance_to_topn tests."""
+
+    def __init__(self) -> None:
+        """Initialize call snapshots."""
+        self.calls: list[dict[str, Any]] = []
+
+    def order_target_weights(
+        self,
+        target_weights: dict[str, float],
+        price_map: dict[str, float] | None = None,
+        liquidate_unmentioned: bool = False,
+        allow_leverage: bool = False,
+        rebalance_tolerance: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        """Capture target weights invocation."""
+        self.calls.append(
+            {
+                "target_weights": target_weights,
+                "price_map": price_map,
+                "liquidate_unmentioned": liquidate_unmentioned,
+                "allow_leverage": allow_leverage,
+                "rebalance_tolerance": rebalance_tolerance,
+                "kwargs": kwargs,
+            }
+        )
+
+
+def test_rebalance_to_topn_equal_weight_selection() -> None:
+    """rebalance_to_topn should select top symbols and place equal weights."""
+    strategy = TopNRebalanceStrategy()
+
+    selected = strategy.rebalance_to_topn(
+        scores={"AAA": 0.03, "BBB": 0.08, "CCC": 0.05},
+        top_n=2,
+    )
+
+    assert selected == ["BBB", "CCC"]
+    assert len(strategy.calls) == 1
+    assert strategy.calls[0]["target_weights"] == {"BBB": 0.5, "CCC": 0.5}
+    assert strategy.calls[0]["liquidate_unmentioned"] is True
+
+
+def test_rebalance_to_topn_filters_non_positive_when_long_only() -> None:
+    """rebalance_to_topn should clear positions when no positive scores remain."""
+    strategy = TopNRebalanceStrategy()
+
+    selected = strategy.rebalance_to_topn(
+        scores={"AAA": -0.02, "BBB": -0.01},
+        top_n=2,
+    )
+
+    assert selected == []
+    assert len(strategy.calls) == 1
+    assert strategy.calls[0]["target_weights"] == {}
+    assert strategy.calls[0]["liquidate_unmentioned"] is True
+
+
+def test_rebalance_to_topn_rejects_invalid_topn() -> None:
+    """rebalance_to_topn should validate top_n."""
+    strategy = TopNRebalanceStrategy()
+
+    with pytest.raises(ValueError, match="top_n must be greater than 0"):
+        strategy.rebalance_to_topn(scores={"AAA": 0.1}, top_n=0)
+
+
+def test_rebalance_to_topn_supports_score_weight_mode() -> None:
+    """rebalance_to_topn should support score-normalized weights."""
+    strategy = TopNRebalanceStrategy()
+
+    selected = strategy.rebalance_to_topn(
+        scores={"AAA": 0.1, "BBB": 0.3, "CCC": 0.05},
+        top_n=2,
+        weight_mode="score",
+    )
+
+    assert selected == ["BBB", "AAA"]
+    assert len(strategy.calls) == 1
+    assert strategy.calls[0]["target_weights"]["BBB"] == pytest.approx(0.75)
+    assert strategy.calls[0]["target_weights"]["AAA"] == pytest.approx(0.25)
+
+
+def test_rebalance_to_topn_rejects_invalid_weight_mode() -> None:
+    """rebalance_to_topn should validate weight_mode."""
+    strategy = TopNRebalanceStrategy()
+
+    with pytest.raises(ValueError, match="weight_mode must be one of: equal, score"):
+        strategy.rebalance_to_topn(
+            scores={"AAA": 0.1, "BBB": 0.2},
+            top_n=1,
+            weight_mode="invalid",  # type: ignore[arg-type]
+        )
 
 
 class StartCounterStrategy(Strategy):
@@ -1645,6 +1780,40 @@ def test_live_mode_timer_registration_not_duplicated() -> None:
     assert payloads.count("__daily__|14:55:00|daily_timer") == 1
 
 
+def test_on_start_timer_registration_is_deferred_until_context_ready() -> None:
+    """Allow on_start schedule calls before context is injected."""
+    strategy = TimerIdempotencyStrategy()
+
+    strategy._on_start_internal()
+
+    assert len(strategy._pending_schedules) == 1
+    assert len(strategy._pending_daily_timers) == 1
+
+    ctx = MagicMock(spec=StrategyContext)
+    ctx.get_position.return_value = 0.0
+    ctx.canceled_order_ids = []
+    ctx.active_orders = []
+    ctx.recent_trades = []
+
+    ts = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    bar = Bar(
+        timestamp=ts,
+        open=100.0,
+        high=100.0,
+        low=100.0,
+        close=100.0,
+        volume=1000.0,
+        symbol="AAPL",
+    )
+    strategy._on_bar_event(bar, ctx)
+
+    assert len(strategy._pending_schedules) == 0
+    assert len(strategy._pending_daily_timers) == 0
+    payloads = [call.args[1] for call in ctx.schedule.call_args_list]
+    assert "manual_timer" in payloads
+    assert "__daily__|14:55:00|daily_timer" in payloads
+
+
 def test_live_mode_daily_timer_reschedules_once_per_trigger() -> None:
     """Live mode daily timer should reschedule once per single trigger."""
     strategy = TimerIdempotencyStrategy()
@@ -1834,6 +2003,10 @@ class FrameworkHooksStrategy(Strategy):
         """Record before trading hook."""
         self.events.append(f"before:{trading_date}:{timestamp}")
 
+    def on_daily_rebalance(self, trading_date: Any, timestamp: int) -> None:
+        """Record daily rebalance hook."""
+        self.events.append(f"rebalance:{trading_date}:{timestamp}")
+
     def after_trading(self, trading_date: Any, timestamp: int) -> None:
         """Record after trading hook."""
         self.events.append(f"after:{trading_date}:{timestamp}")
@@ -1889,6 +2062,7 @@ def test_framework_hooks_session_day_reject_and_portfolio() -> None:
 
     assert any(e.startswith("session_start:") for e in strategy.events)
     assert any(e.startswith("before:") for e in strategy.events)
+    assert any(e.startswith("rebalance:") for e in strategy.events)
     assert "order:rej1" in strategy.events
     assert "reject:rej1" in strategy.events
     assert strategy.events.index("order:rej1") < strategy.events.index("reject:rej1")
@@ -1901,14 +2075,57 @@ def test_framework_hooks_session_day_reject_and_portfolio() -> None:
     strategy._on_tick_event(tick2, ctx)
     assert any(e.startswith("session_end:") for e in strategy.events)
     assert any(e.startswith("after:") for e in strategy.events)
+    same_day_rebalance_count = len(
+        [e for e in strategy.events if e.startswith("rebalance:2023-01-01")]
+    )
+    assert same_day_rebalance_count == 1
 
     before_count = len([e for e in strategy.events if e.startswith("before:")])
+    rebalance_count = len([e for e in strategy.events if e.startswith("rebalance:")])
     ctx.current_time = pd.Timestamp("2023-01-02 09:31:00", tz="Asia/Shanghai").value
     ctx.session = "normal"
     tick3 = Tick(timestamp=ctx.current_time, price=102.0, volume=1.0, symbol="AAPL")
     strategy._on_tick_event(tick3, ctx)
     after_count = len([e for e in strategy.events if e.startswith("before:")])
+    rebalance_after_count = len(
+        [e for e in strategy.events if e.startswith("rebalance:")]
+    )
     assert after_count == before_count + 1
+    assert rebalance_after_count == rebalance_count + 1
+
+
+def test_daily_rebalance_fallback_when_session_missing() -> None:
+    """When session is missing, daily rebalance still runs once per day."""
+    strategy = FrameworkHooksStrategy()
+    ctx = MagicMock(spec=StrategyContext)
+    ctx.get_position.return_value = 0.0
+    ctx.canceled_order_ids = []
+    ctx.active_orders = []
+    ctx.recent_trades = []
+    ctx.positions = {}
+    ctx.available_positions = {}
+    ctx.cash = 1000.0
+    ctx.session = None
+
+    ts1 = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    ts2 = pd.Timestamp("2023-01-01 10:30:00", tz="Asia/Shanghai").value
+    ts3 = pd.Timestamp("2023-01-02 09:30:00", tz="Asia/Shanghai").value
+
+    tick1 = Tick(timestamp=ts1, price=100.0, volume=1.0, symbol="AAPL")
+    tick2 = Tick(timestamp=ts2, price=100.0, volume=1.0, symbol="AAPL")
+    tick3 = Tick(timestamp=ts3, price=100.0, volume=1.0, symbol="AAPL")
+
+    ctx.current_time = ts1
+    strategy._on_tick_event(tick1, ctx)
+    ctx.current_time = ts2
+    strategy._on_tick_event(tick2, ctx)
+    ctx.current_time = ts3
+    strategy._on_tick_event(tick3, ctx)
+
+    day1 = len([e for e in strategy.events if e.startswith("rebalance:2023-01-01")])
+    day2 = len([e for e in strategy.events if e.startswith("rebalance:2023-01-02")])
+    assert day1 == 1
+    assert day2 == 1
 
 
 def test_portfolio_update_skips_clean_tick_without_changes() -> None:
@@ -2409,6 +2626,7 @@ def test_boundary_timers_register_and_drive_day_hooks() -> None:
 
     strategy._on_timer_event("__framework_boundary__|before|2023-01-03", ctx)
     assert any(e.startswith("before:2023-01-03") for e in strategy.events)
+    assert any(e.startswith("rebalance:2023-01-03") for e in strategy.events)
 
     ctx.current_time = end_ts + 1
     strategy._on_timer_event("__framework_boundary__|after|2023-01-03", ctx)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -14,3 +14,13 @@ def test_version_present() -> None:
     v: Any = aq.__version__
     assert isinstance(v, str)
     assert len(v) > 0
+
+
+def test_top_level_exposes_metric_formatter() -> None:
+    """
+    Ensure top-level package exports format_metric_value helper.
+
+    :return: None
+    """
+    assert hasattr(aq, "format_metric_value")
+    assert aq.format_metric_value("annualized_return", 0.021184) == "2.12%"


### PR DESCRIPTION
- 新增 `on_daily_rebalance` 回调，确保每个交易日最多触发一次，适用于横截面轮动策略
- 新增 `get_history_map` 方法，支持批量获取多个标的的历史数据数组
- 新增 `rebalance_to_topn` 方法，根据打分结果自动选取 TopN 并执行调仓
- 新增 `format_metric_value` 工具函数，统一绩效指标格式化逻辑
- 优化定时器注册机制，支持在 `on_start` 中提前注册定时任务
- 修复 Calmar 比率计算中最大回撤单位混淆的问题
- 更新文档与示例，展示新的横截面策略范式