### PR TITLE
feat(risk): 实现期权保证金计算并完善资金检查

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.90"
+version = "0.1.91"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.90"
+version = "0.1.91"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.90"
+version = "0.1.91"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -405,6 +405,7 @@ class RiskConfig:
 
     **Order & Position Limits:**
     :param active: Master switch to enable/disable risk checks. Default True.
+    :param check_cash: Enable cash/margin sufficiency checks. Default True.
     :param safety_margin: Cash buffer to reserve (e.g., 0.0001 to avoid precision
                           issues).
     :param max_order_size: Max quantity per order.
@@ -424,6 +425,7 @@ class RiskConfig:
     """
 
     active: bool = True
+    check_cash: bool = True
     safety_margin: float = 0.0001
     max_order_size: Optional[float] = None
     max_order_value: Optional[float] = None

--- a/python/akquant/risk.py
+++ b/python/akquant/risk.py
@@ -40,6 +40,9 @@ def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
     if config.active is not None:
         rust_config.active = config.active
 
+    if hasattr(config, "check_cash") and config.check_cash is not None:
+        rust_config.check_cash = config.check_cash
+
     if config.safety_margin is not None:
         rust_config.safety_margin = config.safety_margin
 

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1295,8 +1295,8 @@ class Strategy:
                 - cash: 可用资金
                 - equity: 总权益 (现金 + 持仓市值)
                 - market_value: 持仓总市值 (equity - cash)
-                - frozen_cash: (预留) 冻结资金, 暂为 0.0
-                - margin: (预留) 占用保证金, 暂为 0.0
+                - frozen_cash: 当前未完成订单预占资金
+                - margin: 当前仓位占用保证金
         """
         return _get_account_impl(self)
 

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -300,6 +300,7 @@ def dispatch_portfolio_update(strategy: Any) -> None:
         return
 
     strategy._framework_last_portfolio_state = state_key
+    account_snapshot = strategy.get_account()
     snapshot: Dict[str, Any] = {
         "timestamp": current_time,
         "session": session,
@@ -308,7 +309,8 @@ def dispatch_portfolio_update(strategy: Any) -> None:
         "market_value": market_value,
         "positions": positions,
         "available_positions": available_positions,
-        "margin": 0.0,
+        "margin": float(account_snapshot.get("margin", 0.0)),
+        "frozen_cash": float(account_snapshot.get("frozen_cash", 0.0)),
     }
     call_user_callback(strategy, "on_portfolio_update", snapshot, payload=snapshot)
     strategy._framework_portfolio_dirty = False

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-from .akquant import OrderStatus, OrderType, TimeInForce
+from .akquant import OrderSide, OrderStatus, OrderType, TimeInForce
 
 
 def resolve_symbol(strategy: Any, symbol: Optional[str]) -> str:
@@ -472,20 +472,99 @@ def get_portfolio_value(strategy: Any) -> float:
     return total_value
 
 
