### PR TITLE
feat(ctp): 增加严格执行语义模式并更新文档

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.81"
+version = "0.1.82"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.81"
+version = "0.1.82"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/live_functional_quickstart.md
+++ b/docs/en/advanced/live_functional_quickstart.md
@@ -30,7 +30,13 @@ Switch to broker_live after gateway connectivity is verified:
   - `trading_mode="broker_live"`
   - call `ctx.submit_order(...)` inside `on_bar`
   - pass explicit `client_order_id` for idempotency tracking
+  - default execution semantics is `execution_semantics_mode="strict"` (terminal states are driven by broker order callbacks)
   - optional `on_broker_event` for unified `event_type/owner_strategy_id/payload` persistence
+
+You can pass `execution_semantics_mode` via `gateway_options`:
+
+- `strict` (default, recommended for production): terminal states such as `Cancelled/Rejected/Filled` are confirmed by `OnRtnOrder`; error callbacks cache rejection reasons and merge them into subsequent order callbacks.
+- `compatible` (migration mode): allows immediate local terminal-state updates for selected error/cancel paths to preserve legacy behavior.
 
 ## 3. Function-style template
 
@@ -59,6 +65,7 @@ runner = LiveRunner(
     instruments=instruments,
     broker="ctp",
     trading_mode="broker_live",
+    gateway_options={"execution_semantics_mode": "strict"},
 )
 runner.run(duration="30s", show_progress=False)
 ```
@@ -74,6 +81,9 @@ runner.run(duration="30s", show_progress=False)
 - Market data arrives but no trades
   - Cause: trader gateway not connected, risk rejection, or invalid lot/tick constraints.
   - Fix: inspect `on_order` status and rejection reason first.
+- Cancel request sent but status remains `Submitted`
+  - Cause: strict semantics requires `OnRtnOrder(Cancelled)` to finalize terminal state.
+  - Fix: verify trader callback path and broker order-return logs, not only request send success.
 
 ## 5. Suggested rollout
 

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -358,6 +358,8 @@ AKQuant provides a callback mechanism similar to Backtrader for tracking order s
 
 Triggered when order status changes (e.g., from `New` to `Submitted`, or to `Filled`).
 
+In `broker_live` with CTP, the default execution semantics is strict: terminal states are confirmed by `OnRtnOrder`. For example, a cancel request does not imply `Cancelled` until `OnRtnOrder(Cancelled)` arrives.
+
 ```python
 from akquant import OrderStatus
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -2,6 +2,10 @@
 
 This API documentation covers the core classes and methods of AKQuant.
 
