### PR TITLE
feat(backtest): 引入统一成交语义配置 fill_policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.80"
+version = "0.1.81"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.80"
+version = "0.1.81"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/llm.md
+++ b/docs/en/advanced/llm.md
@@ -51,7 +51,10 @@ Your task is to write trading strategies or backtest scripts based on user requi
         *   `symbol`: Benchmark symbol or list of symbols.
         *   `initial_cash`: Float (e.g., 100_000.0).
         *   `warmup_period`: Int (optional override).
-        *   `execution_mode`: `ExecutionMode.NextOpen` (default), `CurrentClose`, or `NextAverage`.
+        *   `execution_mode`: `ExecutionMode.NextOpen` (default) or `CurrentClose`.
+        *   `timer_execution_policy`: `"same_cycle"` or `"next_event"` (timer fill timing).
+        *   `fill_policy`: Preferred unified semantics, e.g.
+            `{"price_basis": "current_close", "temporal": "next_event"}`.
         *   `timezone`: Default "Asia/Shanghai".
     *   Example:
         ```python

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -203,7 +203,7 @@ Recommendation: use Plan A by default; use Plan B only when a stable rebalance t
 
 *   **Suspensions / missing bars**: Plan B may not trigger if some symbols have no bar at a timestamp; add timeout fallback or minimum-valid-sample execution.
 *   **Universe drift**: If constituents change but your universe list is stale, weights and ranks diverge from target; refresh periodically and track effective date.
-*   **Rebalance time vs execution mode mismatch**: With `execution_mode="next_open"`, close-time signals are filled on next bar; document this in result interpretation.
+*   **Rebalance time vs execution mode mismatch**: With `execution_mode="next_open"`, close-time signals are filled on the next bar; under `current_close`, also define `timer_execution_policy` (or `fill_policy.temporal`) to make timer fill timing explicit.
 *   **Insufficient history windows**: Newly listed or recently resumed symbols may fail window requirements; check `len(closes)` and skip invalid samples.
 *   **Position convergence lag**: Multi-asset sell-then-buy cycles can leave partial allocations in one event; use target-position APIs and converge again on next cycle.
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -54,6 +54,8 @@ def run_backtest(
     risk_budget_reset_daily: bool = False,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     broker_profile: Optional[str] = None,
+    timer_execution_policy: Literal["same_cycle", "next_event"] = "same_cycle",
+    fill_policy: Optional[Dict[str, str]] = None,
     **kwargs: Any,
 ) -> BacktestResult
 ```
