### PR TITLE
feat(execution): 新增定时器下单撮合策略选项

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.79"
+version = "0.1.80"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.79"
+version = "0.1.80"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.79"
+version = "0.1.80"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -497,6 +497,15 @@ class Engine:
         """
         ...
 
+    def set_timer_execution_policy(self, policy: str) -> None:
+        r"""
+        设置定时器下单撮合策略.
+
+        :param policy: "same_cycle" 表示在当前 timer 事件撮合;
+                       "next_event" 表示延后到下一条行情事件撮合.
+        """
+        ...
+
     def use_simple_market(self, commission_rate: float) -> None:
         r"""
         启用 SimpleMarket (7x24小时, T+0, 无税, 简单佣金).

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -93,6 +93,7 @@ def run_backtest(
     risk_budget_reset_daily: bool = ...,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = ...,
     broker_profile: Optional[str] = ...,
+    timer_execution_policy: Literal["same_cycle", "next_event"] = ...,
     stream_mode: Literal["observability", "audit"] = ...,
     **kwargs: Any,
 ) -> BacktestResult: ...

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -643,6 +643,7 @@ def run_backtest(
     analyzer_plugins: Optional[Sequence[AnalyzerPlugin]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     broker_profile: Optional[str] = None,
+    timer_execution_policy: str = "same_cycle",
     **kwargs: Any,
 ) -> BacktestResult:
     """
@@ -676,6 +677,9 @@ def run_backtest(
     :param slippage: 滑点 (默认 0.0)
     :param volume_limit_pct: 成交量限制比例 (默认 0.25)
     :param execution_mode: 执行模式 (ExecutionMode.NextOpen 或 "next_open")
+    :param timer_execution_policy: 定时器下单撮合策略:
+        "same_cycle" 表示在当前 timer 事件撮合（CurrentClose 模式）；
+        "next_event" 表示延后到下一条行情事件撮合。
     :param timezone: 时区名称 (默认 "Asia/Shanghai")
     :param t_plus_one: 是否启用 T+1 交易规则 (默认 False)
     :param initialize: 初始化回调函数 (仅当 strategy 为函数时使用)
@@ -1813,6 +1817,13 @@ def run_backtest(
         engine.set_execution_mode(mode)
     else:
         engine.set_execution_mode(execution_mode)
+    timer_policy = str(timer_execution_policy).strip().lower()
+    if timer_policy not in {"same_cycle", "next_event"}:
+        raise ValueError(
+            "timer_execution_policy must be one of: same_cycle, next_event"
+        )
+    if hasattr(engine, "set_timer_execution_policy"):
+        cast(Any, engine).set_timer_execution_policy(timer_policy)
 
     # 4.1 市场规则配置
     china_futures_config: Optional[ChinaFuturesConfig] = None

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -56,6 +56,7 @@ pub struct Engine {
     pub(crate) clock: Clock,
     pub(crate) timers: BinaryHeap<Timer>, // Min-Heap via Timer's Ord implementation
     pub(crate) force_session_continuous: bool,
+    pub(crate) timer_execution_policy: String,
     #[pyo3(get, set)]
     pub risk_manager: RiskManager,
     pub(crate) timezone_offset: i32,
@@ -126,6 +127,10 @@ pub(crate) struct PendingStreamEvent {
 
 // Internal implementation of Engine (not exposed to Python)
 impl Engine {
+    pub(crate) fn timer_same_cycle_enabled(&self) -> bool {
+        self.timer_execution_policy == "same_cycle"
+    }
+
     pub(crate) fn normalized_order_strategy_id(order: &Order) -> Option<String> {
         order
             .owner_strategy_id

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -480,6 +480,7 @@ impl Engine {
             clock: Clock::new(),
             timers: BinaryHeap::new(),
             force_session_continuous: false,
+            timer_execution_policy: "same_cycle".to_string(),
             risk_manager: RiskManager::new(),
             timezone_offset: 28800, // Default UTC+8
             history_buffer: Arc::new(RwLock::new(HistoryBuffer::new(10000))), // Default large capacity for MAE/MFE
@@ -687,6 +688,24 @@ impl Engine {
     /// :type mode: ExecutionMode
     fn set_execution_mode(&mut self, mode: ExecutionMode) {
         self.execution_mode = mode;
+    }
+
+    /// 设置定时器下单撮合策略.
+    ///
+    /// :param policy: "same_cycle" 表示在当前 timer 事件撮合;
+    ///                "next_event" 表示延后到下一条行情事件撮合.
+    fn set_timer_execution_policy(&mut self, policy: &str) -> PyResult<()> {
+        let normalized = policy.trim().to_lowercase();
+        match normalized.as_str() {
+            "same_cycle" | "next_event" => {
+                self.timer_execution_policy = normalized;
+                Ok(())
+            }
+            _ => Err(PyValueError::new_err(format!(
+                "Unknown timer execution policy '{}', expected one of: same_cycle, next_event",
+                policy
+            ))),
+        }
     }
 
     /// 启用 SimpleMarket (7x24小时, T+0, 无税, 简单佣金)

--- a/src/execution/common.rs
+++ b/src/execution/common.rs
@@ -94,6 +94,7 @@ impl CommonMatcher {
             match event {
                 Event::Bar(b) => order.updated_at = b.timestamp,
                 Event::Tick(t) => order.updated_at = t.timestamp,
+                Event::Timer(t) => order.updated_at = t.timestamp,
                 _ => {}
             }
             return Some(Event::ExecutionReport(order.clone(), None));
@@ -381,6 +382,80 @@ impl CommonMatcher {
                         };
                         return Some(Event::ExecutionReport(order.clone(), Some(trade)));
                     }
+                }
+            }
+            Event::Timer(timer) => {
+                if execution_mode != ExecutionMode::CurrentClose {
+                    return None;
+                }
+                let Some(reference_price) = ctx.last_price else {
+                    return None;
+                };
+
+                if matches!(
+                    order.order_type,
+                    OrderType::StopTrail | OrderType::StopTrailLimit
+                ) {
+                    Self::update_trailing_trigger_with_tick(order, reference_price);
+                }
+
+                if let Some(trigger_price) = order.trigger_price {
+                    let triggered = match order.side {
+                        OrderSide::Buy => reference_price >= trigger_price,
+                        OrderSide::Sell => reference_price <= trigger_price,
+                    };
+                    if !triggered {
+                        return None;
+                    }
+                    order.trigger_price = None;
+                    Self::promote_triggered_order_type(order);
+                }
+
+                let mut execute_price = None;
+                match order.order_type {
+                    OrderType::Market => execute_price = Some(reference_price),
+                    OrderType::Limit => {
+                        if let Some(limit) = order.price {
+                            let can_execute = match order.side {
+                                OrderSide::Buy => reference_price <= limit,
+                                OrderSide::Sell => reference_price >= limit,
+                            };
+                            if can_execute {
+                                execute_price = Some(reference_price);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                if let Some(price) = execute_price {
+                    let final_price = slippage.calculate_price(price, order.quantity, order.side);
+                    let trade_qty = order.quantity - order.filled_quantity;
+                    if trade_qty > Decimal::ZERO {
+                        order.status = OrderStatus::Filled;
+                        order.updated_at = timer.timestamp;
+                        order.filled_quantity += trade_qty;
+                        order.average_filled_price = Some(final_price);
+                        let trade = Trade {
+                            id: Uuid::new_v4().to_string(),
+                            order_id: order.id.clone(),
+                            symbol: order.symbol.clone(),
+                            side: order.side,
+                            quantity: trade_qty,
+                            price: final_price,
+                            commission: Decimal::ZERO,
+                            timestamp: timer.timestamp,
+                            bar_index,
+                            owner_strategy_id: order.owner_strategy_id.clone(),
+                        };
+                        return Some(Event::ExecutionReport(order.clone(), Some(trade)));
+                    }
+                } else if order.time_in_force == TimeInForce::IOC
+                    || order.time_in_force == TimeInForce::FOK
+                {
+                    order.status = OrderStatus::Cancelled;
+                    order.updated_at = timer.timestamp;
+                    return Some(Event::ExecutionReport(order.clone(), None));
                 }
             }
             _ => {}

--- a/src/execution/futures.rs
+++ b/src/execution/futures.rs
@@ -230,6 +230,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 0,
+            last_price: None,
         }
     }
 

--- a/src/execution/matcher.rs
+++ b/src/execution/matcher.rs
@@ -11,6 +11,7 @@ pub struct MatchContext<'a> {
     pub slippage: &'a dyn SlippageModel,
     pub volume_limit_pct: Decimal,
     pub bar_index: usize,
+    pub last_price: Option<Decimal>,
 }
 
 /// 撮合器接口

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -208,6 +208,7 @@ impl ExecutionClient for SimulatedExecutionClient {
                             slippage: self.slippage_model.as_ref(),
                             volume_limit_pct: self.volume_limit_pct,
                             bar_index: ctx.bar_index,
+                            last_price: ctx.last_prices.get(&order.symbol).copied(),
                         };
                         let report_opt = matcher.match_order(order, &match_ctx);
 

--- a/src/execution/stock.rs
+++ b/src/execution/stock.rs
@@ -101,6 +101,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 0,
+            last_price: None,
         };
         let res = matcher.match_order(&mut order, &ctx);
 
@@ -139,6 +140,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 0,
+            last_price: None,
         };
         let res = matcher.match_order(&mut order, &ctx);
 
@@ -170,6 +172,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 0,
+            last_price: None,
         };
         let first_res = matcher.match_order(&mut order, &first_ctx);
         assert!(first_res.is_none());
@@ -194,6 +197,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 1,
+            last_price: None,
         };
         let second_res = matcher.match_order(&mut order, &second_ctx);
         assert!(second_res.is_some());
@@ -225,6 +229,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 0,
+            last_price: None,
         };
         let first_res = matcher.match_order(&mut order, &first_ctx);
         assert!(first_res.is_none());
@@ -239,6 +244,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 1,
+            last_price: None,
         };
         let second_res = matcher.match_order(&mut order, &second_ctx);
         assert!(second_res.is_none());
@@ -253,6 +259,7 @@ mod tests {
             slippage: &crate::execution::slippage::ZeroSlippage,
             volume_limit_pct: Decimal::ZERO,
             bar_index: 2,
+            last_price: None,
         };
         let third_res = matcher.match_order(&mut order, &third_ctx);
         assert!(third_res.is_some());

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -670,7 +670,10 @@ impl Processor for ExecutionProcessor {
 
         if let Some(event) = engine.current_event.clone() {
             match event {
-                Event::Bar(_) | Event::Tick(_) => {
+                Event::Bar(_) | Event::Tick(_) | Event::Timer(_) => {
+                    if matches!(event, Event::Timer(_)) && !engine.timer_same_cycle_enabled() {
+                        return Ok(ProcessorResult::Next);
+                    }
                     // Create Context
                     let ctx = EngineContext {
                         instruments: &engine.instruments,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -133,6 +133,104 @@ class ContinuousSmallBuyStrategy(akquant.Strategy):
         self.buy(symbol=bar.symbol, quantity=5)
 
 
+class TimerCurrentCloseStrategy(akquant.Strategy):
+    """Submit order from timer and capture timer/trade timestamps."""
+
+    def __init__(self) -> None:
+        """Initialize capture state."""
+        super().__init__()
+        self.timer_timestamp: int | None = None
+        self.trade_timestamp: int | None = None
+        self.trade_price: float | None = None
+        self.symbol_ref: str = "TIMER_BUG"
+        self.timer_trigger: pd.Timestamp = pd.Timestamp(
+            "2023-01-02 10:00:01", tz="Asia/Shanghai"
+        )
+
+    def on_start(self) -> None:
+        """Register a timer between first and second bar."""
+        self.schedule(self.timer_trigger, "timer_buy")
+
+    def on_timer(self, payload: str) -> None:
+        """Submit market buy on timer event."""
+        if payload != "timer_buy":
+            return
+        if self.ctx is None:
+            return
+        self.timer_timestamp = int(self.ctx.current_time)
+        self.buy(symbol=self.symbol_ref, quantity=1)
+
+    def on_trade(self, trade: akquant.Trade) -> None:
+        """Capture trade timestamp and price."""
+        self.trade_timestamp = int(trade.timestamp)
+        self.trade_price = float(trade.price)
+
+
+class BarOnlyCaptureStrategy(akquant.Strategy):
+    """Capture on_bar order fill timestamp and price."""
+
+    def __init__(self) -> None:
+        """Initialize capture state."""
+        super().__init__()
+        self.submitted = False
+        self.trade_timestamp: int | None = None
+        self.trade_price: float | None = None
+
+    def on_bar(self, bar: akquant.Bar) -> None:
+        """Submit one market order on first bar."""
+        if self.submitted:
+            return
+        self.buy(symbol=bar.symbol, quantity=1)
+        self.submitted = True
+
+    def on_trade(self, trade: akquant.Trade) -> None:
+        """Capture first trade timestamp and price."""
+        self.trade_timestamp = int(trade.timestamp)
+        self.trade_price = float(trade.price)
+
+
+class MixedBarTimerCaptureStrategy(akquant.Strategy):
+    """Submit one order on bar and one order on timer, then capture fills."""
+
+    def __init__(self) -> None:
+        """Initialize capture state."""
+        super().__init__()
+        self.bar_submitted = False
+        self.timer_submitted = False
+        self.trade_timestamps: list[int] = []
+        self.trade_prices: list[float] = []
+        self.symbol_ref: str = "TIMER_BUG"
+        self.timer_timestamp: int | None = None
+        self.timer_trigger: pd.Timestamp = pd.Timestamp(
+            "2023-01-02 10:00:01", tz="Asia/Shanghai"
+        )
+
+    def on_start(self) -> None:
+        """Register timer trigger between two bars."""
+        self.schedule(self.timer_trigger, "timer_buy")
+
+    def on_bar(self, bar: akquant.Bar) -> None:
+        """Submit bar-side order once."""
+        if self.bar_submitted:
+            return
+        self.buy(symbol=bar.symbol, quantity=1)
+        self.bar_submitted = True
+
+    def on_timer(self, payload: str) -> None:
+        """Submit timer-side order once."""
+        if payload != "timer_buy" or self.timer_submitted:
+            return
+        if self.ctx is not None:
+            self.timer_timestamp = int(self.ctx.current_time)
+        self.buy(symbol=self.symbol_ref, quantity=1)
+        self.timer_submitted = True
+
+    def on_trade(self, trade: akquant.Trade) -> None:
+        """Capture all trade timestamps and prices."""
+        self.trade_timestamps.append(int(trade.timestamp))
+        self.trade_prices.append(float(trade.price))
+
+
 def _ns(dt: datetime) -> int:
     """
     Convert a datetime to nanoseconds since epoch.
@@ -209,6 +307,164 @@ def _build_benchmark_data(n: int, symbol: str) -> pd.DataFrame:
             "symbol": symbol,
         }
     )
