### PR TITLE
fix(backtest): 修正每日定时器在日期对齐时忽略时区的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.82"
+version = "0.1.83"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.82"
+version = "0.1.83"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.82"
+version = "0.1.83"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -79,6 +79,15 @@ _RESERVED_FILL_PRICE_BASIS: set[str] = {"mid_quote", "vwap_window", "twap_window
 _SUPPORTED_FILL_TEMPORAL: set[str] = {"same_cycle", "next_event"}
 
 
+def _index_to_local_trading_days(
+    index: pd.DatetimeIndex, timezone: str
+) -> pd.DatetimeIndex:
+    local_index = index
+    if local_index.tz is None:
+        local_index = local_index.tz_localize("UTC")
+    return cast(pd.DatetimeIndex, local_index.tz_convert(timezone))
+
+
 BacktestDataInput = Union[
     pd.DataFrame, Dict[str, pd.DataFrame], List[Bar], DataFeed, DataFeedAdapter
 ]
@@ -1511,7 +1520,10 @@ def run_backtest(
         day_bounds: Dict[str, Tuple[int, int]] = {}
         for df in data_map_for_indicators.values():
             if not df.empty and isinstance(df.index, pd.DatetimeIndex):
-                normalized_index = cast(pd.DatetimeIndex, df.index.normalize())
+                local_index = _index_to_local_trading_days(
+                    cast(pd.DatetimeIndex, df.index), timezone
+                )
+                normalized_index = cast(pd.DatetimeIndex, local_index.normalize())
                 dates = normalized_index.unique()
                 all_dates.update(dates)
                 for raw_day_ts in dates:
@@ -3146,9 +3158,12 @@ def run_warm_start(
         day_bounds: Dict[str, Tuple[int, int]] = {}
         for df in data_map_for_indicators.values():
             if not df.empty and isinstance(df.index, pd.DatetimeIndex):
-                dates = df.index.normalize().unique()
+                local_index = _index_to_local_trading_days(
+                    cast(pd.DatetimeIndex, df.index), timezone_name
+                )
+                dates = local_index.normalize().unique()
                 all_dates.update(dates)
-                grouped = df.groupby(df.index.normalize())
+                grouped = df.groupby(local_index.normalize())
                 for day_ts, day_df in grouped:
                     day_key = pd.Timestamp(day_ts).date().isoformat()
                     start_ns = int(day_df.index.min().value)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -231,6 +231,37 @@ class MixedBarTimerCaptureStrategy(akquant.Strategy):
         self.trade_prices.append(float(trade.price))
 
 
+class DailyTimerBuyStrategy(akquant.Strategy):
+    """Submit one order from daily timer for trading-day alignment checks."""
+
+    def __init__(self, symbol: str) -> None:
+        """Initialize symbol and one-shot state."""
+        super().__init__()
+        self.symbol_ref = symbol
+        self.submitted = False
+        self.exited = False
+
+    def on_start(self) -> None:
+        """Register a daily timer at session close."""
+        self.add_daily_timer("15:00:00", "daily_buy")
+
+    def on_bar(self, bar: akquant.Bar) -> None:
+        """Close the position on the first bar after timer entry."""
+        if self.exited or not self.submitted:
+            return
+        if self.position.size <= 0:
+            return
+        self.sell(symbol=bar.symbol, quantity=1)
+        self.exited = True
+
+    def on_timer(self, payload: str) -> None:
+        """Submit one buy on the first matching daily timer."""
+        if payload != "daily_buy" or self.submitted:
+            return
+        self.buy(symbol=self.symbol_ref, quantity=1)
+        self.submitted = True
+
+
 def _ns(dt: datetime) -> int:
     """
     Convert a datetime to nanoseconds since epoch.
@@ -353,6 +384,56 @@ def test_current_close_timer_order_should_fill_at_timer_timestamp() -> None:
     assert strategy.trade_timestamp is not None
     assert strategy.trade_timestamp == strategy.timer_timestamp
     assert strategy.trade_price == pytest.approx(10.0)
+
+
+def test_daily_timer_trading_day_alignment_uses_local_calendar_day() -> None:
+    """Daily timer should align with local trading days for date-only input."""
+    symbol = "DAILY_TIMER_ALIGN"
+    data = pd.DataFrame(
+        {
+            "open": [10.0, 11.0],
+            "high": [10.0, 11.0],
+            "low": [10.0, 11.0],
+            "close": [10.0, 11.0],
+            "volume": [1000.0, 1000.0],
+            "symbol": [symbol, symbol],
+        },
+        index=pd.to_datetime(["2025-01-24", "2025-01-27"]),
+    )
+    strategy = DailyTimerBuyStrategy(symbol=symbol)
+
+    result = akquant.run_backtest(
+        data=data,
+        strategy=strategy,
+        symbol=symbol,
+        execution_mode="current_close",
+        timer_execution_policy="same_cycle",
+        t_plus_one=True,
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    executions_df = result.executions_df
+    assert not executions_df.empty
+
+    first_trade_time = pd.Timestamp(executions_df.iloc[0]["timestamp"]).tz_convert(
+        "Asia/Shanghai"
+    )
+    assert first_trade_time == pd.Timestamp("2025-01-24 15:00:00", tz="Asia/Shanghai")
+    assert first_trade_time.weekday() < 5
+
+    trades_df = result.trades_df
+    assert not trades_df.empty
+    first_entry_time = pd.Timestamp(trades_df.iloc[0]["entry_time"]).tz_convert(
+        "Asia/Shanghai"
+    )
+    assert first_entry_time == pd.Timestamp("2025-01-24 15:00:00", tz="Asia/Shanghai")
+    assert first_entry_time.weekday() < 5
 
 
 def test_current_close_timer_order_next_event_policy_fills_on_next_bar() -> None:


### PR DESCRIPTION
确保每日定时器正确使用本地交易日的日历对齐，而非UTC日期。引入辅助函数将数据索引转换为本地时区，并更新回测引擎中交易日边界计算和预热启动逻辑，以正确处理仅包含日期的数据输入。添加测试验证定时器在本地交易日触发。