@@ -69,6 +71,13 @@ def run_backtest(
 *   `execution_mode`: Execution mode.
     *   `ExecutionMode.NextOpen`: Match at next Bar Open (Default).
     *   `ExecutionMode.CurrentClose`: Match at current Bar Close.
+*   `timer_execution_policy`: Temporal matching policy for timer-triggered orders (mainly under `CurrentClose`).
+    *   `"same_cycle"`: Match within the current timer event cycle.
+    *   `"next_event"`: Defer matching to the next market event.
+*   `fill_policy`: Unified fill semantics (higher priority than `execution_mode` and `timer_execution_policy`).
+    *   `price_basis`: `next_open`, `current_close`, `ohlc4` (OHLC average), or `hl2` (high-low midpoint).
+    *   Reserved (not implemented yet): `mid_quote`, `vwap_window`, `twap_window` (currently raises `NotImplementedError`).
+    *   `temporal`: `same_cycle` or `next_event`.
 *   `t_plus_one`: Enable T+1 trading rule (Default False). If enabled, it forces usage of China Market Model.
 *   `slippage`: Global slippage (Default 0.0). E.g., 0.0001 means 1bp (0.01%) slippage, using percent model.
 *   `volume_limit_pct`: Volume limit percentage (Default 0.25). Limits single trade to not exceed this percentage of the bar's total volume.
@@ -88,6 +97,16 @@ def run_backtest(
 *   `analyzer_plugins`: Optional analyzer plugin list. Plugins receive `on_start/on_bar/on_trade/on_finish` callbacks and final outputs are stored in `result.analyzer_outputs`.
 *   `on_event`: Optional stream callback. When omitted, an internal no-op callback keeps legacy blocking return semantics; when provided, runtime events are emitted.
 *   `broker_profile`: Optional broker template preset for quick defaults (fees/slippage/lot size). Built-ins: `cn_stock_miniqmt`, `cn_stock_t1_low_fee`, `cn_stock_sim_high_slippage`.
+
+**Execution semantics migration map:**
+
+| Legacy parameters | New style |
+| :--- | :--- |
+| `execution_mode="next_open"` | `fill_policy={"price_basis":"next_open","temporal":"same_cycle"}` |
+| `execution_mode="current_close", timer_execution_policy="same_cycle"` | `fill_policy={"price_basis":"current_close","temporal":"same_cycle"}` |
+| `execution_mode="current_close", timer_execution_policy="next_event"` | `fill_policy={"price_basis":"current_close","temporal":"next_event"}` |
+| `execution_mode="next_average"` | `fill_policy={"price_basis":"ohlc4","temporal":"same_cycle"}` |
+| `execution_mode="next_high_low_mid"` | `fill_policy={"price_basis":"hl2","temporal":"same_cycle"}` |
 
 ### `akquant.run_warm_start`
 

--- a/docs/en/textbook/04_backtest_engine.md
+++ b/docs/en/textbook/04_backtest_engine.md
@@ -3,6 +3,7 @@
 This chapter is currently maintained in Chinese first.
 
 - Chinese chapter: [第 4 章：事件驱动回测原理 (Event-Driven Architecture)](../../zh/textbook/04_backtest_engine.md)
+- New execution semantics note: `fill_policy={"price_basis": "...", "temporal": "..."}` is now the recommended style.
 - Textbook home: [Chinese textbook index](../../zh/textbook/index.md)
 - Practice links:
   - Primary example: [examples/textbook/ch04_comparison.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch04_comparison.py)

--- a/docs/zh/advanced/llm.md
+++ b/docs/zh/advanced/llm.md
@@ -51,7 +51,10 @@ Your task is to write trading strategies or backtest scripts based on user requi
         *   `symbol`: Benchmark symbol or list of symbols.
         *   `initial_cash`: Float (e.g., 100_000.0).
         *   `warmup_period`: Int (optional override).
-        *   `execution_mode`: `ExecutionMode.NextOpen` (default), `CurrentClose`, or `NextAverage`.
+        *   `execution_mode`: `ExecutionMode.NextOpen` (default) or `CurrentClose`.
+        *   `timer_execution_policy`: `"same_cycle"` or `"next_event"` (for timer matching timing).
+        *   `fill_policy`: Preferred unified semantics, e.g.
+            `{"price_basis": "current_close", "temporal": "next_event"}`.
         *   `timezone`: Default "Asia/Shanghai".
         *   `risk_config`: Use `engine.risk_manager` to set pre-trade checks (Position Limit, Sector Limit, Leverage).
     *   Example:

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -290,7 +290,7 @@ class CrossSectionBucketStrategy(Strategy):
 
 *   **停牌/缺失数据**：某些标的当日无 Bar 时，方案 B 可能不触发；可设置超时降级，或允许“有效样本数达阈值”即执行。
 *   **Universe 漂移**：成分股调整后若仍用旧列表，会出现权重与真实池不一致；建议定期刷新并记录生效日期。
-*   **调仓时点与执行模式错配**：例如 `execution_mode="next_open"` 时，收盘时点信号会在下一根撮合，需在回测解释里明确。
+*   **调仓时点与执行模式错配**：例如 `execution_mode="next_open"` 时，收盘时点信号会在下一根撮合；`current_close` 下还需结合 `timer_execution_policy`（或 `fill_policy.temporal`）明确 timer 是否当期成交。
 *   **历史长度不足**：新上市或停牌恢复标的数据窗口不完整；评分前统一做 `len(closes)` 检查并跳过不足样本。
 *   **仓位未收敛**：多标的先卖后买若资金未及时释放，可能导致买入不足；可采用目标仓位 API 并在下一时点二次收敛。
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -41,6 +41,8 @@ def run_backtest(
     strategies_by_slot: Optional[Dict[str, Union[Type[Strategy], Strategy, Callable[[Any, Bar], None]]]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     broker_profile: Optional[str] = None,
+    timer_execution_policy: Literal["same_cycle", "next_event"] = "same_cycle",
+    fill_policy: Optional[Dict[str, str]] = None,
     **kwargs: Any,
 ) -> BacktestResult
 ```
@@ -89,6 +91,13 @@ def run_warm_start(
 *   `execution_mode`: 执行模式。
     *   `ExecutionMode.NextOpen`: 下一 Bar 开盘价成交 (默认)。
     *   `ExecutionMode.CurrentClose`: 当前 Bar 收盘价成交。
+*   `timer_execution_policy`: 定时器事件成交时序策略（主要用于 `CurrentClose`）。
+    *   `"same_cycle"`: 在当前 `timer` 事件周期内撮合。
+    *   `"next_event"`: 延后到下一条行情事件再撮合。
+*   `fill_policy`: 统一成交语义配置（优先级高于 `execution_mode` 与 `timer_execution_policy`）。
+    *   `price_basis`: `next_open`、`current_close`、`ohlc4`（OHLC 平均价）或 `hl2`（高低中价）。
+    *   预留（暂未实现）: `mid_quote`、`vwap_window`、`twap_window`（当前会抛出 `NotImplementedError`）。
+    *   `temporal`: `same_cycle` 或 `next_event`。
 *   `t_plus_one`: 是否启用 T+1 交易规则 (默认 False)。如果启用，将强制使用中国市场模型。
 *   `slippage`: 全局滑点 (默认 0.0)。例如 0.0001 代表 1bp (0.01%) 的滑点，采用百分比模型。
 *   `volume_limit_pct`: 成交量限制比例 (默认 0.25)。限制单笔成交不超过该 Bar 总成交量的百分比。
@@ -103,6 +112,16 @@ def run_warm_start(
 *   `analyzer_plugins`: 可选 Analyzer 插件列表。插件接收 `on_start/on_bar/on_trade/on_finish` 生命周期回调，结果汇总到 `result.analyzer_outputs`。
 *   `on_event`: 可选事件回调。不传时内部使用 no-op 回调并保持阻塞返回语义；传入时可实时消费事件。
 *   `broker_profile`: 可选 broker 参数模板，用于快速注入费率/滑点/最小手数等默认值。内置模板：`cn_stock_miniqmt`、`cn_stock_t1_low_fee`、`cn_stock_sim_high_slippage`。
+
+**执行语义迁移映射：**
+
+| 旧参数组合 | 新参数写法 |
+| :--- | :--- |
+| `execution_mode="next_open"` | `fill_policy={"price_basis":"next_open","temporal":"same_cycle"}` |
+| `execution_mode="current_close", timer_execution_policy="same_cycle"` | `fill_policy={"price_basis":"current_close","temporal":"same_cycle"}` |
+| `execution_mode="current_close", timer_execution_policy="next_event"` | `fill_policy={"price_basis":"current_close","temporal":"next_event"}` |
+| `execution_mode="next_average"` | `fill_policy={"price_basis":"ohlc4","temporal":"same_cycle"}` |
+| `execution_mode="next_high_low_mid"` | `fill_policy={"price_basis":"hl2","temporal":"same_cycle"}` |
 
 **DataFeedAdapter 用法（多时间框）:**
 

--- a/docs/zh/textbook/04_backtest_engine.md
+++ b/docs/zh/textbook/04_backtest_engine.md
@@ -471,7 +471,26 @@ stateDiagram-v2
 | **NextOpen** (默认) | 当前 Bar 的信号，在**下一根 Bar 的开盘价**成交。 | 日线/分钟线策略 | **最推荐**。完全避免未来函数。 |
 | **CurrentClose** | 当前 Bar 的信号，在**当前 Bar 的收盘价**成交。 | 收盘竞价策略 | 需小心使用，容易引入前视偏差。 |
 
-### 4.10.3 滑点与冲击成本 (Slippage & Impact)
+### 4.10.3 成交时序策略 (Temporal Policy)
+
+在 `execution_mode` 之外，AKQuant 还支持通过 `timer_execution_policy`（或统一写法 `fill_policy.temporal`）控制 `on_timer` 下单的撮合时点：
+
+| 时序策略 | 描述 | 典型场景 |
+| :--- | :--- | :--- |
+| `same_cycle` (默认) | 在当前 timer 事件周期内撮合 | 定时调仓后立即成交的仿真 |
+| `next_event` | 延后到下一条行情事件撮合 | 更保守的“信号与成交分离”建模 |
+
+推荐统一使用：
+
+```python
+result = akquant.run_backtest(
+    data=data,
+    strategy=MyStrategy,
+    fill_policy={"price_basis": "current_close", "temporal": "next_event"},
+)
+```
+
+### 4.10.4 滑点与冲击成本 (Slippage & Impact)
 
 回测中最容易高估收益的因素是忽略了交易成本。`akquant` 支持配置滑点模型：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.80"
+version = "0.1.81"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -24,6 +24,7 @@ class ExecutionMode:
     NextOpen: typing.ClassVar["ExecutionMode"]
     CurrentClose: typing.ClassVar["ExecutionMode"]
     NextAverage: typing.ClassVar["ExecutionMode"]
+    NextHighLowMid: typing.ClassVar["ExecutionMode"]
 
 class OrderStatus:
     New: typing.ClassVar["OrderStatus"]

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -36,6 +36,18 @@ class BacktestStreamEvent(TypedDict):
     level: str
     payload: Dict[str, str]
 
+class FillPolicy(TypedDict, total=False):
+    price_basis: Literal[
+        "next_open",
+        "current_close",
+        "ohlc4",
+        "hl2",
+        "mid_quote",
+        "vwap_window",
+        "twap_window",
+    ]
+    temporal: Literal["same_cycle", "next_event"]
+
 def run_backtest(
     data: Optional[BacktestDataInput] = ...,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = ...,
@@ -94,6 +106,7 @@ def run_backtest(
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = ...,
     broker_profile: Optional[str] = ...,
     timer_execution_policy: Literal["same_cycle", "next_event"] = ...,
+    fill_policy: Optional[FillPolicy] = ...,
     stream_mode: Literal["observability", "audit"] = ...,
     **kwargs: Any,
 ) -> BacktestResult: ...

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -62,6 +62,23 @@ class BacktestStreamEvent(TypedDict):
     payload: Dict[str, str]
 
 
+class FillPolicy(TypedDict, total=False):
+    """Unified fill semantics for price basis and temporal policy."""
+
+    price_basis: str
+    temporal: str
+
+
+_SUPPORTED_FILL_PRICE_BASIS_TO_MODE: Dict[str, ExecutionMode] = {
+    "next_open": ExecutionMode.NextOpen,
+    "current_close": ExecutionMode.CurrentClose,
+    "ohlc4": ExecutionMode.NextAverage,
+    "hl2": ExecutionMode.NextHighLowMid,
+}
+_RESERVED_FILL_PRICE_BASIS: set[str] = {"mid_quote", "vwap_window", "twap_window"}
+_SUPPORTED_FILL_TEMPORAL: set[str] = {"same_cycle", "next_event"}
+
+
 BacktestDataInput = Union[
     pd.DataFrame, Dict[str, pd.DataFrame], List[Bar], DataFeed, DataFeedAdapter
 ]
@@ -644,6 +661,7 @@ def run_backtest(
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     broker_profile: Optional[str] = None,
     timer_execution_policy: str = "same_cycle",
+    fill_policy: Optional[FillPolicy] = None,
     **kwargs: Any,
 ) -> BacktestResult:
     """
@@ -680,6 +698,11 @@ def run_backtest(
     :param timer_execution_policy: 定时器下单撮合策略:
         "same_cycle" 表示在当前 timer 事件撮合（CurrentClose 模式）；
         "next_event" 表示延后到下一条行情事件撮合。
+    :param fill_policy: 统一成交语义配置（可选），格式:
+        {"price_basis": "next_open|current_close|ohlc4|hl2",
+         "temporal": "same_cycle|next_event"}。
+        预留未实现 price_basis: mid_quote、vwap_window、twap_window。
+        若提供该参数，则其语义优先于 execution_mode 与 timer_execution_policy。
     :param timezone: 时区名称 (默认 "Asia/Shanghai")
     :param t_plus_one: 是否启用 T+1 交易规则 (默认 False)
     :param initialize: 初始化回调函数 (仅当 strategy 为函数时使用)
@@ -1802,25 +1825,75 @@ def run_backtest(
                     e,
                 )
 
-    # ... (ExecutionMode logic)
-    if isinstance(execution_mode, str):
+    resolved_execution_mode = execution_mode
+    resolved_timer_policy = str(timer_execution_policy).strip().lower()
+    if fill_policy is not None:
+        if not isinstance(fill_policy, dict):
+            raise TypeError("fill_policy must be a dict")
+        raw_basis = str(fill_policy.get("price_basis", "next_open")).strip().lower()
+        raw_temporal = str(fill_policy.get("temporal", "same_cycle")).strip().lower()
+        basis_mode = _SUPPORTED_FILL_PRICE_BASIS_TO_MODE.get(raw_basis)
+        if basis_mode is None:
+            if raw_basis in _RESERVED_FILL_PRICE_BASIS:
+                raise NotImplementedError(
+                    "fill_policy.price_basis='%s' is reserved but not implemented yet"
+                    % raw_basis
+                )
+            raise ValueError(
+                "fill_policy.price_basis must be one of: "
+                "next_open, current_close, ohlc4, hl2; "
+                "reserved: mid_quote, vwap_window, twap_window"
+            )
+        if raw_temporal not in _SUPPORTED_FILL_TEMPORAL:
+            raise ValueError(
+                "fill_policy.temporal must be one of: same_cycle, next_event"
+            )
+        if execution_mode != ExecutionMode.NextOpen:
+            logger.warning(
+                "fill_policy overrides execution_mode=%s",
+                execution_mode,
+            )
+        if str(timer_execution_policy).strip().lower() != "same_cycle":
+            logger.warning(
+                "fill_policy overrides timer_execution_policy=%s",
+                timer_execution_policy,
+            )
+        resolved_execution_mode = basis_mode
+        resolved_timer_policy = raw_temporal
+
+    if isinstance(resolved_execution_mode, str):
         mode_map = {
             "next_open": ExecutionMode.NextOpen,
             "current_close": ExecutionMode.CurrentClose,
+            "next_average": ExecutionMode.NextAverage,
+            "next_high_low_mid": ExecutionMode.NextHighLowMid,
+            "ohlc4": ExecutionMode.NextAverage,
+            "hl2": ExecutionMode.NextHighLowMid,
         }
-        mode = mode_map.get(execution_mode.lower())
+        mode = mode_map.get(resolved_execution_mode.lower())
         if not mode:
             logger.warning(
-                f"Unknown execution mode '{execution_mode}', defaulting to NextOpen"
+                "Unknown execution mode '%s', defaulting to NextOpen",
+                resolved_execution_mode,
             )
             mode = ExecutionMode.NextOpen
-        engine.set_execution_mode(mode)
+        resolved_mode_enum = mode
     else:
-        engine.set_execution_mode(execution_mode)
-    timer_policy = str(timer_execution_policy).strip().lower()
-    if timer_policy not in {"same_cycle", "next_event"}:
+        resolved_mode_enum = resolved_execution_mode
+    engine.set_execution_mode(resolved_mode_enum)
+    timer_policy = resolved_timer_policy
+    if timer_policy not in _SUPPORTED_FILL_TEMPORAL:
         raise ValueError(
             "timer_execution_policy must be one of: same_cycle, next_event"
+        )
+    if (
+        resolved_mode_enum != ExecutionMode.CurrentClose
+        and timer_policy == "same_cycle"
+    ):
+        logger.info(
+            "timer_execution_policy=%s has no effect when execution_mode=%s",
+            timer_policy,
+            resolved_mode_enum,
         )
     if hasattr(engine, "set_timer_execution_policy"):
         cast(Any, engine).set_timer_execution_policy(timer_policy)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -467,6 +467,169 @@ def test_current_close_mixed_bar_timer_next_event_policy() -> None:
         assert ts != strategy.timer_timestamp
 
 
+def test_fill_policy_same_cycle_matches_legacy_parameters() -> None:
+    """Fill policy should align with legacy current_close+same_cycle behavior."""
+    symbol = "TIMER_BUG"
+    bars = [
+        akquant.Bar(
+            pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value,
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value,
+            11.0,
+            11.0,
+            11.0,
+            11.0,
+            1000.0,
+            symbol,
+        ),
+    ]
+    strategy = TimerCurrentCloseStrategy()
+    strategy.symbol_ref = symbol
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        fill_policy={"price_basis": "current_close", "temporal": "same_cycle"},
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.timer_timestamp is not None
+    assert strategy.trade_timestamp is not None
+    assert strategy.trade_timestamp == strategy.timer_timestamp
+    assert strategy.trade_price == pytest.approx(10.0)
+
+
+def test_fill_policy_next_event_matches_legacy_parameters() -> None:
+    """Fill policy next_event should match legacy next_event timer behavior."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    second_ts = pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value
+    third_ts = pd.Timestamp("2023-01-02 10:02:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
+        akquant.Bar(second_ts, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
+        akquant.Bar(third_ts, 12.0, 12.0, 12.0, 12.0, 1000.0, symbol),
+    ]
+    strategy = TimerCurrentCloseStrategy()
+    strategy.symbol_ref = symbol
+    strategy.timer_trigger = pd.Timestamp("2023-01-02 10:01:30", tz="Asia/Shanghai")
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        fill_policy={"price_basis": "current_close", "temporal": "next_event"},
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.timer_timestamp is not None
+    assert strategy.trade_timestamp != strategy.timer_timestamp
+
+
+def test_fill_policy_ohlc4_maps_to_next_average() -> None:
+    """fill_policy price_basis=ohlc4 should map to NextAverage pricing."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    second_ts = pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 9.0, 9.5, 8.5, 9.2, 1000.0, symbol),
+        akquant.Bar(second_ts, 10.0, 15.0, 9.0, 12.0, 1000.0, symbol),
+    ]
+    strategy = BarOnlyCaptureStrategy()
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        fill_policy={"price_basis": "ohlc4", "temporal": "same_cycle"},
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.trade_timestamp == second_ts
+    assert strategy.trade_price == pytest.approx(11.5)
+
+
+def test_fill_policy_hl2_maps_to_next_high_low_mid() -> None:
+    """fill_policy price_basis=hl2 should map to NextHighLowMid pricing."""
+    symbol = "TIMER_BUG"
+    first_ts = pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai").value
+    second_ts = pd.Timestamp("2023-01-02 10:01:00", tz="Asia/Shanghai").value
+    bars = [
+        akquant.Bar(first_ts, 9.0, 9.5, 8.5, 9.2, 1000.0, symbol),
+        akquant.Bar(second_ts, 10.0, 15.0, 9.0, 12.0, 1000.0, symbol),
+    ]
+    strategy = BarOnlyCaptureStrategy()
+
+    _ = akquant.run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbol=symbol,
+        fill_policy={"price_basis": "hl2", "temporal": "same_cycle"},
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert strategy.trade_timestamp == second_ts
+    assert strategy.trade_price == pytest.approx(12.0)
+
+
+def test_fill_policy_reserved_mid_quote_raises_not_implemented() -> None:
+    """Reserved price_basis mid_quote should raise NotImplementedError."""
+    bars = _build_benchmark_data(3, "RESERVED_BASIS")
+    with pytest.raises(NotImplementedError, match="mid_quote"):
+        akquant.run_backtest(
+            data=bars,
+            strategy=SingleBuyStrategy,
+            symbols="RESERVED_BASIS",
+            fill_policy={"price_basis": "mid_quote", "temporal": "same_cycle"},
+            show_progress=False,
+        )
+
+
+def test_fill_policy_reserved_vwap_window_raises_not_implemented() -> None:
+    """Reserved price_basis vwap_window should raise NotImplementedError."""
+    bars = _build_benchmark_data(3, "RESERVED_BASIS")
+    with pytest.raises(NotImplementedError, match="vwap_window"):
+        akquant.run_backtest(
+            data=bars,
+            strategy=SingleBuyStrategy,
+            symbols="RESERVED_BASIS",
+            fill_policy={"price_basis": "vwap_window", "temporal": "same_cycle"},
+            show_progress=False,
+        )
+
+
 def test_run_backtest_accepts_data_feed_adapter() -> None:
     """run_backtest should accept objects implementing DataFeedAdapter.load."""
 


### PR DESCRIPTION
- 新增 fill_policy 参数，支持 price_basis 和 temporal 统一配置
- 提供从旧参数到新写法的迁移映射表
- 新增 ExecutionMode.NextHighLowMid 枚举值
- 更新文档说明执行语义，补充 timer_execution_policy 说明
- 添加相关单元测试验证行为一致性