+
+
+def test_current_close_timer_order_should_fill_at_timer_timestamp() -> None:
+    """CurrentClose should fill timer order at timer timestamp, not next bar."""
+    symbol = "TIMER_BUG"
+    bars = [
+        akquant.Bar(
+            pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value,
+            11.0,
+            11.0,
+            11.0,
+            11.0,
+            1000.0,
+            symbol,
+        ),
+    ]
+    strategy = TimerCurrentCloseStrategy()
+    strategy.symbol_ref = symbol
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        execution_mode="current_close",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.timer_timestamp is not None
+    assert strategy.trade_timestamp is not None
+    assert strategy.trade_timestamp == strategy.timer_timestamp
+    assert strategy.trade_price == pytest.approx(10.0)
+
+
+def test_current_close_timer_order_next_event_policy_fills_on_next_bar() -> None:
+    """Timer orders should not fill at timer timestamp when policy is next_event."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    second_ts = pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value
+    third_ts = pd.Timestamp("2023-01-02 10:02:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
+        akquant.Bar(second_ts, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
+        akquant.Bar(third_ts, 12.0, 12.0, 12.0, 12.0, 1000.0, symbol),
+    ]
+    strategy = TimerCurrentCloseStrategy()
+    strategy.symbol_ref = symbol
+    strategy.timer_trigger = pd.Timestamp("2023-01-02 10:01:30", tz="Asia/Shanghai")
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        execution_mode="current_close",
+        timer_execution_policy="next_event",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.timer_timestamp is not None
+    if strategy.trade_timestamp is not None:
+        assert strategy.trade_timestamp > strategy.timer_timestamp
+    assert strategy.trade_timestamp != strategy.timer_timestamp
+
+
+def test_current_close_bar_fill_unchanged_with_next_event_timer_policy() -> None:
+    """Bar orders should still fill on current bar under current_close."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
+        akquant.Bar(
+            pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value,
+            11.0,
+            11.0,
+            11.0,
+            11.0,
+            1000.0,
+            symbol,
+        ),
+    ]
+    strategy = BarOnlyCaptureStrategy()
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        execution_mode="current_close",
+        timer_execution_policy="next_event",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.trade_timestamp == first_ts
+    assert strategy.trade_price == pytest.approx(10.0)
+
+
+def test_current_close_mixed_bar_timer_next_event_policy() -> None:
+    """Mixed bar/timer orders should respect policy boundaries."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    second_ts = pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value
+    third_ts = pd.Timestamp("2023-01-02 10:02:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
+        akquant.Bar(second_ts, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
+        akquant.Bar(third_ts, 12.0, 12.0, 12.0, 12.0, 1000.0, symbol),
+    ]
+    strategy = MixedBarTimerCaptureStrategy()
+    strategy.symbol_ref = symbol
+    strategy.timer_trigger = pd.Timestamp("2023-01-02 10:01:30", tz="Asia/Shanghai")
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        execution_mode="current_close",
+        timer_execution_policy="next_event",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.timer_submitted
+    assert strategy.timer_timestamp is not None
+    assert strategy.trade_timestamps
+    assert strategy.trade_timestamps[0] == first_ts
+    assert strategy.trade_timestamps[0] < strategy.timer_timestamp
+    for ts in strategy.trade_timestamps:
+        assert ts != strategy.timer_timestamp
 
 
 def test_run_backtest_accepts_data_feed_adapter() -> None:


### PR DESCRIPTION
新增 `timer_execution_policy` 参数，支持 "same_cycle"（默认）和 "next_event" 两种模式。
- "same_cycle": 定时器事件中提交的订单在当前事件周期内撮合（CurrentClose 模式）
- "next_event": 定时器订单延后到下一条行情事件撮合 为 MatchContext 添加 last_price 字段以支持定时器撮合，并更新相关测试用例。