### PR TITLE
fix(回测): 确保已终态拒单的on_reject回调在回测中被触发

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.84"
+version = "0.1.85"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.84"
+version = "0.1.85"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -49,6 +49,7 @@
 说明：
 
 * `on_reject` 对同一订单 id 只触发一次。
+* 回测中已终态拒单会通过上下文快照 `recent_rejected_orders` 在下一次事件分发时补发，避免因清理活跃订单导致漏触发。
 * `before_trading` 在本地交易日首次进入 Normal 会话时触发一次。
 * `on_daily_rebalance` 与 `before_trading` 同一阶段触发，每个交易日最多触发一次。
 * `after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `after_trading`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.84"
+version = "0.1.85"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_order_events.py
+++ b/python/akquant/strategy_order_events.py
@@ -26,6 +26,14 @@ def check_order_events(strategy: Any) -> None:
                 _emit_order_callback(strategy, order)
                 del strategy._known_orders[oid]
 
+    if hasattr(strategy.ctx, "recent_rejected_orders"):
+        for order in strategy.ctx.recent_rejected_orders:
+            oid = getattr(order, "id", "")
+            if not oid:
+                continue
+            strategy._known_orders[oid] = order
+            _emit_order_callback(strategy, order)
+
     current_active_ids: set[str] = set()
     if hasattr(strategy.ctx, "active_orders"):
         for order in strategy.ctx.active_orders:

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,7 @@ pub struct ContextInit {
     pub active_orders: Arc<Vec<Order>>,
     pub closed_trades: Arc<Vec<ClosedTrade>>,
     pub recent_trades: Vec<Trade>,
+    pub recent_rejected_orders: Vec<Order>,
     pub history_buffer: Option<Arc<RwLock<HistoryBuffer>>>,
     pub event_tx: Option<Sender<Event>>,
     pub risk_config: RiskConfig,
@@ -57,6 +58,7 @@ pub struct ContextUpdate {
     pub active_orders: Arc<Vec<Order>>,
     pub closed_trades: Arc<Vec<ClosedTrade>>,
     pub recent_trades: Vec<Trade>,
+    pub recent_rejected_orders: Vec<Order>,
 }
 
 impl StrategyContext {
@@ -88,6 +90,7 @@ impl StrategyContext {
         }
 
         self.recent_trades = update.recent_trades;
+        self.recent_rejected_orders = update.recent_rejected_orders;
 
         // Reset accumulators
         self.orders.clear();
@@ -144,6 +147,9 @@ pub struct StrategyContext {
     // Recent trades generated in the last step
     #[pyo3(get)]
     pub recent_trades: Vec<Trade>,
+    // Recent rejected orders generated in the last step
+    #[pyo3(get)]
+    pub recent_rejected_orders: Vec<Order>,
     // History Buffer (Shared with Engine)
     pub history_buffer: Option<Arc<RwLock<HistoryBuffer>>>,
     // Event Channel (Optional, for async order submission)
@@ -172,6 +178,7 @@ impl StrategyContext {
             current_time: init.current_time,
             closed_trades: init.closed_trades,
             recent_trades: init.recent_trades,
+            recent_rejected_orders: init.recent_rejected_orders,
             history_buffer: init.history_buffer,
             event_tx: init.event_tx,
             risk_config: init.risk_config,
@@ -233,6 +240,7 @@ impl StrategyContext {
             current_time: current_time.unwrap_or(0),
             closed_trades: Arc::new(closed_trades.unwrap_or_default()),
             recent_trades: recent_trades.unwrap_or_default(),
+            recent_rejected_orders: Vec::new(),
             history_buffer: None,
             event_tx: None,
             risk_config: risk_config.unwrap_or_default(),

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -534,6 +534,7 @@ impl Engine {
         slot_index: usize,
         active_orders: Arc<Vec<Order>>,
         step_trades: Vec<Trade>,
+        step_rejected_orders: Vec<Order>,
     ) -> PyResult<Py<StrategyContext>> {
         self.ensure_strategy_context_capacity();
         if let Some(existing_ctx) = self
@@ -554,6 +555,7 @@ impl Engine {
                         active_orders,
                         closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
                         recent_trades: step_trades,
+                        recent_rejected_orders: step_rejected_orders,
                     });
                 }
                 Ok::<_, PyErr>(py_ctx)
@@ -564,7 +566,8 @@ impl Engine {
             .strategy_slots
             .get(slot_index)
             .map(|slot| slot.strategy_id.clone());
-        let ctx = self.create_context(active_orders, step_trades, strategy_id);
+        let ctx =
+            self.create_context(active_orders, step_trades, step_rejected_orders, strategy_id);
         let (py_ctx, persistent_ref) = Python::attach(|py| {
             let py_ctx = Py::new(py, ctx).unwrap();
             Ok::<_, PyErr>((py_ctx.clone_ref(py), py_ctx.clone_ref(py)))
@@ -836,6 +839,7 @@ impl Engine {
         &self,
         active_orders: Arc<Vec<Order>>,
         step_trades: Vec<Trade>,
+        step_rejected_orders: Vec<Order>,
         strategy_id: Option<String>,
     ) -> StrategyContext {
         // Create a temporary context for the strategy to use
@@ -848,6 +852,7 @@ impl Engine {
             active_orders,
             closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
             recent_trades: step_trades,
+            recent_rejected_orders: step_rejected_orders,
             history_buffer: Some(self.history_buffer.clone()),
             event_tx: Some(self.event_manager.sender()),
             risk_config: self.risk_manager.config.clone(),
@@ -888,13 +893,19 @@ impl Engine {
         slot_index: usize,
         active_orders: Arc<Vec<Order>>,
         step_trades: Vec<Trade>,
+        step_rejected_orders: Vec<Order>,
     ) -> PyResult<(Vec<Order>, Vec<Timer>, Vec<String>)> {
         self.active_strategy_slot = slot_index;
         match event {
             Event::Bar(b) => {
                 self.last_prices.insert(b.symbol.clone(), b.close);
                 let py_ctx =
-                    self.get_or_create_strategy_context(slot_index, active_orders, step_trades)?;
+                    self.get_or_create_strategy_context(
+                        slot_index,
+                        active_orders,
+                        step_trades,
+                        step_rejected_orders,
+                    )?;
 
                 let args = Python::attach(|py| {
                     let bar = b.clone();
@@ -925,7 +936,12 @@ impl Engine {
             Event::Tick(t) => {
                 self.last_prices.insert(t.symbol.clone(), t.price);
                 let py_ctx =
-                    self.get_or_create_strategy_context(slot_index, active_orders, step_trades)?;
+                    self.get_or_create_strategy_context(
+                        slot_index,
+                        active_orders,
+                        step_trades,
+                        step_rejected_orders,
+                    )?;
 
                 let args = Python::attach(|py| {
                     let tick = t.clone();
@@ -954,7 +970,12 @@ impl Engine {
             }
             Event::Timer(timer) => {
                 let py_ctx =
-                    self.get_or_create_strategy_context(slot_index, active_orders, step_trades)?;
+                    self.get_or_create_strategy_context(
+                        slot_index,
+                        active_orders,
+                        step_trades,
+                        step_rejected_orders,
+                    )?;
 
                 let args = Python::attach(|py| {
                     let payload = timer.payload.as_str();

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -25,6 +25,9 @@ pub struct OrderManager {
     pub trades: Vec<Trade>,
     /// 当前步生成的成交 (用于通知策略)
     pub current_step_trades: Vec<Trade>,
+    /// 当前步收到的拒单回报 (用于通知策略 on_reject)
+    #[serde(default)]
+    pub current_step_rejected_orders: Vec<Order>,
     /// 交易追踪器 (用于计算 PnL 和统计)
     pub trade_tracker: TradeTracker,
     /// OCO 订单组映射: group_id -> {order_id}
@@ -54,6 +57,7 @@ impl OrderManager {
             active_orders: Vec::new(),
             trades: Vec::new(),
             current_step_trades: Vec::new(),
+            current_step_rejected_orders: Vec::new(),
             trade_tracker: TradeTracker::new(),
             oco_groups: HashMap::new(),
             oco_order_to_group: HashMap::new(),

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -145,6 +145,13 @@ impl Processor for ChannelProcessor {
                             .into_iter()
                             .find(|o| o.id == report_order_id);
                         if let Some(order_snapshot) = updated_order {
+                            if order_snapshot.status == OrderStatus::Rejected {
+                                engine
+                                    .state
+                                    .order_manager
+                                    .current_step_rejected_orders
+                                    .push(order_snapshot.clone());
+                            }
                             let mut order_payload = HashMap::new();
                             order_payload.insert("order_id", order_snapshot.id.clone());
                             order_payload.insert("status", format!("{:?}", order_snapshot.status));
@@ -580,6 +587,11 @@ impl Processor for StrategyProcessor {
             let slot_count = engine.strategy_slots.len();
             let active_orders = Arc::new(engine.state.order_manager.active_orders.clone());
             let step_trades = engine.state.order_manager.current_step_trades.clone();
+            let step_rejected_orders = engine
+                .state
+                .order_manager
+                .current_step_rejected_orders
+                .clone();
 
             for slot_index in 0..slot_count {
                 let slot_strategy = engine
@@ -596,6 +608,7 @@ impl Processor for StrategyProcessor {
                             slot_index,
                             active_orders.clone(),
                             step_trades.clone(),
+                            step_rejected_orders.clone(),
                         )?;
                         flush_pending_engine_oco_groups(engine, slot_bound)?;
                         flush_pending_engine_bracket_plans(engine, slot_bound)?;
@@ -607,6 +620,7 @@ impl Processor for StrategyProcessor {
                             slot_index,
                             active_orders.clone(),
                             step_trades.clone(),
+                            step_rejected_orders.clone(),
                         )?;
                         flush_pending_engine_oco_groups(engine, strategy)?;
                         flush_pending_engine_bracket_plans(engine, strategy)?;
@@ -624,6 +638,11 @@ impl Processor for StrategyProcessor {
                 }
             }
             engine.state.order_manager.current_step_trades.clear();
+            engine
+                .state
+                .order_manager
+                .current_step_rejected_orders
+                .clear();
         }
         Ok(ProcessorResult::Next)
     }

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -17,6 +17,7 @@ from akquant import (
 )
 from akquant.akquant import Bar, OrderStatus, StrategyContext, Tick, TimeInForce
 from akquant.backtest import FunctionalStrategy
+from akquant.config import RiskConfig
 from akquant.strategy import Strategy, StrategyRuntimeConfig
 
 
@@ -470,6 +471,120 @@ def test_get_trades_refreshes_during_backtest() -> None:
     assert strategy is not None
     assert len(result.trades) >= 1
     assert len(strategy.get_trades()) >= 1
+
+
+class RejectEventBacktestStrategy(Strategy):
+    """Strategy used to validate on_reject callback in run_backtest."""
+
+    def __init__(self) -> None:
+        """Initialize reject capture state."""
+        self.reject_events: list[tuple[str, str]] = []
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit oversized orders on first two bars to trigger risk rejects."""
+        if self._bar_count == 1:
+            self.sell(symbol=bar.symbol, quantity=100)
+        elif self._bar_count == 2:
+            self.buy(symbol=bar.symbol, quantity=10000)
+        elif self._bar_count == 3:
+            self.buy(symbol=bar.symbol, quantity=10)
+
+    def on_reject(self, order: Any) -> None:
+        """Capture rejected order id and reason."""
+        self.reject_events.append((str(order.id), str(order.reject_reason)))
+
+
+def test_run_backtest_emits_on_reject_for_risk_rejected_orders() -> None:
+    """run_backtest should trigger on_reject for risk rejected orders."""
+    bars = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-01-01", periods=5, freq="D"),
+            "open": [100.0, 101.0, 102.0, 103.0, 104.0],
+            "high": [100.5, 101.5, 102.5, 103.5, 104.5],
+            "low": [99.5, 100.5, 101.5, 102.5, 103.5],
+            "close": [100.0, 100.2, 100.3, 100.4, 100.5],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 1000.0],
+            "symbol": ["STOCK", "STOCK", "STOCK", "STOCK", "STOCK"],
+        }
+    )
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(
+            risk=RiskConfig(safety_margin=0.0001, max_order_value=5000.0)
+        )
+    )
+
+    result = run_backtest(
+        data=bars,
+        strategy=RejectEventBacktestStrategy,
+        symbols=["STOCK"],
+        initial_cash=10000.0,
+        config=config,
+        show_progress=False,
+    )
+    strategy = cast(RejectEventBacktestStrategy, result.strategy)
+    assert strategy is not None
+    assert len(strategy.reject_events) == 2
+    assert all("Risk:" in reason for _, reason in strategy.reject_events)
+
+    rejected_df = result.orders_df[
+        result.orders_df["status"].astype(str).str.lower() == "rejected"
+    ]
+    assert len(rejected_df) == 2
+
+
+class RejectOnceBacktestStrategy(Strategy):
+    """Strategy used to validate single-fire semantics of on_reject."""
+
+    def __init__(self) -> None:
+        """Initialize captured callbacks."""
+        self.reject_order_ids: list[str] = []
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit only one oversized order so one order id is rejected."""
+        if self._bar_count == 1:
+            self.buy(symbol=bar.symbol, quantity=10000)
+
+    def on_reject(self, order: Any) -> None:
+        """Capture rejected order id."""
+        self.reject_order_ids.append(str(order.id))
+
+
+def test_run_backtest_on_reject_fires_once_per_order_id() -> None:
+    """on_reject should fire once for the same rejected order id."""
+    bars = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-02-01", periods=6, freq="D"),
+            "open": [100.0, 100.2, 100.3, 100.4, 100.5, 100.6],
+            "high": [100.5, 100.7, 100.8, 100.9, 101.0, 101.1],
+            "low": [99.5, 99.7, 99.8, 99.9, 100.0, 100.1],
+            "close": [100.0, 100.1, 100.2, 100.3, 100.4, 100.5],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0],
+            "symbol": ["STOCK", "STOCK", "STOCK", "STOCK", "STOCK", "STOCK"],
+        }
+    )
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(
+            risk=RiskConfig(safety_margin=0.0001, max_order_value=5000.0)
+        )
+    )
+
+    result = run_backtest(
+        data=bars,
+        strategy=RejectOnceBacktestStrategy,
+        symbols=["STOCK"],
+        initial_cash=10000.0,
+        config=config,
+        show_progress=False,
+    )
+    strategy = cast(RejectOnceBacktestStrategy, result.strategy)
+    assert strategy is not None
+    assert len(strategy.reject_order_ids) == 1
+    assert len(set(strategy.reject_order_ids)) == 1
+
+    rejected_df = result.orders_df[
+        result.orders_df["status"].astype(str).str.lower() == "rejected"
+    ]
+    assert len(rejected_df) == 1
 
 
 class SequenceStrategy(Strategy):
@@ -2215,6 +2330,41 @@ def test_framework_hooks_session_day_reject_and_portfolio() -> None:
     )
     assert after_count == before_count + 1
     assert rebalance_after_count == rebalance_count + 1
+
+
+def test_framework_hooks_emits_reject_from_recent_rejected_orders() -> None:
+    """Reject callback should be emitted from recent_rejected_orders snapshots."""
+    strategy = FrameworkHooksStrategy()
+    ctx = MagicMock(spec=StrategyContext)
+    ctx.get_position.return_value = 0.0
+    ctx.canceled_order_ids = []
+    ctx.active_orders = []
+    ctx.recent_trades = []
+    ctx.positions = {}
+    ctx.available_positions = {}
+    ctx.cash = 1000.0
+    ctx.session = "normal"
+    ctx.current_time = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    ctx.recent_rejected_orders = [
+        SimpleNamespace(
+            id="rej_from_snapshot",
+            status=OrderStatus.Rejected,
+            filled_quantity=0.0,
+            average_filled_price=None,
+        )
+    ]
+
+    tick = Tick(timestamp=ctx.current_time, price=100.0, volume=1.0, symbol="AAPL")
+    strategy._on_tick_event(tick, ctx)
+
+    assert "order:rej_from_snapshot" in strategy.events
+    assert "reject:rej_from_snapshot" in strategy.events
+    assert strategy.events.index("order:rej_from_snapshot") < strategy.events.index(
+        "reject:rej_from_snapshot"
+    )
+    assert strategy.events.index("reject:rej_from_snapshot") < strategy.events.index(
+        "tick"
+    )
 
 
 def test_daily_rebalance_fallback_when_session_missing() -> None:


### PR DESCRIPTION
在回测中，当订单因风控等原因被立即拒绝时，由于订单状态直接变为终态（Rejected）且不进入活跃订单列表，导致策略的on_reject回调可能被遗漏。
- 在OrderManager中新增current_step_rejected_orders字段，收集当前步产生的拒单
- 在StrategyContext中新增recent_rejected_orders字段，通过上下文快照传递给策略
- 在策略事件分发前，检查recent_rejected_orders并补发on_reject回调
- 更新文档说明回测中拒单触发的机制
- 添加测试验证拒单回调的正确触发和单次触发语义