+def _resolve_mark_price(strategy: Any, symbol: str) -> float:
+    price = float(strategy._last_prices.get(symbol, 0.0))
+    if price > 0.0:
+        return price
+    if strategy.current_bar and strategy.current_bar.symbol == symbol:
+        return float(strategy.current_bar.close)
+    if strategy.current_tick and strategy.current_tick.symbol == symbol:
+        return float(strategy.current_tick.price)
+    return 0.0
+
+
+def _calc_position_margin(strategy: Any, symbol: str, quantity: float) -> float:
+    if quantity == 0.0:
+        return 0.0
+    try:
+        inst = strategy.get_instrument(symbol)
+    except Exception:
+        price = _resolve_mark_price(strategy, symbol)
+        return abs(float(quantity) * float(price))
+
+    qty = float(quantity)
+    price = _resolve_mark_price(strategy, symbol)
+    multiplier = float(inst.multiplier)
+    margin_ratio = float(inst.margin_ratio)
+    asset_type = str(inst.asset_type).upper()
+
+    if asset_type == "OPTION":
+        if qty > 0:
+            return 0.0
+        underlying_symbol = (
+            str(inst.underlying_symbol) if inst.underlying_symbol else ""
+        )
+        underlying_price = (
+            _resolve_mark_price(strategy, underlying_symbol)
+            if underlying_symbol
+            else 0.0
+        )
+        if underlying_price > 0.0:
+            margin_per_unit = price + underlying_price * margin_ratio
+        else:
+            margin_per_unit = price * (1.0 + margin_ratio)
+        return max(margin_per_unit, 0.0) * multiplier * abs(qty)
+
+    return abs(qty * price * multiplier) * margin_ratio
+
+
+def _calc_used_margin(strategy: Any) -> float:
+    if strategy.ctx is None:
+        return 0.0
+    total = 0.0
+    for sym, qty in strategy.ctx.positions.items():
+        total += _calc_position_margin(strategy, str(sym), float(qty))
+    return total
+
+
+def _calc_frozen_cash(strategy: Any) -> float:
+    if strategy.ctx is None:
+        return 0.0
+    frozen = 0.0
+    for order in get_open_orders(strategy):
+        qty = max(float(order.quantity) - float(order.filled_quantity), 0.0)
+        if qty <= 0.0:
+            continue
+        symbol = str(order.symbol)
+        current_pos = float(strategy.ctx.positions.get(symbol, 0.0))
+        if order.side == OrderSide.Buy:
+            next_pos = current_pos + qty
+        elif order.side == OrderSide.Sell:
+            next_pos = current_pos - qty
+        else:
+            continue
+        current_margin = _calc_position_margin(strategy, symbol, current_pos)
+        next_margin = _calc_position_margin(strategy, symbol, next_pos)
+        frozen += max(next_margin - current_margin, 0.0)
+    return frozen
+
+
 def get_account(strategy: Any) -> Dict[str, float]:
     """获取账户资金详情快照."""
     if strategy.ctx is None:
         raise RuntimeError("Context not ready")
 
-    cash = strategy.ctx.cash
-    equity = strategy.equity
-    market_value = equity - cash
+    cash = float(strategy.ctx.cash)
+    equity = float(strategy.equity)
+    market_value = float(equity - cash)
+    margin = float(_calc_used_margin(strategy))
+    frozen_cash = float(_calc_frozen_cash(strategy))
     return {
         "cash": cash,
         "equity": equity,
         "market_value": market_value,
-        "frozen_cash": 0.0,
-        "margin": 0.0,
+        "frozen_cash": frozen_cash,
+        "margin": margin,
     }
 
 