+Quick links:
+
+*   [LiveRunner broker-live semantics](#live-broker-semantics)
+
 ## 1. High-Level API
 
 ### `akquant.run_backtest`
@@ -541,6 +545,32 @@ Bar data object.
 *   `timestamp`: Unix timestamp (nanoseconds).
 *   `open`, `high`, `low`, `close`, `volume`: OHLCV data.
 *   `symbol`: Instrument symbol.
+
+### `akquant.live.LiveRunner` (broker live semantics) {: #live-broker-semantics }
+
+For live broker routing, `LiveRunner` accepts broker-specific options through `gateway_options`.
+
+```python
+runner = LiveRunner(
+    strategy_cls=on_bar,
+    instruments=instruments,
+    broker="ctp",
+    trading_mode="broker_live",
+    gateway_options={"execution_semantics_mode": "strict"},
+)
+```
+
+`gateway_options.execution_semantics_mode`:
+
+| Value | Default | Behavior | Recommended |
+| :--- | :--- | :--- | :--- |
+| `strict` | Yes | Terminal states (`Cancelled` / `Rejected` / `Filled`) are finalized by broker order callbacks (`OnRtnOrder`). Error callbacks cache reject reasons and merge them into subsequent order callbacks. | Production live trading |
+| `compatible` | No | Allows immediate local terminal-state transitions for selected error/cancel paths to keep legacy behavior. | Migration / temporary compatibility |
+
+Strict-mode notes:
+
+*   Cancel request sent does not imply `Cancelled`; wait for `OnRtnOrder(Cancelled)`.
+*   Error callback received does not imply `Rejected`; final status is confirmed by order callback.
 
 ## 3. Core Engine
 

--- a/docs/en/textbook/15_live_trading.md
+++ b/docs/en/textbook/15_live_trading.md
@@ -4,6 +4,9 @@ This chapter is currently maintained in Chinese first.
 
 - Chinese chapter: [第 15 章：实盘交易系统与运维](../../zh/textbook/15_live_trading.md)
 - Textbook home: [Chinese textbook index](../../zh/textbook/index.md)
+- Live execution semantics note:
+  - CTP supports `execution_semantics_mode` with `strict` (default) and `compatible`.
+  - In `strict`, terminal order states are confirmed by `OnRtnOrder` callbacks.
 - Practice links:
   - Primary example: [examples/textbook/ch15_live_trading.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_live_trading.py)
   - Extended example: [examples/textbook/ch15_strategy_loader.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_strategy_loader.py)

--- a/docs/zh/advanced/live_functional_quickstart.md
+++ b/docs/zh/advanced/live_functional_quickstart.md
@@ -30,7 +30,13 @@
   - `trading_mode="broker_live"`
   - `on_bar` 中调用 `ctx.submit_order(...)`
   - 显式传入 `client_order_id` 便于幂等追踪
+  - 默认执行语义 `execution_semantics_mode="strict"`（终态仅由柜台订单回报推进）
   - 可选 `on_broker_event` 统一落盘 `event_type/owner_strategy_id/payload`
+
+`execution_semantics_mode` 可通过 `gateway_options` 传入：
+
+- `strict`（默认，推荐生产）：`Cancelled/Rejected/Filled` 等终态仅由 `OnRtnOrder` 推进；错误回报会缓存拒单原因并在后续订单回报补齐。
+- `compatible`（兼容模式）：允许在部分错误/撤单场景下立即本地推进终态，便于旧策略平滑迁移。
 
 ## 3. 函数式入口模板
 
@@ -59,6 +65,7 @@ runner = LiveRunner(
     instruments=instruments,
     broker="ctp",
     trading_mode="broker_live",
+    gateway_options={"execution_semantics_mode": "strict"},
 )
 runner.run(duration="30s", show_progress=False)
 ```
@@ -74,6 +81,9 @@ runner.run(duration="30s", show_progress=False)
 - 有行情但无成交回调
   - 原因：交易网关未连通、风控拒单、最小变动价位/手数不合规。
   - 处理：优先检查 `on_order` 状态与拒单原因。
+- 撤单请求发出后状态仍是 `Submitted`
+  - 原因：当前为严格语义，状态需等待 `OnRtnOrder(Cancelled)`。
+  - 处理：检查交易侧回报链路与订单回报日志，不要用本地请求发送成功替代终态。
 
 ## 5. 建议上线流程
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -328,6 +328,7 @@ AKQuant 提供了两种风格的策略开发接口：
 *   LiveRunner 支持函数式入口与多 slot 编排：`LiveRunner(strategy_cls=on_bar, strategy_id="alpha", strategies_by_slot={"beta": OtherStrategy}, initialize=..., on_tick=..., on_order=..., on_trade=..., on_timer=...)`
 *   回测多 slot 与策略级风控映射建议使用集中式 `BacktestConfig(strategy_config=StrategyConfig(...))`：`docs/zh/advanced/multi_strategy_guide.md`
 *   broker_live 函数式下单示例：`examples/39_live_broker_submit_order_demo.py`
+*   broker_live 默认执行语义为 `strict`，可通过 `gateway_options={"execution_semantics_mode": "strict"}` 显式声明
 *   函数式多策略 slot + 风控示例：`examples/40_functional_multi_slot_risk_demo.py`
 *   LiveRunner 多策略 slot 编排示例：`examples/41_live_multi_slot_orchestration_demo.py`
 *   运行后可分别观察输出标记：
@@ -406,6 +407,8 @@ class MyStrategy(Strategy):
     *   **PartiallyFilled**: 订单部分成交（`filled_quantity < quantity`）。
 5.  **Cancelled**: 订单已取消。
 6.  **Rejected**: 订单被风控或交易所拒绝 (如资金不足、超出涨跌停)。
+
+`broker_live` + CTP 默认使用严格执行语义：终态以 `OnRtnOrder` 为准。也就是说，发送撤单请求后，只有收到 `OnRtnOrder(Cancelled)` 才会进入 `Cancelled`；收到错误回报后，也需要后续订单回报来最终确认 `Rejected`。
 
 ### 7.2 常用交易指令
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -2,6 +2,10 @@
 
 本 API 文档涵盖了 AKQuant 的核心类和方法。
 
+快速跳转：
+
+*   [LiveRunner broker_live 执行语义](#live-broker-semantics)
+
 ## 1. 高级入口 (High-Level API)
 
 ### `akquant.run_backtest`
@@ -580,6 +584,32 @@ Tick 数据对象。
 *   `price`: 最新价。
 *   `volume`: 成交量。
 *   `symbol`: 标的代码。
+
+### `akquant.live.LiveRunner`（broker_live 执行语义） {: #live-broker-semantics }
+
+实盘 broker 路由可通过 `gateway_options` 传入网关特定参数：
+
+```python
+runner = LiveRunner(
+    strategy_cls=on_bar,
+    instruments=instruments,
+    broker="ctp",
+    trading_mode="broker_live",
+    gateway_options={"execution_semantics_mode": "strict"},
+)
+```
+
+`gateway_options.execution_semantics_mode`：
+
+| 取值 | 默认值 | 行为 | 推荐场景 |
+| :--- | :--- | :--- | :--- |
+| `strict` | 是 | `Cancelled` / `Rejected` / `Filled` 等终态由订单回报 (`OnRtnOrder`) 最终确认。错误回报会先缓存拒单原因，再在后续订单回报中补齐。 | 生产实盘 |
+| `compatible` | 否 | 在部分错误/撤单路径允许本地立即推进终态，以兼容历史行为。 | 迁移过渡 |
+
+严格模式注意事项：
+
+*   撤单请求发送成功不等于 `Cancelled`，需等待 `OnRtnOrder(Cancelled)`。
+*   收到错误回报不等于 `Rejected`，最终状态以订单回报为准。
 
 ## 3. 核心引擎 (Core)
 

--- a/docs/zh/textbook/15_live_trading.md
+++ b/docs/zh/textbook/15_live_trading.md
@@ -42,6 +42,11 @@ python examples/textbook/ch15_strategy_loader.py
 
 在实盘模式下，`DataFeed` 切换为实时行情源，交易执行由对应 broker gateway 负责。
 
+CTP 交易链路支持 `execution_semantics_mode`：
+
+*   `strict`（默认，推荐生产）：终态仅由柜台订单回报确认。
+*   `compatible`：兼容旧行为，允许部分场景在本地提前推进终态。
+
 当内置网关不满足需求时，可以通过注册机制扩展自定义 broker，且注册 broker 会被工厂优先解析，再回退到内置 `ctp/miniqmt/ptrade`。
 
 ```python
@@ -83,6 +88,12 @@ OMS 是实盘交易的核心，负责维护订单的全生命周期状态。
 
 *   **定时同步**：每隔 N 秒查询柜台持仓，强制覆盖本地状态。
 *   **事件驱动**：通过 `on_order`、`on_trade`（以及可选 `on_broker_event`）实时更新状态并做审计落盘。
+
+在 CTP 严格模式下，建议遵循以下判定：
+
+1.  发送撤单请求成功 ≠ `Cancelled`，必须等待 `OnRtnOrder(Cancelled)`。
+2.  收到报单错误 ≠ `Rejected`，应以最终 `OnRtnOrder` 状态为准。
+3.  `Filled` 以订单回报终态确认，成交回报用于补充成交明细与审计。
 
 ## 15.3 风险管理系统 (Risk Management System, RMS)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.81"
+version = "0.1.82"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/gateway/ctp_adapter.py
+++ b/python/akquant/gateway/ctp_adapter.py
@@ -81,8 +81,15 @@ class CTPTraderAdapter:
         password: str = "",
         auth_code: str = "0000000000000000",
         app_id: str = "simnow_client_test",
+        execution_semantics_mode: str = "strict",
     ) -> None:
         """Initialize CTP trader adapter."""
