### PR TITLE
docs: 将环境管理工具从conda迁移至uv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,18 +31,21 @@
 本项目混合了 Rust 和 Python，请按以下步骤配置环境：
 
 1.  **安装 Rust**: [官网下载](https://www.rust-lang.org/tools/install)
-2.  **创建 Python 虚拟环境 (推荐 Conda)**:
+2.  **创建 Python 虚拟环境 (推荐 uv)**:
     ```bash
-    conda create -n akquant python=3.10
-    conda activate akquant
+    uv venv --python 3.10
+    # Windows:
+    .venv\Scripts\activate
+    # macOS / Linux:
+    source .venv/bin/activate
     ```
 3.  **安装依赖与编译**:
     ```bash
     # 安装开发依赖
-    pip install -e ".[dev,ml,plot]"
+    uv pip install -e ".[dev,ml,plot]"
 
     # 编译 Rust 扩展 (开发模式)
-    maturin develop
+    uv run maturin develop
     ```
 
 ### 3. 开始开发 (Coding)
@@ -67,12 +70,12 @@
     *   确保添加了类型注解 (Type Hints)。
     *   如果是 Python 代码，请运行检查：
         ```bash
-        ruff check .
-        mypy .
+        uv run ruff check .
+        uv run mypy .
         ```
     *   推荐在提交前统一执行：
         ```bash
-        pre-commit run --all-files
+        uv run pre-commit run --all-files
         ```
         说明：
         *   仓库中的 mypy hook 已配置为以项目根目录运行并读取 `pyproject.toml`，用于避免 `__init__.py` 与 `__init__.pyi` 的重复模块报错。
@@ -102,10 +105,10 @@
 
 1.  **运行常规单元测试**:
     ```bash
-    pytest
+    uv run pytest
     ```
 
-    Rust 核心测试（推荐使用项目脚本，自动处理 macOS + conda 的动态库路径）：
+    Rust 核心测试（推荐使用项目脚本，自动处理 macOS + uv 环境动态库路径）：
     ```bash
     ./scripts/cargo-test.sh -q
     ```
@@ -113,26 +116,26 @@
 2.  **运行黄金测试 (Golden Tests)**:
     黄金测试用于捕捉核心算法变更导致的非预期行为（如 PnL 计算、撮合逻辑差异）。
     ```bash
-    pytest tests/golden/test_golden.py
+    uv run pytest tests/golden/test_golden.py
     ```
     *   如果测试失败，请检查差异是否符合预期。
     *   如果是**预期内的算法改进**（例如修复了撮合 bug 导致成交价格变动），你需要更新基线：
         ```bash
-        python tests/golden/runner.py --generate-baseline
+        uv run python tests/golden/runner.py --generate-baseline
         ```
         并在 PR 中说明导致基线变更的原因。
 
 3.  **代码风格检查**:
     ```bash
-    ruff check .
-    mypy .
-    python scripts/check_docs_links.py
-    python scripts/check_docs_api_examples.py
+    uv run ruff check .
+    uv run mypy .
+    uv run python scripts/check_docs_links.py
+    uv run python scripts/check_docs_api_examples.py
     ```
     如需仅检查本次变更文档，可使用：
     ```bash
-    python scripts/check_docs_links.py --changed-only --from-rev origin/main --to-rev HEAD
-    python scripts/check_docs_api_examples.py --changed-only --from-rev origin/main --to-rev HEAD
+    uv run python scripts/check_docs_links.py --changed-only --from-rev origin/main --to-rev HEAD
+    uv run python scripts/check_docs_api_examples.py --changed-only --from-rev origin/main --to-rev HEAD
     ```
 
 ---
@@ -141,10 +144,10 @@
 
 在提交 PR 之前，请检查：
 
-- [ ] 代码可以通过 `maturin develop` 编译成功。
-- [ ] 运行了 `ruff check .` 和 `mypy .` 没有报错。
-- [ ] 运行了 `python scripts/check_docs_links.py` 且通过。
-- [ ] 运行了 `python scripts/check_docs_api_examples.py` 且通过。
+- [ ] 代码可以通过 `uv run maturin develop` 编译成功。
+- [ ] 运行了 `uv run ruff check .` 和 `uv run mypy .` 没有报错。
+- [ ] 运行了 `uv run python scripts/check_docs_links.py` 且通过。
+- [ ] 运行了 `uv run python scripts/check_docs_api_examples.py` 且通过。
 - [ ] 如果是新功能，是否添加了简单的测试或示例？
 - [ ] 文档是否已更新？
 

--- a/README.md
+++ b/README.md
@@ -278,20 +278,20 @@ AKQuant 采用严格的测试流程以确保回测引擎的准确性：
 
 运行测试：
 ```bash
-# 1. 激活本地 conda 环境
-conda activate <env_name>
+# 1. 使用 uv 环境运行命令
+uv sync
 
 # 2. 构建并绑定 Rust 扩展
-maturin develop
+uv run maturin develop
 
 # 3. 运行所有测试
-pytest
+uv run pytest
 
-# 4. 运行 Rust 核心测试（自动处理 macOS + conda 动态库路径）
+# 4. 运行 Rust 核心测试（自动处理 macOS + uv 环境动态库路径）
 ./scripts/cargo-test.sh -q
 
 # 5. 仅运行黄金测试
-pytest tests/golden/test_golden.py
+uv run pytest tests/golden/test_golden.py
 ```
 
 ## Citation

--- a/docs/en/start/setup_guide.md
+++ b/docs/en/start/setup_guide.md
@@ -1,48 +1,49 @@
 # Environment Setup Guide
 
 Before starting quantitative trading, you need a clean, stable, and isolated Python environment.
-This guide provides two mainstream solutions: **Miniconda (Classic & Stable)** and **uv (Fast & Modern)**.
+This guide recommends **uv (Fast & Modern)** for Python environment and dependency management.
 
 ---
 
-## Option A: Miniconda (Classic)
+## Option A: uv (Recommended)
 
-Miniconda is a minimal installer for conda. It is the industry standard for data science, making it easy to manage Python versions and dependencies.
+uv is a modern Python toolchain written in Rust. It unifies Python version management, virtual environments, and package installation.
 
-### 1. Install Miniconda
+### 1. Install uv
 
-> **Tip**: Users in China can download from [Tsinghua Mirror](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/) for faster speeds.
+> **Tip**: Users in China can install uv first, then use the Tsinghua PyPI mirror to speed up package downloads.
 
 === "Windows"
 
-    1.  Visit [Miniconda Website](https://docs.conda.io/en/latest/miniconda.html) (or [Tsinghua Mirror](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/)).
-    2.  Download the **Windows 64-bit** installer (`.exe`).
-    3.  Run the installer. It is recommended to check "Add Miniconda3 to my PATH environment variable" (convenient for beginners).
-    4.  After installation, open **Command Prompt (CMD)** or **PowerShell**.
+    1.  Open **PowerShell**.
+    2.  Run:
+        ```powershell
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+        ```
+    3.  Reopen terminal and run `uv --version` to verify installation.
 
 === "macOS"
 
-    **Method A: Via Homebrew (Recommended)**
+    **Method A: Installer Script (Recommended)**
     Open Terminal and run:
     ```bash
-    brew install --cask miniconda
-    init conda
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
 
-    **Method B: Via Installer Script**
+    **Method B: Via Homebrew**
 
-    1.  Download script for [Apple Silicon](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh) or [Intel](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh).
-    2.  Run in terminal: `bash Miniconda3-latest-MacOSX-arm64.sh`.
+    1.  After Homebrew is installed, run:
+        ```bash
+        brew install uv
+        ```
+    2.  Run `uv --version` to verify installation.
 
 === "Linux"
 
     Open terminal and run:
     ```bash
-    mkdir -p ~/miniconda3
-    wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-    rm -rf ~/miniconda3/miniconda.sh
-    ~/miniconda3/bin/conda init bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    uv --version
     ```
 
 ### 1.5 Configure Mirrors (For Users in China)
@@ -50,34 +51,32 @@ Miniconda is a minimal installer for conda. It is the industry standard for data
 If you are located in China, download speeds might be slow. It is recommended to use the Tsinghua University mirror.
 
 ```bash
-# Configure Conda Mirror
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
-conda config --set show_channel_urls yes
-
-# Configure Pip Mirror
-pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+# Configure uv/pip mirror
+uv pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ### 2. Create Virtual Environment
 
 Do not install libraries directly into your system Python! We need a dedicated "sandbox".
 
-Open your terminal (or CMD/Anaconda Prompt on Windows) and type:
+Open your terminal (or CMD/PowerShell on Windows) and type:
 
 ```bash
-# Create an environment named 'akquant' with Python 3.10
-conda create -n akquant python=3.10 -y
+# Create a virtual environment with Python 3.10
+uv venv --python 3.10
 
 # Activate the environment
-conda activate akquant
+# Windows:
+.venv\Scripts\activate
+# macOS / Linux:
+source .venv/bin/activate
 ```
 
-Once activated, your command prompt prefix will change to `(akquant)`, indicating you are inside the sandbox.
+Once activated, your command prompt prefix will change to `(.venv)`, indicating you are inside the sandbox.
 
 ---
 
-## Option B: uv (Fast & Modern)
+## Option B: uv (Project Workflow)
 
 If you want extreme speed and lightweight management, [uv](https://github.com/astral-sh/uv) is the fastest package manager in the Python ecosystem (written in Rust). It replaces `pip` and `virtualenv`.
 
@@ -121,19 +120,11 @@ source .venv/bin/activate
 
 ## 3. Install AKQuant & Verify
 
-Whether you used Miniconda or uv, you should now be in an activated virtual environment.
+You should now be in an activated uv virtual environment.
 
 ### Install
 
-**If using Miniconda:**
-```bash
-pip install akquant
-
-# Users in China can use the Tsinghua mirror for speed:
-# pip install akquant -i https://pypi.tuna.tsinghua.edu.cn/simple
-```
-
-**If using uv:**
+**Install with uv:**
 ```bash
 uv pip install akquant
 

--- a/docs/zh/start/setup_guide.md
+++ b/docs/zh/start/setup_guide.md
@@ -1,55 +1,49 @@
 # Python 环境搭建指南 (Environment Setup Guide)
 
 工欲善其事，必先利其器。在开始量化交易之前，你需要一个干净、稳定且独立的 Python 运行环境。
-本指南将提供两种主流的环境管理方案：**Miniconda (经典稳定)** 和 **uv (极速现代)**。
+本指南推荐使用 **uv (极速现代)** 来管理 Python 环境与依赖。
 
 ---
 
-## 方案一：Miniconda (经典推荐)
+## 方案一：uv (推荐)
 
-Miniconda 是 Anaconda 的精简版，是数据科学领域的行业标准。它能帮你轻松管理 Python 版本和各种依赖包。
+uv 是基于 Rust 的现代 Python 工具链，能够统一管理 Python 版本、虚拟环境和依赖包。
 
-### 1. 安装 Miniconda
+### 1. 安装 uv
 
-> **提示**：国内用户访问官网可能较慢，推荐使用 [清华大学开源软件镜像站](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/) 下载安装包。
+> **提示**：国内用户可以先完成 uv 安装，再配合清华 PyPI 镜像提升依赖下载速度。
 
 === "Windows"
 
-    1.  访问 [Miniconda 官网](https://docs.conda.io/en/latest/miniconda.html) 或 [清华镜像站](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/)。
-    2.  下载 **Windows 64-bit** 安装包 (`.exe`)。
-    3.  运行安装程序，建议勾选 "Add Miniconda3 to my PATH environment variable" (虽然提示不推荐，但对新手更方便)。
-    4.  安装完成后，打开 **Command Prompt (CMD)** 或 **PowerShell**。
+    1.  打开 **PowerShell**。
+    2.  运行安装命令：
+        ```powershell
+        powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+        ```
+    3.  重新打开终端，执行 `uv --version` 确认安装成功。
 
 === "macOS"
 
-    **方法 A：使用 Homebrew (推荐)**
+    **方法 A：使用安装脚本 (推荐)**
     打开终端 (Terminal)，运行：
     ```bash
-    brew install --cask miniconda
-    init conda
+    curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
 
-    **方法 B：使用安装脚本**
+    **方法 B：使用 Homebrew**
 
-    1.  下载 [macOS 安装脚本](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh) (M1/M2/M3) 或 [Intel 版](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh)。
-        *   或者从 [清华镜像](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/) 下载对应的 `.sh` 文件。
-    2.  在终端运行：`bash Miniconda3-latest-MacOSX-arm64.sh`。
+    1.  安装 Homebrew 后执行：
+        ```bash
+        brew install uv
+        ```
+    2.  执行 `uv --version` 确认安装成功。
 
 === "Linux"
 
-    打开终端，运行以下命令：
+    打开终端，运行以下命令安装 uv：
     ```bash
-    mkdir -p ~/miniconda3
-
-    # 方式一：官方源
-    # wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-
-    # 方式二：清华源 (推荐国内用户)
-    wget https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-
-    bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-    rm -rf ~/miniconda3/miniconda.sh
-    ~/miniconda3/bin/conda init bash
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    uv --version
     ```
 
 ### 1.5 配置国内镜像源 (推荐)
@@ -57,34 +51,32 @@ Miniconda 是 Anaconda 的精简版，是数据科学领域的行业标准。它
 国内用户访问官方源可能较慢，建议配置清华大学镜像源以加速下载。
 
 ```bash
-# 配置 Conda 镜像源
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main/
-conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/
-conda config --set show_channel_urls yes
-
-# 配置 Pip 镜像源 (永久生效)
-pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+# 配置 uv/pip 镜像源 (永久生效)
+uv pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 ### 2. 创建虚拟环境
 
 不要直接在系统 Python 中安装库！我们需要创建一个专属的“沙盒”。
 
-打开终端（Windows 用户打开 CMD 或 Anaconda Prompt），输入：
+打开终端（Windows 用户打开 CMD 或 PowerShell），输入：
 
 ```bash
-# 创建一个名为 quant_dev 的环境，指定 Python 版本为 3.10，AKQuant 支持 Python 3.10及以上版本
-conda create -n quant_dev python=3.10 -y
+# 创建虚拟环境并指定 Python 3.10（AKQuant 支持 Python 3.10 及以上）
+uv venv --python 3.10
 
 # 激活环境
-conda activate quant_dev
+# Windows:
+.venv\Scripts\activate
+# macOS / Linux:
+source .venv/bin/activate
 ```
 
-激活成功后，你的命令行前缀会变成 `(quant_dev)`，说明你已经进入了沙盒。
+激活成功后，你的命令行前缀会变成 `(.venv)`，说明你已经进入了沙盒。
 
 ---
 
-## 方案二：uv (极速现代)
+## 方案二：uv (项目工作流)
 
 如果你追求极致的速度和轻量化，[uv](https://github.com/astral-sh/uv) 是目前 Python 生态中最快的包管理器（由 Rust 编写）。它可以替代 `pip` 和 `virtualenv`。
 
@@ -128,17 +120,11 @@ source .venv/bin/activate
 
 ## 3. 安装 AKQuant 并验证
 
-无论你使用了 Miniconda 还是 uv，现在你都应该处于一个激活的虚拟环境中。接下来我们安装交易框架。
+现在你应该处于一个激活的 uv 虚拟环境中。接下来我们安装交易框架。
 
 ### 安装
 
-**如果你使用 Miniconda:**
-```bash
-# 如果之前未配置镜像源，可添加 -i 参数临时加速
-pip install akquant -i https://pypi.tuna.tsinghua.edu.cn/simple
-```
-
-**如果你使用 uv:**
+**使用 uv 安装:**
 ```bash
 # 使用清华源加速
 uv pip install akquant --index-url https://pypi.tuna.tsinghua.edu.cn/simple

--- a/docs/zh/textbook/01_foundations.md
+++ b/docs/zh/textbook/01_foundations.md
@@ -126,24 +126,25 @@ $$ E(R_p) = R_f + \beta_p (E(R_m) - R_f) + \alpha_p $$
 
 为了进行量化研究，我们需要搭建一套高效的开发环境。本教材推荐使用 **Python + Rust** 的混合架构。
 
-### 1.5.1 Python 环境 (Miniconda)
+### 1.5.1 Python 环境 (uv)
 
-Python 是量化领域最主流的语言，拥有丰富的生态库（Pandas, NumPy, Scikit-learn）。我们推荐使用 [Miniconda](https://docs.conda.io/en/latest/miniconda.html) 来管理 Python 环境。
+Python 是量化领域最主流的语言，拥有丰富的生态库（Pandas, NumPy, Scikit-learn）。我们推荐使用 [uv](https://github.com/astral-sh/uv) 来管理 Python 环境。
 
 > **国内镜像加速**：
-> 1. **下载加速**：推荐从清华大学开源软件镜像站下载安装包：[https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/](https://mirrors.tuna.tsinghua.edu.cn/anaconda/miniconda/)
-> 2. **配置 Conda 源**：安装完成后，在终端执行以下命令以加速包的下载：
+> 1. **安装 uv**：参考官方安装说明：https://github.com/astral-sh/uv
+> 2. **配置镜像源**：安装完成后，在终端执行以下命令以加速包的下载：
 > ```bash
-> conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/main
-> conda config --add channels https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge
-> conda config --set show_channel_urls yes
+> uv pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 > ```
 
-安装完成后，打开终端（Windows 用户请打开 **Anaconda Powershell Prompt**，macOS/Linux 用户请打开 **Terminal**），创建一个新的环境：
+安装完成后，打开终端（Windows 用户请打开 **PowerShell**，macOS/Linux 用户请打开 **Terminal**），创建一个新的环境：
 
 ```bash
-conda create -n ak_env python=3.14
-conda activate ak_env
+uv venv --python 3.14
+# Windows:
+.venv\Scripts\activate
+# macOS / Linux:
+source .venv/bin/activate
 ```
 
 ### 1.5.2 安装 AKQuant
@@ -157,10 +158,10 @@ conda activate ak_env
 3.  **全资产覆盖**：原生支持 **股票 (Stock)**、**期货 (Futures)**、**期权 (Options)** 及 **基金 (Fund)** 等多种金融资产，并针对 A 股的 T+1 制度和涨跌停机制做了深度适配。
 4.  **回测实盘一体化**：坚持 "Code Once, Run Anywhere" 理念。同一套策略代码，既可以在历史数据上回测，也可以直接切换到 CTP / MiniQMT / PTrade 等实盘接口进行交易。
 
-在激活的 conda 环境中，运行以下命令安装（建议使用清华源加速）：
+在激活的 uv 虚拟环境中，运行以下命令安装（建议使用清华源加速）：
 
 ```bash
-pip install akquant akshare pandas matplotlib -i https://pypi.tuna.tsinghua.edu.cn/simple
+uv pip install akquant akshare pandas matplotlib --index-url https://pypi.tuna.tsinghua.edu.cn/simple
 ```
 
 *   `AKQuant`: **高性能事件驱动量化框架**。作为本课程的核心，它提供了回测引擎、订单管理、风控模块等全套基础设施，让用户只需专注于编写策略逻辑 (`Strategy`)。
@@ -313,4 +314,4 @@ calmar_ratio                            -0.250393
 1. 数据拉取失败：先检查网络和数据源可用性，再重试脚本。
 2. 依赖缺失报错：按安装文档补齐环境后重新运行。
 3. 指标解读混淆：优先关注 `total_return_pct` 与 `max_drawdown_pct` 两项基线指标。
-4. 命令不可用（如 `conda` / `python` / `ruff` / `mypy`）：优先确认已激活本地 conda 环境（如 `ak_env`），并检查 `C:\Users\xxx\miniconda3\Scripts\conda.exe` 路径是否可用。
+4. 命令不可用（如 `uv` / `python` / `ruff` / `mypy`）：优先确认已激活本地 uv 虚拟环境（如 `.venv`），并检查 `uv --version` 与 `python --version` 输出是否正常。

--- a/scripts/dev-check.sh
+++ b/scripts/dev-check.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ENV_NAME="${AKQUANT_CONDA_ENV:-akquant}"
-
-conda run -n "${ENV_NAME}" maturin develop
-conda run -n "${ENV_NAME}" ruff check python/akquant tests
-conda run -n "${ENV_NAME}" mypy python/akquant
-conda run -n "${ENV_NAME}" pytest tests/test_engine.py -k "engine_oco_avoids_same_batch_double_fill"
-conda run -n "${ENV_NAME}" pytest tests/test_engine.py -k "engine_bracket_activates_exit_orders"
-conda run -n "${ENV_NAME}" pytest tests/test_strategy_extras.py -k "oco_group_prefers_engine_registration_when_available or oco_group_falls_back_to_deferred_engine_queue_on_runtime_error"
-conda run -n "${ENV_NAME}" pytest tests/test_strategy_extras.py -k "bracket_prefers_engine_registration_when_available or bracket_falls_back_to_deferred_engine_queue_on_runtime_error"
+uv run maturin develop
+uv run ruff check python/akquant tests
+uv run mypy python/akquant
+uv run pytest tests/test_engine.py -k "engine_oco_avoids_same_batch_double_fill"
+uv run pytest tests/test_engine.py -k "engine_bracket_activates_exit_orders"
+uv run pytest tests/test_strategy_extras.py -k "oco_group_prefers_engine_registration_when_available or oco_group_falls_back_to_deferred_engine_queue_on_runtime_error"
+uv run pytest tests/test_strategy_extras.py -k "bracket_prefers_engine_registration_when_available or bracket_falls_back_to_deferred_engine_queue_on_runtime_error"


### PR DESCRIPTION
更新所有文档和脚本，将Python环境管理工具从Miniconda替换为uv。
- README.md、CONTRIBUTING.md中的运行命令和说明
- 中英文环境搭建指南，将推荐方案改为uv并更新安装步骤
- 开发检查脚本(dev-check.sh)中的conda命令改为uv run
- 故障排除部分更新环境激活和命令检查说明