### PR TITLE
feat(engine): 在策略上下文中添加已平仓交易快照

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@ __pycache__/
 *.dylib
 *.dSYM/
 *.pyd
+*.pdb
 .env
 .venv
 venv/
 .DS_Store
+uv.lock
 
 # IDEs
 .idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.78"
+version = "0.1.79"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.78"
+version = "0.1.79"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -563,6 +563,27 @@ def on_bar(self, bar: Bar):
 *   **`self.get_trades()`**: 获取历史所有已平仓交易记录（Closed Trades）。
 *   **`self.get_open_orders()`**: 获取当前未成交订单。
 
+`on_trade` 与 `get_trades()` 的语义不同：
+
+*   `on_trade(self, trade)` 接收的是当前事件步内的增量成交回报（适合做实时响应）。
+*   `self.get_trades()` 返回的是累计“已平仓”交易（Closed Trades），未平仓时不会出现在这个列表里。
+
+推荐模式：
+
+```python
+class MyStrategy(Strategy):
+    def __init__(self):
+        self.recent_exec_count = 0
+
+    def on_trade(self, trade):
+        self.recent_exec_count += 1
+        print("incremental trade:", trade.order_id, trade.symbol, trade.quantity)
+
+    def on_stop(self):
+        closed = self.get_trades()
+        print("closed trades:", len(closed))
+```
+
 ## 7. 进阶功能
 
 ### 7.1 事件回调

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.78"
+version = "0.1.79"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}
@@ -25,8 +25,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pandas>=3.0.0",
-    "numpy>=2.4.1",
+    "pandas>=2.2.0",
+    "numpy>=2.2.2",
     "pyarrow>=14.0.0",
     "tqdm>=4.0.0",
     "plotly>=5.0.0",

--- a/src/context.rs
+++ b/src/context.rs
@@ -55,6 +55,7 @@ pub struct ContextUpdate {
     pub session: TradingSession,
     pub current_time: i64,
     pub active_orders: Arc<Vec<Order>>,
+    pub closed_trades: Arc<Vec<ClosedTrade>>,
     pub recent_trades: Vec<Trade>,
 }
 
@@ -66,6 +67,7 @@ impl StrategyContext {
         self.session = update.session;
         self.current_time = update.current_time;
         self.active_orders_arc = update.active_orders.clone();
+        self.closed_trades = update.closed_trades;
 
         // Lazy update: clear the vector but don't fill it yet.
         // We will rely on a getter to populate it if accessed, or just update it here if needed.

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -547,6 +547,7 @@ impl Engine {
                         session: self.clock.session,
                         current_time: self.clock.timestamp().unwrap_or(0),
                         active_orders,
+                        closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
                         recent_trades: step_trades,
                     });
                 }

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -426,6 +426,52 @@ def test_trade_dedupe_cache_limit_eviction_allows_replay() -> None:
     assert strategy.trade_count == 4
 
 
+class ClosedTradesSnapshotStrategy(Strategy):
+    """Strategy for validating get_trades snapshot refresh."""
+
+    def __init__(self) -> None:
+        """Initialize observation state."""
+        self.entered = False
+        self.exited = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Run one round-trip order flow."""
+        position = self.get_position(bar.symbol)
+        if position == 0 and not self.entered:
+            self.buy(bar.symbol, 100)
+            self.entered = True
+            return
+        if position > 0 and not self.exited:
+            self.close_position(bar.symbol)
+            self.exited = True
+
+
+def test_get_trades_refreshes_during_backtest() -> None:
+    """get_trades should reflect latest closed trades snapshot in strategy context."""
+    bars = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-01-01", periods=6, freq="D", tz="UTC"),
+            "open": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+            "high": [10.5, 11.5, 12.5, 13.5, 14.5, 15.5],
+            "low": [9.5, 10.5, 11.5, 12.5, 13.5, 14.5],
+            "close": [10.2, 11.2, 12.2, 13.2, 14.2, 15.2],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0],
+            "symbol": ["AAPL", "AAPL", "AAPL", "AAPL", "AAPL", "AAPL"],
+        }
+    )
+    result = run_backtest(
+        data=bars,
+        strategy=ClosedTradesSnapshotStrategy,
+        symbol="AAPL",
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    strategy = cast(ClosedTradesSnapshotStrategy, result.strategy)
+    assert strategy is not None
+    assert len(result.trades) >= 1
+    assert len(strategy.get_trades()) >= 1
+
+
 class SequenceStrategy(Strategy):
     """Strategy for callback sequence assertions."""
 


### PR DESCRIPTION
- 在 ContextUpdate 中新增 closed_trades 字段，用于传递已平仓交易数据
- 更新引擎核心逻辑，将已平仓交易快照同步到策略上下文
- 调整 Python 依赖版本要求以兼容更广泛的环境
- 在文档中澄清 on_trade 与 get_trades() 的语义差异
- 添加测试验证 get_trades() 在回测期间的快照更新行为
- 更新 .gitignore 以排除 uv.lock 和 *.pdb 文件