+        normalized_mode = str(execution_semantics_mode).strip().lower()
+        if normalized_mode not in {"strict", "compatible"}:
+            raise ValueError(
+                "execution_semantics_mode must be 'strict' or 'compatible'"
+            )
+        self.execution_semantics_mode = normalized_mode
         self.mapper: BrokerEventMapper = create_default_mapper()
         self.order_callback: Callable[[UnifiedOrderSnapshot], None] | None = None
         self.trade_callback: Callable[[UnifiedTrade], None] | None = None
@@ -91,6 +98,8 @@ class CTPTraderAdapter:
         self.trades: list[UnifiedTrade] = []
         self.client_to_broker_order_ids: dict[str, str] = {}
         self.broker_to_client_order_ids: dict[str, str] = {}
+        self.order_ref_to_client_order_ids: dict[str, str] = {}
+        self.pending_reject_reasons: dict[str, str] = {}
         self._order_seq = 0
         self.gateway = CTPTraderGateway(
             front_url=front_url,
@@ -100,6 +109,12 @@ class CTPTraderAdapter:
             auth_code=auth_code,
             app_id=app_id,
         )
+        if hasattr(self.gateway, "set_order_handler"):
+            self.gateway.set_order_handler(self._handle_native_order_event)
+        if hasattr(self.gateway, "set_trade_handler"):
+            self.gateway.set_trade_handler(self._handle_native_trade_event)
+        if hasattr(self.gateway, "set_error_handler"):
+            self.gateway.set_error_handler(self._handle_native_error_event)
 
     def connect(self) -> None:
         """Connect and start trader stream."""
@@ -130,9 +145,25 @@ class CTPTraderAdapter:
                 )
         if not self.heartbeat():
             raise RuntimeError("CTP trader is not connected")
+        native_result = self.gateway.insert_order(
+            client_order_id=req.client_order_id,
+            symbol=req.symbol,
+            side=req.side,
+            quantity=req.quantity,
+            price=req.price,
+            order_type=req.order_type,
+            time_in_force=req.time_in_force,
+        )
         self._order_seq += 1
-        now_ns = time.time_ns()
-        broker_order_id = f"ctp-{req.client_order_id}-{self._order_seq}"
+        now_ns = int(native_result.get("timestamp_ns", time.time_ns()))
+        broker_order_id = str(
+            native_result.get(
+                "broker_order_id", f"ctp-{req.client_order_id}-{self._order_seq}"
+            )
+        )
+        order_ref = str(native_result.get("order_ref", "")).strip()
+        if order_ref:
+            self.order_ref_to_client_order_ids[order_ref] = req.client_order_id
         snapshot = UnifiedOrderSnapshot(
             client_order_id=req.client_order_id,
             broker_order_id=broker_order_id,
@@ -155,6 +186,9 @@ class CTPTraderAdapter:
 
     def cancel_order(self, broker_order_id: str) -> None:
         """Cancel order through CTP trader channel."""
+        self.gateway.cancel_order(broker_order_id)
+        if self.execution_semantics_mode != "compatible":
+            return
         order = self.orders.get(broker_order_id)
         if order is None:
             return
@@ -223,6 +257,9 @@ class CTPTraderAdapter:
 
     def heartbeat(self) -> bool:
         """Return whether trader connection is alive."""
+        can_trade = getattr(self.gateway, "can_trade", None)
+        if callable(can_trade):
+            return bool(can_trade())
         return bool(getattr(self.gateway, "connected", False))
 
     def start(self) -> None:
@@ -289,3 +326,57 @@ class CTPTraderAdapter:
             UnifiedOrderStatus.CANCELLED,
             UnifiedOrderStatus.REJECTED,
         )
