### PR TITLE
fix(进度条): 修正多标的回测进度条总步数计算

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.85"
+version = "0.1.86"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.85"
+version = "0.1.86"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.85"
+version = "0.1.86"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -4,7 +4,7 @@ use crate::model::Bar;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rust_decimal::prelude::*;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::fs::File;
 use std::sync::mpsc;
 use std::time::Duration;
@@ -34,6 +34,9 @@ pub trait DataClient: Send {
     fn add(&mut self, event: Event) -> Result<(), AkQuantError>;
     fn sort(&mut self);
     fn len_hint(&self) -> Option<usize>;
+    fn progress_len_hint(&self) -> Option<usize> {
+        self.len_hint()
+    }
 
     /// 是否为实时数据源
     fn is_live(&self) -> bool {
@@ -89,6 +92,22 @@ impl DataClient for SimulatedDataClient {
 
     fn len_hint(&self) -> Option<usize> {
         Some(self.events.len())
+    }
+
+    fn progress_len_hint(&self) -> Option<usize> {
+        let mut timestamps = HashSet::new();
+        for event in &self.events {
+            let ts = match event {
+                Event::Bar(bar) => bar.timestamp,
+                Event::Tick(tick) => tick.timestamp,
+                Event::ExecutionReport(_, Some(trade)) => trade.timestamp,
+                _ => 0,
+            };
+            if ts > 0 {
+                timestamps.insert(ts);
+            }
+        }
+        Some(timestamps.len())
     }
 }
 

--- a/src/data/feed.rs
+++ b/src/data/feed.rs
@@ -173,6 +173,11 @@ impl DataFeed {
         provider.len_hint()
     }
 
+    pub fn progress_len_hint(&self) -> Option<usize> {
+        let provider = self.provider.lock().unwrap();
+        provider.progress_len_hint()
+    }
+
     pub fn wait_peek(&self, timeout: Duration) -> Option<i64> {
         let mut provider = self.provider.lock().unwrap();
         provider.wait_peek(timeout)

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -69,6 +69,7 @@ pub struct Engine {
     // Pipeline state
     pub(crate) current_event: Option<Event>,
     pub(crate) bar_count: usize,
+    pub(crate) progress_total_steps: usize,
     pub(crate) progress_bar: Option<ProgressBar>,
     pub(crate) strategy_contexts: Vec<Option<Py<StrategyContext>>>,
     pub(crate) strategy_slot_strategies: Vec<Option<Py<PyAny>>>,

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -490,6 +490,7 @@ impl Engine {
             settlement_manager: SettlementManager::new(),
             current_event: None,
             bar_count: 0,
+            progress_total_steps: 0,
             progress_bar: None,
             strategy_contexts: vec![None],
             strategy_slot_strategies: vec![None],
@@ -982,10 +983,10 @@ impl Engine {
         }
 
         // Progress Bar Initialization
-        let total_events = self.state.feed.len_hint().unwrap_or(0);
+        let total_progress_steps = self.state.feed.progress_len_hint().unwrap_or(0);
         let pb = if show_progress {
-            let pb = if total_events > 0 {
-                let pb = ProgressBar::new(total_events as u64);
+            let pb = if total_progress_steps > 0 {
+                let pb = ProgressBar::new(total_progress_steps as u64);
                 pb.set_style(
                     ProgressStyle::default_bar()
                         .template(
@@ -1009,7 +1010,8 @@ impl Engine {
             None
         };
         self.progress_bar = pb;
-        self.start_stream_run(py, Some(total_events));
+        self.progress_total_steps = total_progress_steps;
+        self.start_stream_run(py, Some(total_progress_steps));
 
         // Record initial equity
         if self.state.feed.peek_timestamp().is_some() {

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -396,10 +396,10 @@ impl Processor for DataProcessor {
                     if let Some(pb) = &engine.progress_bar {
                         pb.inc(1);
                     }
-                    let total_events = engine.state.feed.len_hint().unwrap_or(0);
                     let mut progress_payload = HashMap::new();
                     progress_payload.insert("processed", engine.bar_count.to_string());
-                    progress_payload.insert("total", total_events.to_string());
+                    progress_payload
+                        .insert("total", engine.progress_total_steps.to_string());
                     engine.emit_stream_event(py, "progress", None, "info", progress_payload);
                 }
                 self.last_timestamp = timestamp;

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -340,6 +340,42 @@ def _build_benchmark_data(n: int, symbol: str) -> pd.DataFrame:
     )
 
 
+def _build_multisymbol_benchmark_data(
+    n_timestamps: int, symbols: list[str]
+) -> pd.DataFrame:
+    """
+    Build synthetic minute-level data for multiple symbols sharing timestamps.
+
+    :param n_timestamps: Number of distinct timestamps.
+    :param symbols: Symbol list.
+    :return: DataFrame sorted by timestamp then symbol.
+    """
+    rng = np.random.default_rng(17)
+    dates = pd.date_range("2020-01-01", periods=n_timestamps, freq="min", tz="UTC")
+    all_frames: list[pd.DataFrame] = []
+    for index, symbol in enumerate(symbols):
+        returns = rng.normal(0, 0.001, n_timestamps)
+        price = (100 + index) * np.exp(np.cumsum(returns))
+        all_frames.append(
+            pd.DataFrame(
+                {
+                    "timestamp": dates,
+                    "open": price,
+                    "high": price,
+                    "low": price,
+                    "close": price,
+                    "volume": np.full(n_timestamps, 1000.0),
+                    "symbol": symbol,
+                }
+            )
+        )
+    data = pd.concat(all_frames, ignore_index=True)
+    return cast(
+        pd.DataFrame,
+        data.sort_values(["timestamp", "symbol"]).reset_index(drop=True),
+    )
+
+
 def test_current_close_timer_order_should_fill_at_timer_timestamp() -> None:
     """CurrentClose should fill timer order at timer timestamp, not next bar."""
     symbol = "TIMER_BUG"
@@ -1237,6 +1273,44 @@ def test_run_backtest_on_event_emits_ordered_events() -> None:
     assert 0 < progress_count < 10
     assert 0 < equity_count < 10
     assert result.metrics.initial_market_value == pytest.approx(100000.0, rel=1e-9)
+
+
+def test_run_backtest_progress_total_uses_unique_timestamps_for_multisymbol() -> None:
+    """Progress events should report total as unique timestamps in multi-symbol runs."""
+    symbols = ["STREAM_A", "STREAM_B", "STREAM_C"]
+    data = _build_multisymbol_benchmark_data(n_timestamps=30, symbols=symbols)
+    events: list[akquant.BacktestStreamEvent] = []
+
+    _ = akquant.run_backtest(
+        data=data,
+        strategy=NoopStrategy,
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+        on_event=events.append,
+        stream_progress_interval=3,
+        stream_equity_interval=7,
+        stream_batch_size=16,
+        stream_max_buffer=128,
+    )
+
+    progress_events = [
+        event for event in events if event.get("event_type") == "progress"
+    ]
+    assert progress_events
+    expected_total = int(data["timestamp"].nunique())
+    expected_rows = int(len(data))
+    assert expected_total < expected_rows
+    totals = {
+        int(cast(dict[str, Any], event.get("payload", {})).get("total", "0"))
+        for event in progress_events
+    }
+    assert totals == {expected_total}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
进度条总步数现在基于唯一时间戳数量而非事件总数，避免多标的数据重复计数。
为模拟数据客户端实现 progress_len_hint 方法，统计事件中的唯一时间戳。
更新引擎初始化以使用新的进度长度提示，确保进度报告准确。