### PR TITLE
fix(backtest): 修复导入策略时日志处理器丢失的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.87"
+version = "0.1.88"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.87"
+version = "0.1.88"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.87"
+version = "0.1.88"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -1,5 +1,6 @@
 import datetime as dt_module
 import inspect
+import logging
 import os
 import sys
 import warnings
@@ -1080,7 +1081,10 @@ def run_backtest(
 
     # 1. 确保日志已初始化
     logger = get_logger()
-    if not logger.handlers:
+    has_effective_handler = any(
+        not isinstance(handler, logging.NullHandler) for handler in logger.handlers
+    )
+    if not has_effective_handler:
         register_logger(console=True, level="INFO")
         logger = get_logger()
     normalized_analyzers = _coerce_analyzer_plugins(analyzer_plugins)
@@ -2564,6 +2568,12 @@ def run_warm_start(
     from ..checkpoint import warm_start
 
     logger = get_logger()
+    has_effective_handler = any(
+        not isinstance(handler, logging.NullHandler) for handler in logger.handlers
+    )
+    if not has_effective_handler:
+        register_logger(console=True, level="INFO")
+        logger = get_logger()
     strategy_config = config.strategy_config if config is not None else None
     if strategy_config is not None:
         if strategy_id is None:

--- a/python/akquant/log.py
+++ b/python/akquant/log.py
@@ -42,6 +42,17 @@ class Logger:
         """
         self._logger.setLevel(level)
 
+    def _sync_handlers(self) -> None:
+        """同步内部 handler 索引，移除已脱离 logger 的引用."""
+        active_handlers = set(self._logger.handlers)
+        stale_keys = [
+            key
+            for key, handler in self._handlers.items()
+            if handler not in active_handlers
+        ]
+        for key in stale_keys:
+            del self._handlers[key]
+
     def enable_console(self, format_str: str = DEFAULT_FORMAT) -> None:
         r"""
         启用控制台日志.
@@ -49,6 +60,7 @@ class Logger:
         :param format_str: 日志格式字符串
         :type format_str: str
         """
+        self._sync_handlers()
         if "console" in self._handlers:
             return
 
@@ -59,6 +71,7 @@ class Logger:
 
     def disable_console(self) -> None:
         r"""禁用控制台日志."""
+        self._sync_handlers()
         if "console" in self._handlers:
             self._logger.removeHandler(self._handlers["console"])
             del self._handlers["console"]
@@ -76,6 +89,7 @@ class Logger:
         :param mode: 文件打开模式 ('a' 追加 或 'w' 覆写)
         :type mode: str
         """
+        self._sync_handlers()
         # Remove existing file handler if path matches (simple check)
         key = f"file_{filename}"
         if key in self._handlers:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -10,6 +10,7 @@ import pytest
 from akquant import (
     BacktestConfig,
     StrategyConfig,
+    register_logger,
     register_strategy_loader,
     run_backtest,
     run_warm_start,
@@ -918,6 +919,86 @@ def test_run_backtest_accepts_strategy_source_python_plain(tmp_path: Path) -> No
     strategy = result.strategy
     assert strategy is not None
     assert getattr(strategy, "calls", 0) == 3
+
+
+def test_run_backtest_rebuilds_console_handler_for_imported_strategy(
+    tmp_path: Path,
+) -> None:
+    """run_backtest should restore visible logger handler after NullHandler fallback."""
+    strategy_file = tmp_path / "strategy_plain_logging.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def on_bar(self, bar):",
+                "        self.log('import_loader_log_visible')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    logger = logging.getLogger("akquant")
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+    register_logger(console=True, level="INFO")
+    logger.handlers = [logging.NullHandler()]
+    try:
+        bars = _make_bars("2023-01-01", 1, symbol="PLAIN_LOG")
+        run_backtest(
+            data=bars,
+            strategy_source=str(strategy_file),
+            strategy_loader="python_plain",
+            symbol="PLAIN_LOG",
+            show_progress=False,
+        )
+        has_console = any(
+            isinstance(handler, logging.StreamHandler)
+            and not isinstance(handler, logging.NullHandler)
+            for handler in logger.handlers
+        )
+        assert has_console
+    finally:
+        logger.handlers = original_handlers
+        logger.setLevel(original_level)
+
+
+def test_run_backtest_imported_strategy_log_visible_in_stdout(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Imported strategy self.log output should be visible in captured stdout."""
+    strategy_file = tmp_path / "strategy_plain_logging_stdout.py"
+    strategy_file.write_text(
+        "\n".join(
+            [
+                "from akquant.strategy import Strategy",
+                "",
+                "class Strategy(Strategy):",
+                "    def on_bar(self, bar):",
+                "        self.log('import_loader_stdout_visible')",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    logger = logging.getLogger("akquant")
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+    register_logger(console=True, level="INFO")
+    logger.handlers = [logging.NullHandler()]
+    try:
+        bars = _make_bars("2023-01-01", 1, symbol="PLAIN_STDOUT")
+        run_backtest(
+            data=bars,
+            strategy_source=str(strategy_file),
+            strategy_loader="python_plain",
+            symbol="PLAIN_STDOUT",
+            show_progress=False,
+        )
+        captured = capsys.readouterr()
+        assert "import_loader_stdout_visible" in captured.out
+    finally:
+        logger.handlers = original_handlers
+        logger.setLevel(original_level)
 
 
 def test_run_backtest_accepts_strategy_source_encrypted_external(


### PR DESCRIPTION
修复 run_backtest 和 run_warm_start 函数中，当 logger 仅包含 NullHandler 时未正确重建控制台处理器的问题，确保导入的策略日志能正常输出。同时在 Logger 类中添加处理器同步机制，防止 handler 引用失效。