+
+    def _handle_native_order_event(self, payload: dict[str, Any]) -> None:
+        data = dict(payload)
+        order_ref = str(data.get("order_ref", "")).strip()
+        client_order_id = str(data.get("client_order_id", "")).strip()
+        if not client_order_id and order_ref:
+            client_order_id = self.order_ref_to_client_order_ids.get(order_ref, "")
+            if client_order_id:
+                data["client_order_id"] = client_order_id
+        broker_order_id = str(data.get("broker_order_id", "")).strip()
+        if not broker_order_id:
+            return
+        pending_reject_reason = self.pending_reject_reasons.pop(
+            broker_order_id, ""
+        ).strip()
+        if pending_reject_reason and not str(data.get("reject_reason", "")).strip():
+            data["reject_reason"] = pending_reject_reason
+        self.ingest_order_event(data)
+
+    def _handle_native_trade_event(self, payload: dict[str, Any]) -> None:
+        data = dict(payload)
+        order_ref = str(data.get("order_ref", "")).strip()
+        client_order_id = str(data.get("client_order_id", "")).strip()
+        if not client_order_id and order_ref:
+            client_order_id = self.order_ref_to_client_order_ids.get(order_ref, "")
+            if client_order_id:
+                data["client_order_id"] = client_order_id
+        broker_order_id = str(data.get("broker_order_id", "")).strip()
+        if not broker_order_id:
+            return
+        self.ingest_trade_event(data)
+
+    def _handle_native_error_event(self, payload: dict[str, Any]) -> None:
+        data = dict(payload)
+        broker_order_id = str(data.get("broker_order_id", "")).strip()
+        if not broker_order_id:
+            return
+        if self.execution_semantics_mode == "compatible":
+            self.ingest_order_event(
+                {
+                    "client_order_id": str(data.get("client_order_id", "")).strip(),
+                    "broker_order_id": broker_order_id,
+                    "symbol": str(data.get("symbol", "")).strip(),
+                    "status": "rejected",
+                    "filled_quantity": 0.0,
+                    "avg_fill_price": 0.0,
+                    "reject_reason": str(data.get("error_message", "")).strip(),
+                    "timestamp_ns": int(data.get("timestamp_ns", time.time_ns())),
+                }
+            )
+            return
+        reject_reason = str(data.get("error_message", "")).strip()
+        if reject_reason:
+            self.pending_reject_reasons[broker_order_id] = reject_reason