--- a/src/market/mod.rs
+++ b/src/market/mod.rs
@@ -139,6 +139,7 @@ mod tests {
             inner: InstrumentEnum::Option(OptionInstrument {
                 symbol: "OPT_510050_C_202601".to_string(),
                 multiplier: Decimal::from(1),
+                margin_ratio: Decimal::from_str("0.2").unwrap(),
                 tick_size: Decimal::from_str("0.0001").unwrap(),
                 strike_price: Decimal::from(2),
                 option_type: crate::model::OptionType::Call,

--- a/src/model/instrument.rs
+++ b/src/model/instrument.rs
@@ -37,6 +37,7 @@ pub struct FuturesInstrument {
 pub struct OptionInstrument {
     pub symbol: String,
     pub multiplier: Decimal,
+    pub margin_ratio: Decimal,
     pub tick_size: Decimal,
     pub option_type: OptionType,
     pub strike_price: Decimal,
@@ -162,6 +163,7 @@ impl Instrument {
             AssetType::Option => InstrumentEnum::Option(OptionInstrument {
                 symbol: symbol.clone(),
                 multiplier: multiplier_val,
+                margin_ratio: margin_val,
                 tick_size: tick_val,
                 option_type: option_type.unwrap_or(OptionType::Call),
                 strike_price: strike_price
@@ -241,6 +243,7 @@ impl Instrument {
     pub fn margin_ratio(&self) -> Decimal {
         match &self.inner {
             InstrumentEnum::Futures(f) => f.margin_ratio,
+            InstrumentEnum::Option(o) => o.margin_ratio,
             InstrumentEnum::Forex(_) => Decimal::new(1, 2), // 0.01 default for Forex
             _ => Decimal::ONE,
         }

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -76,6 +76,7 @@ fn test_portfolio_calculate_margin() {
         inner: InstrumentEnum::Option(OptionInstrument {
             symbol: "OPT_LONG".to_string(),
             multiplier: Decimal::from(100),
+            margin_ratio: Decimal::from_str("0.2").unwrap(),
             tick_size: Decimal::from_str("0.01").unwrap(),
             option_type: OptionType::Call,
             strike_price: Decimal::from(100),

--- a/src/risk/common.rs
+++ b/src/risk/common.rs
@@ -1,5 +1,5 @@
 use crate::error::AkQuantError;
-use crate::model::{AssetType, Order, OrderSide};
+use crate::model::{Order, OrderSide};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 
@@ -134,75 +134,81 @@ impl RiskRule for CashMarginRule {
     }
 
     fn check(&self, order: &Order, ctx: &RiskCheckContext) -> Result<(), AkQuantError> {
-        if ctx.config.check_cash && order.side == OrderSide::Buy {
-            let mut required_margin = Decimal::ZERO;
-            let mut price_found = false;
-
-            // Get instrument info for multiplier and margin_ratio
-            let multiplier = ctx.instrument.multiplier();
-            let margin_ratio = ctx.instrument.margin_ratio();
-
-            // Determine price for current order
-            if let Some(p) = order.price {
-                required_margin = p * order.quantity * multiplier * margin_ratio;
-                price_found = true;
+        if ctx.config.check_cash {
+            let order_price = if let Some(p) = order.price {
+                p
             } else if let Some(p) = ctx.current_prices.get(&order.symbol) {
-                required_margin = *p * order.quantity * multiplier * margin_ratio;
-                price_found = true;
+                *p
+            } else {
+                return Ok(());
+            };
+
+            let mut prices_for_order = ctx.current_prices.clone();
+            prices_for_order.insert(order.symbol.clone(), order_price);
+
+            let mut projected_portfolio = ctx.portfolio.clone();
+            let base_used = projected_portfolio
+                .calculate_used_margin(&prices_for_order, ctx.instruments);
+            {
+                let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
+                let entry = positions
+                    .entry(order.symbol.clone())
+                    .or_insert(Decimal::ZERO);
+                match order.side {
+                    OrderSide::Buy => *entry += order.quantity,
+                    OrderSide::Sell => *entry -= order.quantity,
+                }
+            }
+            let next_used = projected_portfolio
+                .calculate_used_margin(&prices_for_order, ctx.instruments);
+            let required_margin = (next_used - base_used).max(Decimal::ZERO);
+
+            if required_margin.is_zero() {
+                return Ok(());
             }
 
-            if price_found {
-                // Check Active Buy Orders for committed margin
-                let mut committed_margin = Decimal::ZERO;
-                let mut pending_sell_release = Decimal::ZERO;
-                for o in ctx.active_orders {
-                    if o.side == OrderSide::Buy && o.status == crate::model::OrderStatus::New {
-                        let (o_mult, o_margin_ratio) =
-                            if let Some(instr) = ctx.instruments.get(&o.symbol) {
-                                (instr.multiplier(), instr.margin_ratio())
-                            } else {
-                                (Decimal::ONE, Decimal::ONE)
-                            };
+            let mut committed_margin = Decimal::ZERO;
+            for o in ctx.active_orders {
+                if o.status != crate::model::OrderStatus::New {
+                    continue;
+                }
+                let active_price = if let Some(p) = o.price {
+                    p
+                } else if let Some(p) = ctx.current_prices.get(&o.symbol) {
+                    *p
+                } else {
+                    continue;
+                };
+                let mut prices_for_active = ctx.current_prices.clone();
+                prices_for_active.insert(o.symbol.clone(), active_price);
 
-                        if let Some(p) = o.price {
-                            committed_margin += p * o.quantity * o_mult * o_margin_ratio;
-                        } else if let Some(p) = ctx.current_prices.get(&o.symbol) {
-                            committed_margin += *p * o.quantity * o_mult * o_margin_ratio;
-                        }
-                    } else if o.side == OrderSide::Sell
-                        && o.status == crate::model::OrderStatus::New
-                        && let Some(instr) = ctx.instruments.get(&o.symbol)
-                        && matches!(instr.asset_type, AssetType::Stock | AssetType::Fund)
-                    {
-                        if let Some(p) = o.price {
-                            pending_sell_release += p * o.quantity;
-                        } else if let Some(p) = ctx.current_prices.get(&o.symbol) {
-                            pending_sell_release += *p * o.quantity;
-                        }
+                let before_used = projected_portfolio
+                    .calculate_used_margin(&prices_for_active, ctx.instruments);
+                {
+                    let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
+                    let entry = positions.entry(o.symbol.clone()).or_insert(Decimal::ZERO);
+                    match o.side {
+                        OrderSide::Buy => *entry += o.quantity,
+                        OrderSide::Sell => *entry -= o.quantity,
                     }
                 }
+                let after_used = projected_portfolio
+                    .calculate_used_margin(&prices_for_active, ctx.instruments);
+                committed_margin += (after_used - before_used).max(Decimal::ZERO);
+            }
 
-                // Calculate Free Margin
-                let free_margin = ctx
-                    .portfolio
-                    .calculate_free_margin(ctx.current_prices, ctx.instruments);
+            let free_margin = ctx
+                .portfolio
+                .calculate_free_margin(ctx.current_prices, ctx.instruments);
+            let safety_margin = ctx.config.safety_margin;
+            let safety_factor = Decimal::from_f64(1.0 - safety_margin)
+                .unwrap_or(Decimal::from_f64(0.9999).unwrap());
+            let available_margin = (free_margin * safety_factor - committed_margin).max(Decimal::ZERO);
 
-                // Apply Safety Margin (default 0.0001 or user config)
-                let safety_margin = ctx.config.safety_margin;
-                // Safety factor = 1.0 - margin (e.g., 0.9999)
-                let safety_factor = Decimal::from_f64(1.0 - safety_margin)
-                    .unwrap_or(Decimal::from_f64(0.9999).unwrap());
-
-                // Available Margin = (Free Margin - Committed Margin + Pending Sell Release) * Safety Factor
-                // Note: Free Margin already accounts for Used Margin of existing positions
-                let available_margin =
-                    (free_margin - committed_margin + pending_sell_release) * safety_factor;
-
-                if required_margin > available_margin {
-                    return Err(AkQuantError::OrderError(format!(
-                        "Risk: Insufficient margin. Required: {required_margin}, Available: {available_margin} (Free: {free_margin}, Committed: {committed_margin}, PendingSellRelease: {pending_sell_release}, Safety: {safety_margin})",
-                    )));
-                }
+            if required_margin > available_margin {
+                return Err(AkQuantError::OrderError(format!(
+                    "Risk: Insufficient margin. Required: {required_margin}, Available: {available_margin} (Free: {free_margin}, Committed: {committed_margin}, Safety: {safety_margin})",
+                )));
             }
         }
         Ok(())

--- a/src/settlement/option.rs
+++ b/src/settlement/option.rs
@@ -102,6 +102,7 @@ mod tests {
             inner: InstrumentEnum::Option(OptionInstrument {
                 symbol: symbol.to_string(),
                 multiplier: dec!(100),
+                margin_ratio: dec!(0.2),
                 tick_size: dec!(0.01),
                 option_type,
                 strike_price: strike,

--- a/tests/test_account_risk_rules.py
+++ b/tests/test_account_risk_rules.py
@@ -1,7 +1,14 @@
 from typing import Any
 
 import pandas as pd
-from akquant import Bar, Strategy, run_backtest
+from akquant import (
+    BacktestConfig,
+    Bar,
+    InstrumentConfig,
+    Strategy,
+    StrategyConfig,
+    run_backtest,
+)
 from akquant.config import RiskConfig
 
 
@@ -107,3 +114,100 @@ def test_account_stop_loss_threshold_rule_rejects_new_orders() -> None:
     )
     reasons = _reject_reasons(result)
     assert any("stop-loss threshold" in r for r in reasons), reasons
+
+
+def test_risk_config_accepts_check_cash_keyword() -> None:
+    """RiskConfig supports check_cash as constructor argument."""
+    rc = RiskConfig(check_cash=False)
+    assert rc.check_cash is False
+
+
+def test_check_cash_false_can_disable_margin_rejection_for_buy() -> None:
+    """check_cash from Python RiskConfig should propagate to Rust engine config."""
+    from akquant.akquant import Engine
+    from akquant.risk import apply_risk_config
+
+    engine = Engine()
+    assert engine.risk_manager.config.check_cash is True
+
+    apply_risk_config(engine, RiskConfig(check_cash=False))
+    assert engine.risk_manager.config.check_cash is False
+
+
+def test_short_option_margin_is_checked_and_account_margin_updates() -> None:
+    """Short option opening orders should trigger margin checks and account margin."""
+
+    class ShortPutStrategy(Strategy):
+        account_snapshots: list[dict[str, float]] = []
+
+        def __init__(self) -> None:
+            self.order_count = 0
+
+        def on_bar(self, bar: Bar) -> None:
+            if bar.symbol != "PUT_OPT":
+                return
+            if self.order_count == 0:
+                self.sell("PUT_OPT", 1)
+                self.order_count += 1
+            elif self.order_count == 1:
+                self.sell("PUT_OPT", 100000)
+                self.order_count += 1
+
+        def on_trade(self, trade: Any) -> None:
+            self.__class__.account_snapshots.append(self.get_account())
+
+    dates = pd.date_range("2023-12-01 09:30", "2023-12-01 09:32", freq="1min")
+    data_opt = pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": 1.5,
+            "high": 1.5,
+            "low": 1.5,
+            "close": 1.5,
+            "volume": 100,
+            "symbol": "PUT_OPT",
+        }
+    )
+    data_ul = pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": 105.0,
+            "high": 105.0,
+            "low": 105.0,
+            "close": 105.0,
+            "volume": 1000,
+            "symbol": "UL",
+        }
+    )
+    ShortPutStrategy.account_snapshots = []
+    result = run_backtest(
+        data={"PUT_OPT": data_opt, "UL": data_ul},
+        strategy=ShortPutStrategy,
+        show_progress=False,
+        execution_mode="current_close",
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(
+                initial_cash=50000.0,
+                commission_rate=0.0,
+                risk=RiskConfig(check_cash=True, safety_margin=0.0001),
+            ),
+            instruments_config=[
+                InstrumentConfig(
+                    symbol="PUT_OPT",
+                    asset_type="OPTION",
+                    multiplier=100,
+                    margin_ratio=0.35,
+                    option_type="PUT",
+                    strike_price=90,
+                    expiry_date=20231201,
+                    underlying_symbol="UL",
+                ),
+                InstrumentConfig(symbol="UL", asset_type="STOCK"),
+            ],
+        ),
+    )
+
+    reasons = _reject_reasons(result)
+    assert any("Insufficient margin" in r for r in reasons), reasons
+    assert ShortPutStrategy.account_snapshots
+    assert any(s["margin"] > 0.0 for s in ShortPutStrategy.account_snapshots)


### PR DESCRIPTION
- 为期权合约添加保证金比例字段，支持期权保证金计算
- 重构现金保证金检查规则，统一处理所有资产类型的保证金计算
- 在 Python 层实现账户保证金和冻结资金计算，并暴露给策略框架
- 新增 check_cash 配置选项，允许用户控制保证金检查开关
- 更新相关测试以验证期权保证金功能