--- a/python/akquant/gateway/ctp_native.py
+++ b/python/akquant/gateway/ctp_native.py
@@ -6,7 +6,7 @@ This module provides CTP (China Futures) connectivity using openctp-ctp library.
 """
 
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from ..akquant import Bar, BarAggregator, DataFeed
 
@@ -81,6 +81,15 @@ class CTPTraderGateway(tdapi.CThostFtdcTraderSpi):  # type: ignore
         self.connected = False
         self.authenticated = False
         self.login_status = False
+        self.ready_to_trade = False
+        self.front_id = 0
+        self.session_id = 0
+        self.order_ref = 1
+        self.order_callback: Callable[[dict[str, Any]], None] | None = None
+        self.trade_callback: Callable[[dict[str, Any]], None] | None = None
+        self.error_callback: Callable[[dict[str, Any]], None] | None = None
+        self.order_ref_to_client_order_id: dict[str, str] = {}
+        self.order_ref_to_symbol: dict[str, str] = {}
 
     def start(self) -> None:
         """Start the CTP Trader API in a blocking way (should be run in a thread)."""
@@ -96,6 +105,130 @@ class CTPTraderGateway(tdapi.CThostFtdcTraderSpi):  # type: ignore
             self.api.Join()
         except Exception as e:
             print(f"[CTP-Trade] ERROR: Failed to start CTP Trader API: {e}")
+
+    def set_order_handler(self, callback: Callable[[dict[str, Any]], None]) -> None:
+        """Set native order event handler."""
+        self.order_callback = callback
+
+    def set_trade_handler(self, callback: Callable[[dict[str, Any]], None]) -> None:
+        """Set native trade event handler."""
+        self.trade_callback = callback
+
+    def set_error_handler(self, callback: Callable[[dict[str, Any]], None]) -> None:
+        """Set native error event handler."""
+        self.error_callback = callback
+
+    def can_trade(self) -> bool:
+        """Return whether the trader channel is ready for order requests."""
+        return self.connected and self.login_status and self.ready_to_trade
+
+    def insert_order(
+        self,
+        *,
+        client_order_id: str,
+        symbol: str,
+        side: str,
+        quantity: float,
+        price: float | None,
+        order_type: str,
+        time_in_force: str,
+    ) -> dict[str, Any]:
+        """Send CTP order insert request."""
+        if not self.can_trade():
+            raise RuntimeError("CTP trader is not ready for trading")
+        if self.api is None:
+            raise RuntimeError("CTP trader API is not initialized")
+
+        order_ref_text = str(self.order_ref)
+        self.order_ref += 1
+        self.order_ref_to_client_order_id[order_ref_text] = client_order_id
+        self.order_ref_to_symbol[order_ref_text] = symbol
+
+        request = tdapi.CThostFtdcInputOrderField()
+        request.BrokerID = self.broker_id
+        request.InvestorID = self.user_id
+        request.ExchangeID = ""
+        request.InstrumentID = symbol
+        request.OrderRef = order_ref_text
+        request.UserID = self.user_id
+        request.Direction = (
+            tdapi.THOST_FTDC_D_Buy
+            if str(side).strip().lower() == "buy"
+            else tdapi.THOST_FTDC_D_Sell
+        )
+        request.CombOffsetFlag = tdapi.THOST_FTDC_OF_Open
+        request.CombHedgeFlag = tdapi.THOST_FTDC_HF_Speculation
+        request.VolumeTotalOriginal = int(max(1, round(quantity)))
+
+        order_type_key = str(order_type).strip().lower()
+        tif_key = str(time_in_force).strip().upper()
+        if order_type_key == "market":
+            request.OrderPriceType = tdapi.THOST_FTDC_OPT_AnyPrice
+            request.LimitPrice = 0.0
+            request.TimeCondition = tdapi.THOST_FTDC_TC_IOC
+            request.VolumeCondition = tdapi.THOST_FTDC_VC_AV
+        else:
+            if price is None or price <= 0:
+                raise ValueError("limit price must be positive for non-market orders")
+            request.OrderPriceType = tdapi.THOST_FTDC_OPT_LimitPrice
+            request.LimitPrice = float(price)
+            if tif_key in {"IOC", "FAK", "FOK"}:
+                request.TimeCondition = tdapi.THOST_FTDC_TC_IOC
+                if tif_key == "FOK":
+                    request.VolumeCondition = tdapi.THOST_FTDC_VC_CV
+                else:
+                    request.VolumeCondition = tdapi.THOST_FTDC_VC_AV
+            else:
+                request.TimeCondition = tdapi.THOST_FTDC_TC_GFD
+                request.VolumeCondition = tdapi.THOST_FTDC_VC_AV
+
+        request.MinVolume = 1
+        request.ContingentCondition = tdapi.THOST_FTDC_CC_Immediately
+        request.ForceCloseReason = tdapi.THOST_FTDC_FCC_NotForceClose
+        request.IsAutoSuspend = 0
+        request.UserForceClose = 0
+
+        self.req_id += 1
+        ret = self.api.ReqOrderInsert(request, self.req_id)
+        if ret != 0:
+            self.order_ref_to_client_order_id.pop(order_ref_text, None)
+            self.order_ref_to_symbol.pop(order_ref_text, None)
+            raise RuntimeError(f"ReqOrderInsert failed with code={ret}")
+        return {
+            "broker_order_id": self._make_broker_order_id(
+                front_id=self.front_id,
+                session_id=self.session_id,
+                order_ref=order_ref_text,
+                order_sys_id="",
+            ),
+            "order_ref": order_ref_text,
+            "front_id": self.front_id,
+            "session_id": self.session_id,
+            "timestamp_ns": time.time_ns(),
+        }
+
+    def cancel_order(self, broker_order_id: str) -> None:
+        """Send CTP cancel order request."""
+        if not self.can_trade():
+            raise RuntimeError("CTP trader is not ready for cancel requests")
+        if self.api is None:
+            raise RuntimeError("CTP trader API is not initialized")
+        parsed = self._parse_broker_order_id(broker_order_id)
+        order_ref = parsed.get("order_ref", "")
+        if not order_ref:
+            raise ValueError(f"invalid broker_order_id={broker_order_id}")
+        request = tdapi.CThostFtdcInputOrderActionField()
+        request.BrokerID = self.broker_id
+        request.InvestorID = self.user_id
+        request.OrderRef = order_ref
+        request.FrontID = int(parsed.get("front_id") or self.front_id)
+        request.SessionID = int(parsed.get("session_id") or self.session_id)
+        request.ActionFlag = tdapi.THOST_FTDC_AF_Delete
+        request.InstrumentID = self.order_ref_to_symbol.get(order_ref, "")
+        self.req_id += 1
+        ret = self.api.ReqOrderAction(request, self.req_id)
+        if ret != 0:
+            raise RuntimeError(f"ReqOrderAction failed with code={ret}")
 
     def OnFrontConnected(self) -> None:
         """Handle front connection event."""
@@ -157,6 +290,11 @@ class CTPTraderGateway(tdapi.CThostFtdcTraderSpi):  # type: ignore
             f"BrokerID: {pRspUserLogin.BrokerID}, UserID: {pRspUserLogin.UserID}"
         )
         self.login_status = True
+        self.front_id = int(getattr(pRspUserLogin, "FrontID", 0) or 0)
+        self.session_id = int(getattr(pRspUserLogin, "SessionID", 0) or 0)
+        max_order_ref = str(getattr(pRspUserLogin, "MaxOrderRef", "")).strip()
+        if max_order_ref.isdigit():
+            self.order_ref = int(max_order_ref) + 1
 
         self.req_id += 1
         req = tdapi.CThostFtdcSettlementInfoConfirmField()
@@ -176,14 +314,191 @@ class CTPTraderGateway(tdapi.CThostFtdcTraderSpi):  # type: ignore
         """Handle settlement info confirmation response."""
         if pRspInfo is not None and pRspInfo.ErrorID != 0:
             print(f"[CTP-Trade] Settlement Confirm failed: {pRspInfo.ErrorMsg}")
+            self.ready_to_trade = False
         else:
             print("[CTP-Trade] Settlement Info Confirmed.")
+            self.ready_to_trade = True
 
     def OnFrontDisconnected(self, nReason: int) -> None:
         """Handle front disconnection event."""
         print(f"[CTP-Trade] OnFrontDisconnected. [nReason={nReason}]")
         self.connected = False
         self.login_status = False
+        self.ready_to_trade = False
+
+    def OnRspOrderInsert(
+        self, pInputOrder: Any, pRspInfo: Any, nRequestID: int, bIsLast: bool
+    ) -> None:
+        """Handle order insert response."""
+        if pRspInfo is None or pRspInfo.ErrorID == 0:
+            return
+        self._emit_rejected_order(
+            input_order=pInputOrder,
+            error_id=getattr(pRspInfo, "ErrorID", 0),
+            error_msg=self._to_text(getattr(pRspInfo, "ErrorMsg", "")),
+            source="OnRspOrderInsert",
+        )
+
+    def OnErrRtnOrderInsert(self, pInputOrder: Any, pRspInfo: Any) -> None:
+        """Handle asynchronous order insert reject."""
+        self._emit_rejected_order(
+            input_order=pInputOrder,
+            error_id=getattr(pRspInfo, "ErrorID", 0),
+            error_msg=self._to_text(getattr(pRspInfo, "ErrorMsg", "")),
+            source="OnErrRtnOrderInsert",
+        )
+
+    def OnRtnOrder(self, pOrder: Any) -> None:
+        """Handle order return event."""
+        order_ref = self._to_text(getattr(pOrder, "OrderRef", ""))
+        order_sys_id = self._to_text(getattr(pOrder, "OrderSysID", "")).strip()
+        front_id = int(getattr(pOrder, "FrontID", 0) or self.front_id)
+        session_id = int(getattr(pOrder, "SessionID", 0) or self.session_id)
+        payload = {
+            "client_order_id": self.order_ref_to_client_order_id.get(order_ref, ""),
+            "broker_order_id": self._make_broker_order_id(
+                front_id=front_id,
+                session_id=session_id,
+                order_ref=order_ref,
+                order_sys_id=order_sys_id,
+            ),
+            "symbol": self._to_text(getattr(pOrder, "InstrumentID", "")),
+            "status": self._map_order_status(getattr(pOrder, "OrderStatus", "")),
+            "filled_quantity": float(getattr(pOrder, "VolumeTraded", 0.0) or 0.0),
+            "avg_fill_price": float(getattr(pOrder, "LimitPrice", 0.0) or 0.0),
+            "reject_reason": self._to_text(getattr(pOrder, "StatusMsg", "")),
+            "timestamp_ns": time.time_ns(),
+            "order_ref": order_ref,
+        }
+        if self.order_callback is not None:
+            self.order_callback(payload)
+
+    def OnRtnTrade(self, pTrade: Any) -> None:
+        """Handle trade return event."""
+        order_ref = self._to_text(getattr(pTrade, "OrderRef", ""))
+        order_sys_id = self._to_text(getattr(pTrade, "OrderSysID", "")).strip()
+        front_id = int(getattr(pTrade, "FrontID", 0) or self.front_id)
+        session_id = int(getattr(pTrade, "SessionID", 0) or self.session_id)
+        payload = {
+            "trade_id": self._to_text(getattr(pTrade, "TradeID", "")),
+            "broker_order_id": self._make_broker_order_id(
+                front_id=front_id,
+                session_id=session_id,
+                order_ref=order_ref,
+                order_sys_id=order_sys_id,
+            ),
+            "client_order_id": self.order_ref_to_client_order_id.get(order_ref, ""),
+            "symbol": self._to_text(getattr(pTrade, "InstrumentID", "")),
+            "side": self._map_direction(getattr(pTrade, "Direction", "")),
+            "quantity": float(getattr(pTrade, "Volume", 0.0) or 0.0),
+            "price": float(getattr(pTrade, "Price", 0.0) or 0.0),
+            "timestamp_ns": time.time_ns(),
+            "order_ref": order_ref,
+        }
+        if self.trade_callback is not None:
+            self.trade_callback(payload)
+
+    def _emit_rejected_order(
+        self,
+        *,
+        input_order: Any,
+        error_id: Any,
+        error_msg: str,
+        source: str,
+    ) -> None:
+        order_ref = self._to_text(getattr(input_order, "OrderRef", ""))
+        broker_order_id = self._make_broker_order_id(
+            front_id=self.front_id,
+            session_id=self.session_id,
+            order_ref=order_ref,
+            order_sys_id="",
+        )
+        payload = {
+            "client_order_id": self.order_ref_to_client_order_id.get(order_ref, ""),
+            "broker_order_id": broker_order_id,
+            "symbol": self._to_text(getattr(input_order, "InstrumentID", "")),
+            "status": "rejected",
+            "filled_quantity": 0.0,
+            "avg_fill_price": float(getattr(input_order, "LimitPrice", 0.0) or 0.0),
+            "reject_reason": error_msg,
+            "timestamp_ns": time.time_ns(),
+            "order_ref": order_ref,
+            "error_code": str(error_id),
+        }
+        if self.order_callback is not None:
+            self.order_callback(payload)
+        if self.error_callback is not None:
+            self.error_callback(
+                {
+                    "event_type": "order_reject",
+                    "source": source,
+                    "broker_order_id": broker_order_id,
+                    "client_order_id": payload["client_order_id"],
+                    "symbol": payload["symbol"],
+                    "error_code": str(error_id),
+                    "error_message": error_msg,
+                    "timestamp_ns": payload["timestamp_ns"],
+                    "order_ref": order_ref,
+                }
+            )
+
+    def _make_broker_order_id(
+        self,
+        *,
+        front_id: int,
+        session_id: int,
+        order_ref: str,
+        order_sys_id: str,
+    ) -> str:
+        base = f"ctp-{front_id}-{session_id}-{order_ref}"
+        if order_sys_id:
+            return f"{base}-{order_sys_id}"
+        return base
+
+    def _parse_broker_order_id(self, broker_order_id: str) -> dict[str, Any]:
+        text = str(broker_order_id).strip()
+        parts = text.split("-")
+        if len(parts) < 4 or parts[0] != "ctp":
+            return {}
+        return {
+            "front_id": int(parts[1]) if parts[1].isdigit() else self.front_id,
+            "session_id": int(parts[2]) if parts[2].isdigit() else self.session_id,
+            "order_ref": parts[3],
+            "order_sys_id": "-".join(parts[4:]) if len(parts) > 4 else "",
+        }
+
+    def _map_order_status(self, raw_status: Any) -> str:
+        key = self._to_text(raw_status)
+        status_map = {
+            "0": "filled",
+            "1": "partially_filled",
+            "2": "partially_filled",
+            "3": "submitted",
+            "4": "submitted",
+            "5": "cancelled",
+            "a": "submitted",
+            "b": "submitted",
+            "c": "submitted",
+        }
+        if key in status_map:
+            return status_map[key]
+        return key.lower() if key else "submitted"
+
+    def _map_direction(self, raw_direction: Any) -> str:
+        key = self._to_text(raw_direction)
+        if key in {"0", "buy", "b"}:
+            return "Buy"
+        if key in {"1", "sell", "s"}:
+            return "Sell"
+        return str(raw_direction)
+
+    def _to_text(self, value: Any) -> str:
+        if isinstance(value, bytes):
+            try:
+                return value.decode("gbk", errors="ignore").strip()
+            except Exception:
+                return value.decode("utf-8", errors="ignore").strip()
+        return str(value).strip()
 
 
 class CTPMarketGateway(mdapi.CThostFtdcMdSpi):  # type: ignore

--- a/python/akquant/gateway/factory.py
+++ b/python/akquant/gateway/factory.py
@@ -50,6 +50,9 @@ def create_gateway_bundle(
                 password=kwargs.get("password", ""),
                 auth_code=kwargs.get("auth_code", "0000000000000000"),
                 app_id=kwargs.get("app_id", "simnow_client_test"),
+                execution_semantics_mode=kwargs.get(
+                    "execution_semantics_mode", "strict"
+                ),
             )
         return GatewayBundle(
             market_gateway=market_gateway,

--- a/python/akquant/gateway/mapper.py
+++ b/python/akquant/gateway/mapper.py
@@ -91,6 +91,21 @@ DEFAULT_STATUS_MAP = {
     "cancelled": UnifiedOrderStatus.CANCELLED,
     "canceled": UnifiedOrderStatus.CANCELLED,
     "rejected": UnifiedOrderStatus.REJECTED,
+    "alltraded": UnifiedOrderStatus.FILLED,
+    "parttradedqueueing": UnifiedOrderStatus.PARTIALLY_FILLED,
+    "parttradednotqueueing": UnifiedOrderStatus.PARTIALLY_FILLED,
+    "notradequeueing": UnifiedOrderStatus.SUBMITTED,
+    "notradenotqueueing": UnifiedOrderStatus.SUBMITTED,
+    "unknown": UnifiedOrderStatus.SUBMITTED,
+    "0": UnifiedOrderStatus.FILLED,
+    "1": UnifiedOrderStatus.PARTIALLY_FILLED,
+    "2": UnifiedOrderStatus.PARTIALLY_FILLED,
+    "3": UnifiedOrderStatus.SUBMITTED,
+    "4": UnifiedOrderStatus.SUBMITTED,
+    "5": UnifiedOrderStatus.CANCELLED,
+    "a": UnifiedOrderStatus.SUBMITTED,
+    "b": UnifiedOrderStatus.SUBMITTED,
+    "c": UnifiedOrderStatus.SUBMITTED,
 }
 
 

--- a/tests/test_gateway_ctp_adapter.py
+++ b/tests/test_gateway_ctp_adapter.py
@@ -1,9 +1,33 @@
+from typing import Any, cast
+
 from akquant.gateway.ctp_adapter import CTPTraderAdapter
 from akquant.gateway.mapper import create_default_mapper
-from akquant.gateway.models import UnifiedOrderRequest
+from akquant.gateway.models import UnifiedOrderRequest, UnifiedOrderStatus
 
 
-def _build_adapter(connected: bool = True) -> CTPTraderAdapter:
+def _build_adapter(
+    connected: bool = True, execution_semantics_mode: str = "strict"
+) -> CTPTraderAdapter:
+    class Gateway:
+        def __init__(self, connected_flag: bool) -> None:
+            self.connected = connected_flag
+            self.login_status = connected_flag
+            self.ready_to_trade = connected_flag
+
+        def can_trade(self) -> bool:
+            return self.connected and self.login_status and self.ready_to_trade
+
+        def insert_order(self, **kwargs: object) -> dict[str, object]:
+            client_order_id = str(kwargs.get("client_order_id", ""))
+            return {
+                "broker_order_id": f"ctp-1-2-{client_order_id}",
+                "order_ref": f"ref-{client_order_id}",
+                "timestamp_ns": 1,
+            }
+
+        def cancel_order(self, broker_order_id: str) -> None:
+            _ = broker_order_id
+
     adapter = CTPTraderAdapter.__new__(CTPTraderAdapter)
     adapter.mapper = create_default_mapper()
     adapter.order_callback = None
@@ -13,13 +37,16 @@ def _build_adapter(connected: bool = True) -> CTPTraderAdapter:
     adapter.trades = []
     adapter.client_to_broker_order_ids = {}
     adapter.broker_to_client_order_ids = {}
+    adapter.order_ref_to_client_order_ids = {}
+    adapter.pending_reject_reasons = {}
+    adapter.execution_semantics_mode = execution_semantics_mode
     adapter._order_seq = 0
-    adapter.gateway = type("Gateway", (), {"connected": connected})()
+    adapter.gateway = cast(Any, Gateway(connected))
     return adapter
 
 
 def test_ctp_adapter_place_and_cancel_order() -> None:
-    """Place and cancel order should emit callbacks and update state."""
+    """Cancel request should rely on native order callback to reach terminal state."""
     adapter = _build_adapter(connected=True)
     order_ids: list[str] = []
     report_ids: list[str] = []
@@ -37,8 +64,17 @@ def test_ctp_adapter_place_and_cancel_order() -> None:
         )
     )
     adapter.cancel_order(broker_order_id)
+    adapter._handle_native_order_event(
+        {
+            "broker_order_id": broker_order_id,
+            "client_order_id": "c1",
+            "symbol": "au2606",
+            "status": "cancelled",
+            "timestamp_ns": 2,
+        }
+    )
 
-    assert broker_order_id.startswith("ctp-c1-")
+    assert broker_order_id.startswith("ctp-1-2-c1")
     assert order_ids[0] == broker_order_id
     assert report_ids[0] == broker_order_id
     assert report_ids[-1] == broker_order_id
@@ -95,6 +131,118 @@ def test_ctp_adapter_ingest_events_update_state() -> None:
     assert adapter.query_trades()[-1].trade_id == "t2"
 
 
+def test_ctp_adapter_native_event_flow_advances_status() -> None:
+    """Native order and trade events should update unified state."""
+    adapter = _build_adapter(connected=True)
+    adapter.order_ref_to_client_order_ids["42"] = "c42"
+
+    adapter._handle_native_order_event(
+        {
+            "order_ref": "42",
+            "broker_order_id": "ctp-1-2-42",
+            "symbol": "au2606",
+            "status": "partially_filled",
+            "filled_quantity": 1.0,
+            "avg_fill_price": 500.0,
+            "timestamp_ns": 10,
+        }
+    )
+    adapter._handle_native_trade_event(
+        {
+            "order_ref": "42",
+            "trade_id": "t42",
+            "broker_order_id": "ctp-1-2-42",
+            "symbol": "au2606",
+            "side": "Buy",
+            "quantity": 1.0,
+            "price": 500.0,
+            "timestamp_ns": 11,
+        }
+    )
+    adapter._handle_native_order_event(
+        {
+            "order_ref": "42",
+            "broker_order_id": "ctp-1-2-42",
+            "symbol": "au2606",
+            "status": "filled",
+            "filled_quantity": 1.0,
+            "avg_fill_price": 500.0,
+            "timestamp_ns": 12,
+        }
+    )
+
+    snapshot = adapter.query_order("ctp-1-2-42")
+    assert snapshot is not None
+    assert snapshot.status == UnifiedOrderStatus.FILLED
+    assert adapter.query_trades()[-1].trade_id == "t42"
+
+
+def test_ctp_adapter_native_error_maps_to_rejected() -> None:
+    """Native reject event should wait for order callback to mark rejected."""
+    adapter = _build_adapter(connected=True)
+    adapter.place_order(
+        UnifiedOrderRequest(
+            client_order_id="r1",
+            symbol="ag2606",
+            side="Buy",
+            quantity=1.0,
+        )
+    )
+    adapter._handle_native_error_event(
+        {
+            "broker_order_id": "ctp-1-2-r1",
+            "client_order_id": "r1",
+            "symbol": "ag2606",
+            "error_message": "insufficient funds",
+            "timestamp_ns": 13,
+        }
+    )
+    snapshot_before = adapter.query_order("ctp-1-2-r1")
+    assert snapshot_before is not None
+    assert snapshot_before.status == UnifiedOrderStatus.SUBMITTED
+    adapter._handle_native_order_event(
+        {
+            "broker_order_id": "ctp-1-2-r1",
+            "client_order_id": "r1",
+            "symbol": "ag2606",
+            "status": "rejected",
+            "timestamp_ns": 14,
+        }
+    )
+
+    snapshot = adapter.query_order("ctp-1-2-r1")
+    assert snapshot is not None
+    assert snapshot.status == UnifiedOrderStatus.REJECTED
+    assert snapshot.reject_reason == "insufficient funds"
+
+
+def test_ctp_adapter_compatible_mode_rejects_on_error_event() -> None:
+    """Compatible mode should immediately mark rejected on native error event."""
+    adapter = _build_adapter(connected=True, execution_semantics_mode="compatible")
+    adapter.place_order(
+        UnifiedOrderRequest(
+            client_order_id="r2",
+            symbol="ag2606",
+            side="Buy",
+            quantity=1.0,
+        )
+    )
+    adapter._handle_native_error_event(
+        {
+            "broker_order_id": "ctp-1-2-r2",
+            "client_order_id": "r2",
+            "symbol": "ag2606",
+            "error_message": "risk blocked",
+            "timestamp_ns": 15,
+        }
+    )
+
+    snapshot = adapter.query_order("ctp-1-2-r2")
+    assert snapshot is not None
+    assert snapshot.status == UnifiedOrderStatus.REJECTED
+    assert snapshot.reject_reason == "risk blocked"
+
+
 def test_ctp_adapter_place_order_requires_connection() -> None:
     """Placing order without connection should fail fast."""
     adapter = _build_adapter(connected=False)
@@ -128,6 +276,15 @@ def test_ctp_adapter_sync_open_orders_excludes_terminal_orders() -> None:
     assert any(order.broker_order_id == broker_order_id for order in open_orders)
 
     adapter.cancel_order(broker_order_id)
+    adapter._handle_native_order_event(
+        {
+            "broker_order_id": broker_order_id,
+            "client_order_id": "c4",
+            "symbol": "ag2606",
+            "status": "cancelled",
+            "timestamp_ns": 3,
+        }
+    )
     open_orders_after_cancel = adapter.sync_open_orders()
     assert all(
         order.broker_order_id != broker_order_id for order in open_orders_after_cancel


### PR DESCRIPTION
- 在 CTP 交易适配器中新增 `execution_semantics_mode` 参数，支持 `strict`（默认）和 `compatible` 两种模式
- 严格模式下，订单的终态（如 Cancelled/Rejected/Filled）仅由柜台订单回报（OnRtnOrder）确认，错误回报会缓存拒单原因并在后续订单回报中补齐
- 兼容模式允许在部分错误/撤单路径下立即本地推进终态，以保持旧有行为
- 更新 CTP 原生网关以支持订单插入、撤单请求，并正确映射订单状态和方向
- 更新所有相关中英文文档，说明执行语义的差异和使用方法
- 更新测试以覆盖新的严格语义和兼容模式行为
- 将项目版本从 0.1.81 提升至 0.1.82