### PR TITLE
feat(risk): 支持信用账户融资融券回测与强平审计

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.91"
+version = "0.1.92"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.91"
+version = "0.1.92"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/llm.md
+++ b/docs/en/advanced/llm.md
@@ -56,6 +56,11 @@ Your task is to write trading strategies or backtest scripts based on user requi
         *   `fill_policy`: Preferred unified semantics, e.g.
             `{"price_basis": "current_close", "temporal": "next_event"}`.
         *   `timezone`: Default "Asia/Shanghai".
+        *   `risk_config.account_mode`: `"cash"` (default) or `"margin"` for margin-account backtests.
+        *   `risk_config.enable_short_sell`: Whether stock short opening is allowed in margin mode.
+        *   `risk_config.allow_force_liquidation`: Whether forced liquidation runs when maintenance ratio is breached.
+        *   `risk_config.liquidation_priority`: Forced-liquidation order, `"short_first"` (default) or `"long_first"`.
+        *   `result.liquidation_audit_df`: Forced-liquidation audit table in backtest result with date, interest, symbols, and priority.
     *   Example:
         ```python
         run_backtest(

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -231,4 +231,12 @@ exec_by_strategy = result.executions_by_strategy()  # strategy-level execution s
 risk_by_strategy = result.risk_rejections_by_strategy()  # strategy-level risk rejection summary
 risk_trend = result.risk_rejections_trend(freq="D")  # daily trend of risk rejections
 risk_trend_by_strategy = result.risk_rejections_trend_by_strategy(freq="D")
+
+# margin-account forced liquidation audit (when enabled)
+liquidation_audit = result.liquidation_audit_df
 ```
+
+When margin mode is enabled and forced liquidation occurs, `result.report(...)` automatically includes:
+
+- a forced liquidation audit table (date, daily interest, symbols, priority)
+- daily liquidation charts in the risk chart section (shown when data exists)

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -469,6 +469,48 @@ Suggested account-level presets (starting points):
 
 Start from the balanced preset, then tighten or loosen values based on observed volatility and turnover.
 
+### 6.1 Margin Account Backtest (Financing / Short Sell)
+
+If your strategy needs financing long or stock short selling in backtests, switch the account mode to `margin` in `RiskConfig`:
+
+```python
+from akquant.config import RiskConfig
+
+risk_config = RiskConfig(
+    account_mode="margin",
+    enable_short_sell=True,
+    initial_margin_ratio=0.5,
+    maintenance_margin_ratio=0.3,
+    financing_rate_annual=0.08,
+    borrow_rate_annual=0.10,
+    allow_force_liquidation=True,
+    liquidation_priority="short_first",
+)
+```
+
+Key fields:
+
+- `account_mode`: `"cash"` or `"margin"`.
+- `enable_short_sell`: allows opening stock short positions.
+- `initial_margin_ratio`: initial margin ratio used for stock/fund sizing checks.
+- `maintenance_margin_ratio`: maintenance threshold.
+- `allow_force_liquidation`: force close when maintenance is breached.
+- `liquidation_priority`: `"short_first"` or `"long_first"`.
+
+You can read extended margin fields via `get_account()` inside strategy callbacks:
+
+```python
+snap = self.get_account()
+print(
+    snap["account_mode"],
+    snap["borrowed_cash"],
+    snap["short_market_value"],
+    snap["maintenance_ratio"],
+    snap["accrued_interest"],
+    snap["daily_interest"],
+)
+```
+
 ## 6. Using High-Performance Indicators {: #indicatorset }
 
 AKQuant includes commonly used technical indicators built into the Rust layer. They use Incremental Calculation to avoid repeated full recalculations, resulting in extremely high performance.

--- a/docs/en/start/quickstart.md
+++ b/docs/en/start/quickstart.md
@@ -395,7 +395,44 @@ Phase-5 Migration FAQ:
 *   How do we roll back? Since Phase 5, `_engine_mode` runtime fallback is removed; use release-level rollback.
 *   Home navigation entry: see [Quick Links in docs home](../index.md#quick-links).
 
-## 4. Advanced Learning
+## 4. Margin Account & Liquidation Audit (Backtest)
+
+To validate financing/short-selling behavior in backtests, enable `margin` mode in `RiskConfig`:
+
+```python
+from akquant import run_backtest
+from akquant.config import RiskConfig
+
+result = run_backtest(
+    data=df,
+    strategy=MyStrategy,
+    symbols="sh600000",
+    risk_config=RiskConfig(
+        account_mode="margin",
+        enable_short_sell=True,
+        initial_margin_ratio=0.5,
+        maintenance_margin_ratio=0.3,
+        financing_rate_annual=0.08,
+        borrow_rate_annual=0.10,
+        allow_force_liquidation=True,
+        liquidation_priority="short_first",
+    ),
+)
+```
+
+After the run, inspect the audit output directly:
+
+```python
+print(result.liquidation_audit_df)
+result.report(filename="report_margin.html", show=False)
+```
+
+The generated report includes:
+
+*   Forced liquidation audit table (date, symbols, priority, daily interest)
+*   Daily liquidation charts in the risk chart area (shown when data exists)
+
+## 5. Advanced Learning
 
 Too simple? Want to learn how to write real quantitative strategies (like Dual Moving Average, MACD, etc.)?
 

--- a/docs/zh/advanced/llm.md
+++ b/docs/zh/advanced/llm.md
@@ -58,6 +58,11 @@ Your task is to write trading strategies or backtest scripts based on user requi
             `{"price_basis": "current_close", "temporal": "next_event"}`.
         *   `timezone`: Default "Asia/Shanghai".
         *   `risk_config`: Use `engine.risk_manager` to set pre-trade checks (Position Limit, Sector Limit, Leverage).
+        *   `risk_config.account_mode`: `"cash"`（默认）或 `"margin"`，信用账户回测需设置为 `"margin"`。
+        *   `risk_config.enable_short_sell`: 信用账户是否允许股票开空，默认 `False`。
+        *   `risk_config.allow_force_liquidation`: 维持担保比例触发时是否执行强平，默认 `True`。
+        *   `risk_config.liquidation_priority`: 强平顺序，`"short_first"`（默认）或 `"long_first"`。
+        *   `result.liquidation_audit_df`: 回测结果中的强平审计表，包含日期、利息、强平标的与顺序。
     *   Example:
         ```python
         engine = Engine()

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -207,7 +207,15 @@ executions_by_strategy = result.executions_by_strategy()
 risk_by_strategy = result.risk_rejections_by_strategy()
 risk_trend = result.risk_rejections_trend(freq="D")
 risk_trend_by_strategy = result.risk_rejections_trend_by_strategy(freq="D")
+
+# 5) 信用账户强平审计（融资融券回测时）
+liquidation_audit = result.liquidation_audit_df
 ```
+
+当启用信用账户并触发强平后，`result.report(...)` 的 HTML 报告会自动包含：
+
+- 强平审计明细表（日期、当日计息、强平标的、强平顺序）
+- 风险图表区中的按日强平统计图（有数据时展示）
 
 或者使用 `plot` 方法快速预览特定图表：
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -137,6 +137,48 @@ result = run_backtest(
 
 建议先从“中性”起步，再根据策略波动与换手逐步收紧或放宽。
 
+### 3.1 信用账户回测（融资/融券）
+
+若策略需要在回测中启用融资买入或融券卖出，可在 `RiskConfig` 中显式切换到账户模式 `margin`：
+
+```python
+from akquant.config import RiskConfig
+
+risk_config = RiskConfig(
+    account_mode="margin",
+    enable_short_sell=True,
+    initial_margin_ratio=0.5,
+    maintenance_margin_ratio=0.3,
+    financing_rate_annual=0.08,
+    borrow_rate_annual=0.10,
+    allow_force_liquidation=True,
+    liquidation_priority="short_first",
+)
+```
+
+常用字段说明：
+
+- `account_mode`: `"cash"` / `"margin"`。
+- `enable_short_sell`: `True` 时允许股票开空。
+- `initial_margin_ratio`: 初始保证金比例（影响可开仓规模）。
+- `maintenance_margin_ratio`: 维持担保比例阈值。
+- `allow_force_liquidation`: 维持担保比例跌破阈值时是否触发强平。
+- `liquidation_priority`: `"short_first"` 或 `"long_first"`。
+
+策略中可通过 `get_account()` 读取信用账户扩展字段：
+
+```python
+snap = self.get_account()
+print(
+    snap["account_mode"],
+    snap["borrowed_cash"],
+    snap["short_market_value"],
+    snap["maintenance_ratio"],
+    snap["accrued_interest"],
+    snap["daily_interest"],
+)
+```
+
 ## 4. 常用工具 (Utilities)
 
 AKQuant 提供了一系列便捷工具来简化策略开发。

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -442,3 +442,40 @@ result = run_backtest(
 - PyCharm 看不到进度条怎么办？开启 `Emulate terminal in output console`，或使用 `on_event + progress` 事件输出文本进度。
 - 如何回滚？阶段 5 后不再支持 `_engine_mode` 参数级回滚，建议使用版本级回滚。
 - 首页导航入口：见 [文档首页的阶段 5 迁移入口](../index.md)。
+
+## 5. 信用账户与强平审计（回测）
+
+如果你要在回测中验证融资/融券场景，可在 `RiskConfig` 中开启 `margin` 模式：
+
+```python
+from akquant import run_backtest
+from akquant.config import RiskConfig
+
+result = run_backtest(
+    data=df,
+    strategy=MyStrategy,
+    symbols="sh600000",
+    risk_config=RiskConfig(
+        account_mode="margin",
+        enable_short_sell=True,
+        initial_margin_ratio=0.5,
+        maintenance_margin_ratio=0.3,
+        financing_rate_annual=0.08,
+        borrow_rate_annual=0.10,
+        allow_force_liquidation=True,
+        liquidation_priority="short_first",
+    ),
+)
+```
+
+回测完成后可以直接查看审计数据：
+
+```python
+print(result.liquidation_audit_df)
+result.report(filename="report_margin.html", show=False)
+```
+
+`report_margin.html` 会包含：
+
+- 强平审计明细（日期、强平标的、优先顺序、当日利息）
+- 风险图表区中的按日强平统计图（有数据时显示）

--- a/docs/zh/textbook/05_strategy.md
+++ b/docs/zh/textbook/05_strategy.md
@@ -109,6 +109,44 @@ result = aq.run_backtest(
 
 一键平仓。无论当前持有多头还是空头，都会发出相反方向的市价单将其平掉。
 
+### 5.3.4 信用账户参数与账户快照
+
+当你在股票场景做融资/融券回测时，需要在 `RiskConfig` 中显式启用信用账户模式：
+
+```python
+from akquant.config import RiskConfig
+
+risk_config = RiskConfig(
+    account_mode="margin",
+    enable_short_sell=True,
+    initial_margin_ratio=0.5,
+    maintenance_margin_ratio=0.3,
+    financing_rate_annual=0.08,
+    borrow_rate_annual=0.10,
+    allow_force_liquidation=True,
+    liquidation_priority="short_first",
+)
+```
+
+策略内可通过 `get_account()` 读取信用账户专有字段：
+
+- `borrowed_cash`: 融资负债
+- `short_market_value`: 空头市值
+- `maintenance_ratio`: 维持担保比例
+- `accrued_interest` / `daily_interest`: 累计与当日计息
+
+```python
+snap = self.get_account()
+print(
+    snap["account_mode"],
+    snap["borrowed_cash"],
+    snap["short_market_value"],
+    snap["maintenance_ratio"],
+    snap["accrued_interest"],
+    snap["daily_interest"],
+)
+```
+
 ## 5.4 高级策略模式 (Advanced Patterns)
 
 在实际开发中，简单的双均线往往不够用。我们需要更复杂的策略模式。

--- a/docs/zh/textbook/13_visualization.md
+++ b/docs/zh/textbook/13_visualization.md
@@ -89,6 +89,26 @@ plt.show()
 result.plot(engine="plotly", filename="backtest.html")
 ```
 
+### 13.3.3 信用账户强平审计视图
+
+在融资/融券回测中，如果发生维持担保比例触发的强平，`BacktestResult` 会产出结构化审计表：
+
+```python
+liq_audit = result.liquidation_audit_df
+print(liq_audit.head())
+```
+
+使用内置报告：
+
+```python
+result.report(filename="report_margin.html", show=False)
+```
+
+报告会自动包含：
+
+1. 强平审计明细表（日期、当日计息、强平标的、强平顺序）
+2. 风险图表区中的按日强平统计图（有数据时展示）
+
 ## 13.4 第三方工具集成：QuantStats
 
 `AKQuant` 完美支持 `QuantStats`，这是一个强大的 Python 量化分析库，能生成媲美专业基金的 Tearsheet。

--- a/examples/01_quickstart.py
+++ b/examples/01_quickstart.py
@@ -112,6 +112,11 @@ pd.set_option("display.max_columns", None)
 pd.set_option("display.max_rows", None)
 print(result)
 print(result.orders_df)
+liquidation_audit_df = result.liquidation_audit_df
+if liquidation_audit_df.empty:
+    print("liquidation_audit_df is empty")
+else:
+    print(liquidation_audit_df)
 print(f"stream_events={len(events)}")
 
 # Verify metrics manually in Python

--- a/examples/47_margin_liquidation_audit_demo.py
+++ b/examples/47_margin_liquidation_audit_demo.py
@@ -1,0 +1,88 @@
+import pandas as pd
+from akquant import Bar, Strategy, run_backtest
+from akquant.config import RiskConfig
+
+
+class MarginLiquidationAuditStrategy(Strategy):
+    """Open leveraged long once and let maintenance breach trigger liquidation."""
+
+    def __init__(self) -> None:
+        """Initialize one-shot order flag."""
+        self.ordered = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit first order and print account snapshot fields."""
+        if not self.ordered:
+            self.buy(symbol=bar.symbol, quantity=150)
+            self.ordered = True
+        snap = self.get_account()
+        print(
+            "account_snapshot",
+            {
+                "ts": pd.to_datetime(bar.timestamp, unit="ns", utc=True)
+                .tz_convert("Asia/Shanghai")
+                .isoformat(),
+                "account_mode": snap.get("account_mode"),
+                "cash": snap.get("cash"),
+                "borrowed_cash": snap.get("borrowed_cash"),
+                "short_market_value": snap.get("short_market_value"),
+                "maintenance_ratio": snap.get("maintenance_ratio"),
+                "accrued_interest": snap.get("accrued_interest"),
+                "daily_interest": snap.get("daily_interest"),
+            },
+        )
+
+
+def _build_data() -> list[Bar]:
+    rows = [
+        ("2023-01-01 10:00:00", 100.0),
+        ("2023-01-01 14:00:00", 20.0),
+        ("2023-01-02 10:00:00", 20.0),
+    ]
+    bars: list[Bar] = []
+    for dt_str, close in rows:
+        ts = pd.Timestamp(dt_str, tz="Asia/Shanghai").value
+        bars.append(
+            Bar(
+                timestamp=ts,
+                open=close,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=10000.0,
+                symbol="LIQ",
+            )
+        )
+    return bars
+
+
+def run_example() -> None:
+    """Run margin liquidation audit demo."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=MarginLiquidationAuditStrategy,
+        symbols="LIQ",
+        initial_cash=10000.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            enable_short_sell=True,
+            initial_margin_ratio=0.5,
+            maintenance_margin_ratio=0.5,
+            financing_rate_annual=0.0,
+            borrow_rate_annual=0.0,
+            allow_force_liquidation=True,
+            liquidation_priority="short_first",
+        ),
+    )
+    print("liquidation_audit_df")
+    print(result.liquidation_audit_df)
+    report_file = "margin_liquidation_report.html"
+    result.report(filename=report_file, show=False)
+    print(f"report_saved={report_file}")
+
+
+if __name__ == "__main__":
+    run_example()

--- a/examples/48_margin_liquidation_priority_compare.py
+++ b/examples/48_margin_liquidation_priority_compare.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+import pandas as pd
+from akquant import Bar, Strategy, run_backtest
+from akquant.config import RiskConfig
+
+
+class HedgedMarginStrategy(Strategy):
+    """Open one long and one short leg for liquidation-priority comparison."""
+
+    def __init__(self) -> None:
+        """Initialize one-shot submit flags."""
+        self.long_submitted = False
+        self.short_submitted = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit initial hedged legs."""
+        if bar.symbol == "LONG" and not self.long_submitted:
+            self.buy(symbol=bar.symbol, quantity=100)
+            self.long_submitted = True
+        if bar.symbol == "SHORT" and not self.short_submitted:
+            self.sell(symbol=bar.symbol, quantity=50)
+            self.short_submitted = True
+
+
+def _build_data() -> list[Bar]:
+    rows = [
+        ("2023-01-01 10:00:00", "LONG", 100.0),
+        ("2023-01-01 10:00:00", "SHORT", 100.0),
+        ("2023-01-02 10:00:00", "LONG", 100.0),
+        ("2023-01-02 10:00:00", "SHORT", 100.0),
+    ]
+    bars: list[Bar] = []
+    for dt_str, symbol, close in rows:
+        ts = pd.Timestamp(dt_str, tz="Asia/Shanghai").value
+        bars.append(
+            Bar(
+                timestamp=ts,
+                open=close,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=10000.0,
+                symbol=symbol,
+            )
+        )
+    return bars
+
+
+def _run_once(liquidation_priority: str) -> Any:
+    return run_backtest(
+        data=_build_data(),
+        strategy=HedgedMarginStrategy,
+        symbols=["LONG", "SHORT"],
+        initial_cash=50000.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            enable_short_sell=True,
+            initial_margin_ratio=0.5,
+            maintenance_margin_ratio=4.0,
+            financing_rate_annual=0.0,
+            borrow_rate_annual=0.0,
+            allow_force_liquidation=True,
+            liquidation_priority=liquidation_priority,
+        ),
+    )
+
+
+def run_example() -> None:
+    """Run and compare short_first vs long_first liquidation results."""
+    result_short_first = _run_once("short_first")
+    result_long_first = _run_once("long_first")
+
+    audit_short_first = result_short_first.liquidation_audit_df
+    audit_long_first = result_long_first.liquidation_audit_df
+    if audit_short_first.empty or audit_long_first.empty:
+        raise RuntimeError("liquidation audit is empty in at least one run")
+
+    symbol_short_first = str(audit_short_first.iloc[-1]["liquidated_symbols"])
+    symbol_long_first = str(audit_long_first.iloc[-1]["liquidated_symbols"])
+
+    print("short_first_liquidation_audit")
+    print(audit_short_first)
+    print("long_first_liquidation_audit")
+    print(audit_long_first)
+    print(
+        "liquidation_priority_compare",
+        {
+            "short_first_liquidated_symbol": symbol_short_first,
+            "long_first_liquidated_symbol": symbol_long_first,
+        },
+    )
+
+    short_report = "margin_liquidation_priority_short_first.html"
+    long_report = "margin_liquidation_priority_long_first.html"
+    result_short_first.report(filename=short_report, show=False)
+    result_long_first.report(filename=long_report, show=False)
+    print(f"report_saved={short_report}")
+    print(f"report_saved={long_report}")
+
+
+if __name__ == "__main__":
+    run_example()

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,8 @@
 - [44_strategy_source_loader_demo.py](./44_strategy_source_loader_demo.py): strategy_source + strategy_loader 动态加载示例（明文 + 外部解密）。
 - [45_talib_indicator_playbook_demo.py](./45_talib_indicator_playbook_demo.py): TA-Lib 指标组合模板示例（趋势跟随 + 均值回归 + 风险过滤，支持 `--data-source synthetic|akshare`）。
 - [46_broker_profile_demo.py](./46_broker_profile_demo.py): `broker_profile` 模板注入示例（默认费率/滑点/手数一键生效）。
+- [47_margin_liquidation_audit_demo.py](./47_margin_liquidation_audit_demo.py): 信用账户强平审计示例（`margin` 模式 + `liquidation_audit_df` + 报告输出）。
+- [48_margin_liquidation_priority_compare.py](./48_margin_liquidation_priority_compare.py): 强平顺序对比示例（`short_first` vs `long_first`）。
 
 ## 流式回测与实时报告
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.91"
+version = "0.1.92"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -642,6 +642,34 @@ class BacktestResult:
             ).dt.tz_convert(self._timezone)
         return df
 
+    @cached_property
+    def liquidation_audit_df(self) -> pd.DataFrame:
+        """Get margin forced-liquidation audit records as a Pandas DataFrame."""
+        if not hasattr(self._raw, "get_liquidation_audits_dict"):
+            return pd.DataFrame()
+
+        try:
+            data = self._raw.get_liquidation_audits_dict()
+            if not data:
+                return pd.DataFrame()
+            df = pd.DataFrame(data)
+        except Exception:
+            return pd.DataFrame()
+
+        if df.empty:
+            return df
+        if "timestamp" in df.columns and pd.api.types.is_numeric_dtype(df["timestamp"]):
+            df["timestamp"] = pd.to_datetime(
+                df["timestamp"], unit="ns", utc=True
+            ).dt.tz_convert(self._timezone)
+        if "date" in df.columns and not pd.api.types.is_datetime64_any_dtype(
+            df["date"]
+        ):
+            df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        if "timestamp" in df.columns:
+            df = df.sort_values("timestamp").reset_index(drop=True)
+        return cast(pd.DataFrame, df)
+
     def exposure_df(self, freq: Optional[str] = "D") -> pd.DataFrame:
         """Get portfolio exposure decomposition time series."""
         positions = self.positions_df.copy()

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -422,6 +422,18 @@ class RiskConfig:
     :param max_daily_loss: Max allowed daily loss percentage.
     :param stop_loss_threshold: Net value threshold (e.g., 0.8). If equity drops below
                                 initial_cash * threshold, trading is stopped.
+    :param account_mode: Account mode. "cash" (default) or "margin".
+    :param enable_short_sell: Whether margin account allows opening short stock
+                              positions.
+    :param initial_margin_ratio: Initial margin ratio for stock/fund in margin mode.
+    :param maintenance_margin_ratio: Maintenance margin ratio reference for
+                                     margin account.
+    :param financing_rate_annual: Annual financing rate for margin buying.
+    :param borrow_rate_annual: Annual borrow rate for short selling.
+    :param allow_force_liquidation: Whether to force-liquidate positions when
+                                    maintenance ratio is breached.
+    :param liquidation_priority: Forced-liquidation order, "short_first" (default)
+                                 or "long_first".
     """
 
     active: bool = True
@@ -440,6 +452,14 @@ class RiskConfig:
     stop_loss_threshold: Optional[float] = (
         None  # e.g., 0.8 means stop if equity < 0.8 * initial
     )
+    account_mode: str = "cash"
+    enable_short_sell: bool = False
+    initial_margin_ratio: float = 1.0
+    maintenance_margin_ratio: float = 0.3
+    financing_rate_annual: float = 0.08
+    borrow_rate_annual: float = 0.10
+    allow_force_liquidation: bool = True
+    liquidation_priority: str = "short_first"
 
 
 @dataclass

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -470,6 +470,10 @@ HTML_TEMPLATE = """
             <summary>策略风控拒单明细 (Risk Rejections by Strategy)</summary>
             <div class="details-content">{risk_by_strategy_html}</div>
         </details>
+        <details class="details-block">
+            <summary>强平审计明细 (Forced Liquidation Audit)</summary>
+            <div class="details-content">{liquidation_audit_html}</div>
+        </details>
         {risk_charts_html}
 
         <footer>
@@ -832,6 +836,8 @@ def _build_chart_html_sections(
     has_risk_trend_chart = False
     has_risk_strategy_trend_chart = False
     has_risk_reason_trend_chart = False
+    has_liquidation_count_chart = False
+    has_liquidation_interest_chart = False
     total_reject_count = 0.0
     risk_df = (
         result.risk_rejections_by_strategy()
@@ -1099,6 +1105,85 @@ def _build_chart_html_sections(
             )
             has_risk_strategy_trend_chart = True
 
+    liquidation_audit_df = (
+        result.liquidation_audit_df
+        if hasattr(result, "liquidation_audit_df")
+        else pd.DataFrame()
+    )
+    liquidation_count_chart_html = ""
+    liquidation_interest_chart_html = ""
+    if not liquidation_audit_df.empty:
+        liq_df = liquidation_audit_df.copy()
+        if "timestamp" in liq_df.columns:
+            liq_df["timestamp"] = pd.to_datetime(liq_df["timestamp"], errors="coerce")
+        elif "date" in liq_df.columns:
+            liq_df["timestamp"] = pd.to_datetime(liq_df["date"], errors="coerce")
+        else:
+            liq_df["timestamp"] = pd.NaT
+        liq_df = liq_df.dropna(subset=["timestamp"]).sort_values("timestamp")
+
+        if not liq_df.empty and "liquidated_count" in liq_df.columns:
+            liq_df["liquidated_count"] = pd.to_numeric(
+                liq_df["liquidated_count"], errors="coerce"
+            ).fillna(0.0)
+            daily_liq = (
+                liq_df.set_index("timestamp")["liquidated_count"].resample("D").sum()
+            ).reset_index()
+            if not daily_liq.empty and float(daily_liq["liquidated_count"].sum()) > 0.0:
+                px = __import__("plotly.express", fromlist=["line"])
+                fig_liq_count = px.line(
+                    daily_liq,
+                    x="timestamp",
+                    y="liquidated_count",
+                    markers=True,
+                    title="按日强平标的数趋势 (Daily Liquidated Symbols Trend)",
+                    labels={
+                        "timestamp": "日期 (Date)",
+                        "liquidated_count": "强平标的数 (Liquidated Symbols)",
+                    },
+                )
+                fig_liq_count.update_layout(
+                    height=320, margin=dict(l=20, r=20, t=60, b=20)
+                )
+                fig_liq_count.update_traces(
+                    hovertemplate="日期=%{x}<br>强平标的数=%{y:.0f}<extra></extra>"
+                )
+                liquidation_count_chart_html = fig_liq_count.to_html(
+                    full_html=False, include_plotlyjs=False, config=config
+                )
+                has_liquidation_count_chart = True
+
+        if not liq_df.empty and "daily_interest" in liq_df.columns:
+            liq_df["daily_interest"] = pd.to_numeric(
+                liq_df["daily_interest"], errors="coerce"
+            ).fillna(0.0)
+            daily_interest = (
+                liq_df.set_index("timestamp")["daily_interest"].resample("D").sum()
+            ).reset_index()
+            has_positive_interest = bool((daily_interest["daily_interest"] > 0.0).any())
+            if not daily_interest.empty and has_positive_interest:
+                px = __import__("plotly.express", fromlist=["bar"])
+                fig_liq_interest = px.bar(
+                    daily_interest,
+                    x="timestamp",
+                    y="daily_interest",
+                    title="按日强平计息 (Daily Liquidation Interest)",
+                    labels={
+                        "timestamp": "日期 (Date)",
+                        "daily_interest": "当日利息 (Daily Interest)",
+                    },
+                )
+                fig_liq_interest.update_layout(
+                    height=320, margin=dict(l=20, r=20, t=60, b=20)
+                )
+                fig_liq_interest.update_traces(
+                    hovertemplate="日期=%{x}<br>当日利息=%{y:.4f}<extra></extra>"
+                )
+                liquidation_interest_chart_html = fig_liq_interest.to_html(
+                    full_html=False, include_plotlyjs=False, config=config
+                )
+                has_liquidation_interest_chart = True
+
     risk_chart_blocks: list[str] = []
 
     def append_risk_chart_block(chart_html: str) -> None:
@@ -1120,6 +1205,10 @@ def _build_chart_html_sections(
         append_risk_chart_block(risk_reject_trend_by_strategy_html)
     if has_risk_reason_trend_chart:
         append_risk_chart_block(risk_reason_trend_html)
+    if has_liquidation_count_chart:
+        append_risk_chart_block(liquidation_count_chart_html)
+    if has_liquidation_interest_chart:
+        append_risk_chart_block(liquidation_interest_chart_html)
 
     if risk_chart_blocks:
         risk_charts_html = "".join(risk_chart_blocks)
@@ -1405,6 +1494,52 @@ def _build_analysis_table_sections(
     else:
         risk_by_strategy_html = "<div>暂无策略归属风控拒单聚合数据</div>"
 
+    liquidation_audit_df = (
+        result.liquidation_audit_df
+        if hasattr(result, "liquidation_audit_df")
+        else pd.DataFrame()
+    )
+    if not liquidation_audit_df.empty:
+        liq_df = liquidation_audit_df.copy()
+        cols = [
+            "timestamp",
+            "date",
+            "daily_interest",
+            "liquidated_count",
+            "liquidated_symbols",
+            "priority",
+        ]
+        cols = [c for c in cols if c in liq_df.columns]
+        if "priority" in liq_df.columns:
+            liq_df["priority"] = (
+                liq_df["priority"]
+                .astype(str)
+                .replace({"short_first": "先平空头", "long_first": "先平多头"})
+            )
+        if "liquidated_symbols" in liq_df.columns:
+            liq_df["liquidated_symbols"] = (
+                liq_df["liquidated_symbols"].astype(str).str.replace(",", ", ")
+            )
+        liquidation_view = _rename_table_columns(
+            liq_df[cols],
+            {
+                "timestamp": "时间戳 (Timestamp)",
+                "date": "日期 (Date)",
+                "daily_interest": "当日利息 (Daily Interest)",
+                "liquidated_count": "强平标的数 (Liquidated Count)",
+                "liquidated_symbols": "强平标的 (Liquidated Symbols)",
+                "priority": "强平顺序 (Priority)",
+            },
+        )
+        liquidation_audit_html = _format_table(
+            liquidation_view,
+            max_rows=20,
+            compact_currency_columns={"当日利息 (Daily Interest)"},
+            compact_currency=compact_currency,
+        )
+    else:
+        liquidation_audit_html = "<div>暂无强平审计数据</div>"
+
     if overview_cards:
         analysis_overview_html = "".join(
             [
@@ -1428,6 +1563,7 @@ def _build_analysis_table_sections(
         "orders_by_strategy_html": orders_by_strategy_html,
         "executions_by_strategy_html": executions_by_strategy_html,
         "risk_by_strategy_html": risk_by_strategy_html,
+        "liquidation_audit_html": liquidation_audit_html,
     }
 
 
@@ -1503,6 +1639,7 @@ def plot_report(
         orders_by_strategy_html=analysis_sections["orders_by_strategy_html"],
         executions_by_strategy_html=analysis_sections["executions_by_strategy_html"],
         risk_by_strategy_html=analysis_sections["risk_by_strategy_html"],
+        liquidation_audit_html=analysis_sections["liquidation_audit_html"],
         risk_charts_html=chart_sections["risk_charts_html"],
     )
 

--- a/python/akquant/risk.py
+++ b/python/akquant/risk.py
@@ -45,6 +45,32 @@ def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
 
     if config.safety_margin is not None:
         rust_config.safety_margin = config.safety_margin
+    account_mode = getattr(config, "account_mode", None)
+    if account_mode is not None:
+        setattr(rust_config, "account_mode", str(account_mode))
+    enable_short_sell = getattr(config, "enable_short_sell", None)
+    if enable_short_sell is not None:
+        setattr(rust_config, "enable_short_sell", bool(enable_short_sell))
+    initial_margin_ratio = getattr(config, "initial_margin_ratio", None)
+    if initial_margin_ratio is not None:
+        setattr(rust_config, "initial_margin_ratio", float(initial_margin_ratio))
+    maintenance_margin_ratio = getattr(config, "maintenance_margin_ratio", None)
+    if maintenance_margin_ratio is not None:
+        setattr(
+            rust_config, "maintenance_margin_ratio", float(maintenance_margin_ratio)
+        )
+    financing_rate_annual = getattr(config, "financing_rate_annual", None)
+    if financing_rate_annual is not None:
+        setattr(rust_config, "financing_rate_annual", float(financing_rate_annual))
+    borrow_rate_annual = getattr(config, "borrow_rate_annual", None)
+    if borrow_rate_annual is not None:
+        setattr(rust_config, "borrow_rate_annual", float(borrow_rate_annual))
+    allow_force_liquidation = getattr(config, "allow_force_liquidation", None)
+    if allow_force_liquidation is not None:
+        setattr(rust_config, "allow_force_liquidation", bool(allow_force_liquidation))
+    liquidation_priority = getattr(config, "liquidation_priority", None)
+    if liquidation_priority is not None:
+        setattr(rust_config, "liquidation_priority", str(liquidation_priority))
 
     # Use the dedicated setter method to ensure the update propagates to the Engine
     # Direct attribute assignment (engine.risk_manager.config = ...) might only

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1286,7 +1286,7 @@ class Strategy:
         """
         return _get_order_impl(self, order_id)
 
-    def get_account(self) -> Dict[str, float]:
+    def get_account(self) -> Dict[str, Any]:
         """
         获取账户资金详情快照.
 
@@ -1297,6 +1297,12 @@ class Strategy:
                 - market_value: 持仓总市值 (equity - cash)
                 - frozen_cash: 当前未完成订单预占资金
                 - margin: 当前仓位占用保证金
+                - borrowed_cash: 融资负债 (现金为负时)
+                - short_market_value: 空头市值
+                - maintenance_ratio: 维持担保比例
+                - account_mode: 账户模式 ("cash" / "margin")
+                - accrued_interest: 累计计提利息
+                - daily_interest: 当日计提利息
         """
         return _get_account_impl(self)
 

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -483,6 +483,26 @@ def _resolve_mark_price(strategy: Any, symbol: str) -> float:
     return 0.0
 
 
+def _is_margin_account(strategy: Any) -> bool:
+    if strategy.ctx is None:
+        return False
+    risk_config = getattr(strategy.ctx, "risk_config", None)
+    account_mode = str(getattr(risk_config, "account_mode", "cash")).strip().lower()
+    return account_mode == "margin"
+
+
+def _stock_margin_ratio(strategy: Any, margin_ratio: float) -> float:
+    if not _is_margin_account(strategy):
+        return margin_ratio
+    if strategy.ctx is None:
+        return margin_ratio
+    risk_config = getattr(strategy.ctx, "risk_config", None)
+    ratio = float(getattr(risk_config, "initial_margin_ratio", margin_ratio))
+    if ratio <= 0.0:
+        return margin_ratio
+    return ratio
+
+
 def _calc_position_margin(strategy: Any, symbol: str, quantity: float) -> float:
     if quantity == 0.0:
         return 0.0
@@ -515,6 +535,8 @@ def _calc_position_margin(strategy: Any, symbol: str, quantity: float) -> float:
             margin_per_unit = price * (1.0 + margin_ratio)
         return max(margin_per_unit, 0.0) * multiplier * abs(qty)
 
+    if asset_type in {"STOCK", "FUND"}:
+        margin_ratio = _stock_margin_ratio(strategy, margin_ratio)
     return abs(qty * price * multiplier) * margin_ratio
 
 
@@ -549,7 +571,7 @@ def _calc_frozen_cash(strategy: Any) -> float:
     return frozen
 
 
-def get_account(strategy: Any) -> Dict[str, float]:
+def get_account(strategy: Any) -> Dict[str, Any]:
     """获取账户资金详情快照."""
     if strategy.ctx is None:
         raise RuntimeError("Context not ready")
@@ -559,12 +581,30 @@ def get_account(strategy: Any) -> Dict[str, float]:
     market_value = float(equity - cash)
     margin = float(_calc_used_margin(strategy))
     frozen_cash = float(_calc_frozen_cash(strategy))
+    borrowed_cash = float(max(-cash, 0.0))
+    short_market_value = 0.0
+    for sym, qty in strategy.ctx.positions.items():
+        qty_f = float(qty)
+        if qty_f >= 0.0:
+            continue
+        short_market_value += abs(qty_f) * _resolve_mark_price(strategy, str(sym))
+    denominator = market_value + short_market_value
+    maintenance_ratio = float(equity / denominator) if denominator > 0.0 else 0.0
+    account_mode = "margin" if _is_margin_account(strategy) else "cash"
+    accrued_interest = float(getattr(strategy.ctx, "margin_accrued_interest", 0.0))
+    daily_interest = float(getattr(strategy.ctx, "margin_daily_interest", 0.0))
     return {
         "cash": cash,
         "equity": equity,
         "market_value": market_value,
         "frozen_cash": frozen_cash,
         "margin": margin,
+        "borrowed_cash": borrowed_cash,
+        "short_market_value": float(short_market_value),
+        "maintenance_ratio": maintenance_ratio,
+        "account_mode": account_mode,
+        "accrued_interest": accrued_interest,
+        "daily_interest": daily_interest,
     }
 
 

--- a/src/analysis/python.rs
+++ b/src/analysis/python.rs
@@ -698,6 +698,34 @@ impl BacktestResult {
         Ok(dict.into())
     }
 
+    pub fn get_liquidation_audits_dict(&self, py: Python) -> PyResult<Py<PyAny>> {
+        let n = self.liquidation_audits.len();
+        let mut timestamps = Vec::with_capacity(n);
+        let mut dates = Vec::with_capacity(n);
+        let mut daily_interests = Vec::with_capacity(n);
+        let mut liquidated_counts = Vec::with_capacity(n);
+        let mut liquidated_symbols = Vec::with_capacity(n);
+        let mut priorities = Vec::with_capacity(n);
+
+        for row in &self.liquidation_audits {
+            timestamps.push(row.timestamp);
+            dates.push(row.date.clone());
+            daily_interests.push(row.daily_interest);
+            liquidated_counts.push(row.liquidated_count as u64);
+            liquidated_symbols.push(row.liquidated_symbols.join(","));
+            priorities.push(row.priority.clone());
+        }
+
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("timestamp", timestamps)?;
+        dict.set_item("date", dates)?;
+        dict.set_item("daily_interest", daily_interests)?;
+        dict.set_item("liquidated_count", liquidated_counts)?;
+        dict.set_item("liquidated_symbols", liquidated_symbols)?;
+        dict.set_item("priority", priorities)?;
+        Ok(dict.into())
+    }
+
     /// Get orders as a DataFrame similar to PyBroker's format.
     #[getter]
     pub fn orders_df(&self, py: Python) -> PyResult<Py<PyAny>> {

--- a/src/analysis/result.rs
+++ b/src/analysis/result.rs
@@ -16,6 +16,7 @@ pub struct CalculatorInput {
     pub initial_cash: Decimal,
     pub orders: Vec<Order>,
     pub executions: Vec<Trade>,
+    pub liquidation_audits: Vec<LiquidationAudit>,
 }
 
 #[gen_stub_pyclass]
@@ -31,6 +32,7 @@ pub struct CalculatorInput {
 /// :ivar snapshots: 每日持仓快照 [(timestamp, [snapshot])]
 /// :ivar orders: 订单列表
 /// :ivar executions: 成交列表
+/// :ivar liquidation_audits: 强平审计记录
 pub struct BacktestResult {
     #[pyo3(get)]
     pub equity_curve: Vec<(i64, f64)>,
@@ -49,6 +51,8 @@ pub struct BacktestResult {
     pub orders: Vec<Order>,
     #[pyo3(get)]
     pub executions: Vec<Trade>,
+    #[pyo3(get)]
+    pub liquidation_audits: Vec<LiquidationAudit>,
 }
 
 impl BacktestResult {
@@ -102,6 +106,7 @@ impl BacktestResult {
                 snapshots: input.snapshots,
                 orders: input.orders,
                 executions: input.executions,
+                liquidation_audits: input.liquidation_audits,
             };
         }
 
@@ -363,6 +368,7 @@ impl BacktestResult {
             snapshots: input.snapshots,
             orders: input.orders,
             executions: input.executions,
+            liquidation_audits: input.liquidation_audits,
         }
     }
 }

--- a/src/analysis/tests.rs
+++ b/src/analysis/tests.rs
@@ -167,6 +167,7 @@ fn test_max_drawdown_logic() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
     assert_eq!(result.metrics.max_drawdown, 0.25);
 
@@ -186,6 +187,7 @@ fn test_max_drawdown_logic() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
     assert_eq!(result_2.metrics.max_drawdown, 0.0);
 
@@ -205,6 +207,7 @@ fn test_max_drawdown_logic() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
     assert_eq!(result_3.metrics.max_drawdown, 0.2);
 
@@ -227,6 +230,7 @@ fn test_max_drawdown_logic() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
     assert_eq!(result_4.metrics.max_drawdown, 0.5);
 }
@@ -259,6 +263,7 @@ fn test_ulcer_index_logic() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
     let expected_ui = 0.004f64.sqrt();
     assert!((result.metrics.ulcer_index - expected_ui).abs() < 1e-9);
@@ -282,6 +287,7 @@ fn test_calmar_uses_raw_drawdown_ratio_not_pct() {
         initial_cash: Decimal::from(100),
         orders: vec![],
         executions: vec![],
+        liquidation_audits: vec![],
     });
 
     let expected_raw_calmar = result.metrics.annualized_return / result.metrics.max_drawdown;

--- a/src/analysis/types.rs
+++ b/src/analysis/types.rs
@@ -77,6 +77,32 @@ impl ClosedTrade {
 
 #[gen_stub_pyclass]
 #[pyclass(from_py_object)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiquidationAudit {
+    #[pyo3(get)]
+    pub timestamp: i64,
+    #[pyo3(get)]
+    pub date: String,
+    #[pyo3(get)]
+    pub daily_interest: f64,
+    #[pyo3(get)]
+    pub liquidated_count: usize,
+    #[pyo3(get)]
+    pub liquidated_symbols: Vec<String>,
+    #[pyo3(get)]
+    pub priority: String,
+}
+
+#[gen_stub_pymethods]
+#[pymethods]
+impl LiquidationAudit {
+    pub fn __repr__(&self) -> String {
+        format!("{:?}", self)
+    }
+}
+
+#[gen_stub_pyclass]
+#[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 /// 绩效指标.
 ///

--- a/src/context.rs
+++ b/src/context.rs
@@ -31,6 +31,7 @@ pub struct EngineContext<'a> {
     pub current_time: i64,
     pub session: TradingSession,
     pub active_orders: &'a [Order],
+    pub risk_config: &'a RiskConfig,
 }
 
 pub struct ContextInit {
@@ -47,6 +48,8 @@ pub struct ContextInit {
     pub event_tx: Option<Sender<Event>>,
     pub risk_config: RiskConfig,
     pub strategy_id: Option<String>,
+    pub margin_accrued_interest: f64,
+    pub margin_daily_interest: f64,
 }
 
 pub struct ContextUpdate {
@@ -59,6 +62,8 @@ pub struct ContextUpdate {
     pub closed_trades: Arc<Vec<ClosedTrade>>,
     pub recent_trades: Vec<Trade>,
     pub recent_rejected_orders: Vec<Order>,
+    pub margin_accrued_interest: f64,
+    pub margin_daily_interest: f64,
 }
 
 impl StrategyContext {
@@ -91,6 +96,8 @@ impl StrategyContext {
 
         self.recent_trades = update.recent_trades;
         self.recent_rejected_orders = update.recent_rejected_orders;
+        self.margin_accrued_interest = update.margin_accrued_interest;
+        self.margin_daily_interest = update.margin_daily_interest;
 
         // Reset accumulators
         self.orders.clear();
@@ -158,6 +165,10 @@ pub struct StrategyContext {
     pub risk_config: RiskConfig,
     #[pyo3(get)]
     pub strategy_id: Option<String>,
+    #[pyo3(get)]
+    pub margin_accrued_interest: f64,
+    #[pyo3(get)]
+    pub margin_daily_interest: f64,
 }
 
 impl StrategyContext {
@@ -183,6 +194,8 @@ impl StrategyContext {
             event_tx: init.event_tx,
             risk_config: init.risk_config,
             strategy_id: init.strategy_id,
+            margin_accrued_interest: init.margin_accrued_interest,
+            margin_daily_interest: init.margin_daily_interest,
         }
     }
 }
@@ -214,6 +227,8 @@ impl StrategyContext {
         recent_trades: Option<Vec<Trade>>,
         risk_config: Option<RiskConfig>,
         strategy_id: Option<String>,
+        margin_accrued_interest: Option<f64>,
+        margin_daily_interest: Option<f64>,
     ) -> PyResult<Self> {
         let pos_dec: HashMap<String, Decimal> = positions
             .into_iter()
@@ -245,6 +260,8 @@ impl StrategyContext {
             event_tx: None,
             risk_config: risk_config.unwrap_or_default(),
             strategy_id,
+            margin_accrued_interest: margin_accrued_interest.unwrap_or(0.0),
+            margin_daily_interest: margin_daily_interest.unwrap_or(0.0),
         })
     }
 

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -99,6 +99,8 @@ pub struct Engine {
     pub(crate) strategy_last_pnl: HashMap<String, Decimal>,
     pub(crate) strategy_peak_pnl: HashMap<String, Decimal>,
     pub(crate) strategy_reduce_only_active: HashSet<String>,
+    pub(crate) margin_accrued_interest: Decimal,
+    pub(crate) margin_daily_interest: Decimal,
     pub(crate) snapshot_time: i64,
     pub(crate) stream_callback: Option<Py<PyAny>>,
     pub(crate) stream_run_id: Option<String>,
@@ -557,6 +559,14 @@ impl Engine {
                         closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
                         recent_trades: step_trades,
                         recent_rejected_orders: step_rejected_orders,
+                        margin_accrued_interest: self
+                            .margin_accrued_interest
+                            .to_f64()
+                            .unwrap_or_default(),
+                        margin_daily_interest: self
+                            .margin_daily_interest
+                            .to_f64()
+                            .unwrap_or_default(),
                     });
                 }
                 Ok::<_, PyErr>(py_ctx)
@@ -858,6 +868,8 @@ impl Engine {
             event_tx: Some(self.event_manager.sender()),
             risk_config: self.risk_manager.config.clone(),
             strategy_id,
+            margin_accrued_interest: self.margin_accrued_interest.to_f64().unwrap_or_default(),
+            margin_daily_interest: self.margin_daily_interest.to_f64().unwrap_or_default(),
         })
     }
 

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -522,6 +522,8 @@ impl Engine {
             strategy_last_pnl: HashMap::new(),
             strategy_peak_pnl: HashMap::new(),
             strategy_reduce_only_active: std::collections::HashSet::new(),
+            margin_accrued_interest: Decimal::ZERO,
+            margin_daily_interest: Decimal::ZERO,
             snapshot_time: 0,
             stream_callback: None,
             stream_run_id: None,

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -227,7 +227,14 @@ impl ExecutionClient for SimulatedExecutionClient {
                                 );
 
                                 let multiplier = instrument.multiplier();
-                                let margin_ratio = instrument.margin_ratio();
+                                let margin_ratio = if ctx.risk_config.is_margin_account()
+                                    && (instrument.asset_type == AssetType::Stock
+                                        || instrument.asset_type == AssetType::Fund)
+                                {
+                                    ctx.risk_config.stock_initial_margin_ratio()
+                                } else {
+                                    instrument.margin_ratio()
+                                };
 
                                 // Margin Required = Price * Qty * Multiplier * MarginRatio
                                 let margin_required =
@@ -462,7 +469,7 @@ mod tests {
             available_positions: HashMap::new().into(),
         };
         let last_prices = HashMap::new();
-        let _risk_manager = crate::risk::RiskManager::new();
+        let risk_manager = crate::risk::RiskManager::new();
 
         let china_config = crate::market::ChinaMarketConfig {
             stock: Some(crate::market::stock::StockConfig::default()),
@@ -482,6 +489,7 @@ mod tests {
             current_time: 0,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &risk_manager.config,
         };
 
         let events = sim.on_event(&event, &ctx);
@@ -542,7 +550,7 @@ mod tests {
             available_positions: HashMap::new().into(),
         };
         let last_prices = HashMap::new();
-        let _risk_manager = crate::risk::RiskManager::new();
+        let risk_manager = crate::risk::RiskManager::new();
 
         let china_config = crate::market::ChinaMarketConfig {
             stock: Some(crate::market::stock::StockConfig::default()),
@@ -562,6 +570,7 @@ mod tests {
             current_time: 0,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &risk_manager.config,
         };
 
         let events = sim.on_event(&event, &ctx);
@@ -610,7 +619,7 @@ mod tests {
             available_positions: HashMap::new().into(),
         };
         let last_prices = HashMap::new();
-        let _risk_manager = crate::risk::RiskManager::new();
+        let risk_manager = crate::risk::RiskManager::new();
 
         let china_config = crate::market::ChinaMarketConfig {
             stock: Some(crate::market::stock::StockConfig::default()),
@@ -630,6 +639,7 @@ mod tests {
             current_time: 0,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &risk_manager.config,
         };
 
         let events = sim.on_event(&event, &ctx);
@@ -678,7 +688,7 @@ mod tests {
             available_positions: HashMap::new().into(),
         };
         let last_prices = HashMap::new();
-        let _risk_manager = crate::risk::RiskManager::new();
+        let risk_manager = crate::risk::RiskManager::new();
 
         let china_config = crate::market::ChinaMarketConfig {
             stock: Some(crate::market::stock::StockConfig::default()),
@@ -698,6 +708,7 @@ mod tests {
             current_time: 0,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &risk_manager.config,
         };
 
         let events = sim.on_event(&event, &ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ mod risk;
 pub mod settlement;
 pub mod statistics;
 
-use analysis::{BacktestResult, ClosedTrade, PerformanceMetrics, TradePnL};
+use analysis::{BacktestResult, ClosedTrade, LiquidationAudit, PerformanceMetrics, TradePnL};
 use context::StrategyContext;
 use data::{BarAggregator, DataFeed, from_arrays};
 use engine::Engine;
@@ -64,6 +64,7 @@ fn akquant(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<BacktestResult>()?;
     m.add_class::<TradePnL>()?;
     m.add_class::<ClosedTrade>()?;
+    m.add_class::<LiquidationAudit>()?;
     m.add_class::<RiskManager>()?;
     m.add_class::<RiskConfig>()?;
     indicators::register_py_classes(m)?;

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -59,6 +59,7 @@ fn process_order_request(engine: &mut Engine, py: Python<'_>, mut order: Order) 
             current_time: engine.clock.timestamp().unwrap_or(0),
             session: engine.clock.session,
             active_orders: &engine.state.order_manager.active_orders,
+            risk_config: &engine.risk_manager.config,
         };
         engine.risk_manager.check_and_adjust(&mut order, &ctx)
     };
@@ -138,6 +139,7 @@ fn emit_execution_reports_for_current_event(engine: &mut Engine) {
         current_time: engine.clock.timestamp().unwrap_or(0),
         session: engine.clock.session,
         active_orders: &engine.state.order_manager.active_orders,
+        risk_config: &engine.risk_manager.config,
     };
 
     let reports = engine.execution_model.on_event(&event, &ctx);
@@ -532,13 +534,58 @@ impl Processor for DataProcessor {
                         instruments: &engine.instruments,
                         last_prices: &engine.last_prices,
                         market_manager: &engine.market_manager,
+                        risk_config: &engine.risk_manager.config,
                     };
-                    engine.settlement_manager.process_daily_settlement(
+                    let settlement_outcome = engine.settlement_manager.process_daily_settlement(
                         &mut engine.state.portfolio,
                         &mut engine.state.order_manager.active_orders,
                         &mut expired_orders,
                         &settlement_ctx,
                     );
+                    engine.margin_daily_interest = settlement_outcome.daily_interest;
+                    engine.margin_accrued_interest += settlement_outcome.daily_interest;
+                    if settlement_outcome.daily_interest > Decimal::ZERO {
+                        let mut settlement_payload = HashMap::new();
+                        settlement_payload.insert("date", local_date.to_string());
+                        settlement_payload.insert(
+                            "daily_interest",
+                            settlement_outcome.daily_interest.to_string(),
+                        );
+                        settlement_payload.insert(
+                            "accrued_interest",
+                            engine.margin_accrued_interest.to_string(),
+                        );
+                        engine.emit_stream_event(py, "settlement", None, "info", settlement_payload);
+                    }
+                    if settlement_outcome.forced_liquidation {
+                        let liquidated_symbols = settlement_outcome.liquidated_symbols.clone();
+                        let priority = engine.risk_manager.config.liquidation_priority.clone();
+                        engine.statistics_manager.record_liquidation_audit(
+                            crate::analysis::LiquidationAudit {
+                                timestamp,
+                                date: local_date.to_string(),
+                                daily_interest: settlement_outcome
+                                    .daily_interest
+                                    .to_f64()
+                                    .unwrap_or_default(),
+                                liquidated_count: liquidated_symbols.len(),
+                                liquidated_symbols: liquidated_symbols.clone(),
+                                priority: priority.clone(),
+                            },
+                        );
+                        let mut risk_payload = HashMap::new();
+                        risk_payload.insert("date", local_date.to_string());
+                        risk_payload.insert(
+                            "liquidated_count",
+                            liquidated_symbols.len().to_string(),
+                        );
+                        risk_payload.insert(
+                            "liquidated_symbols",
+                            liquidated_symbols.join(","),
+                        );
+                        risk_payload.insert("priority", priority);
+                        engine.emit_stream_event(py, "risk", None, "warn", risk_payload);
+                    }
 
                     for o in expired_orders {
                         engine.state.order_manager.orders.push(o);
@@ -794,6 +841,7 @@ impl Processor for ExecutionProcessor {
                         current_time: engine.clock.timestamp().unwrap_or(0),
                         session: engine.clock.session,
                         active_orders: &engine.state.order_manager.active_orders,
+                        risk_config: &engine.risk_manager.config,
                     };
 
                     let reports = engine.execution_model.on_event(&event, &ctx);

--- a/src/risk/common.rs
+++ b/src/risk/common.rs
@@ -1,7 +1,8 @@
 use crate::error::AkQuantError;
-use crate::model::{Order, OrderSide};
+use crate::model::{AssetType, Order, OrderSide};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
+use std::collections::HashMap;
 
 use super::rule::{RiskCheckContext, RiskRule};
 
@@ -146,27 +147,14 @@ impl RiskRule for CashMarginRule {
             let mut prices_for_order = ctx.current_prices.clone();
             prices_for_order.insert(order.symbol.clone(), order_price);
 
-            let mut projected_portfolio = ctx.portfolio.clone();
-            let base_used = projected_portfolio
-                .calculate_used_margin(&prices_for_order, ctx.instruments);
-            {
-                let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
-                let entry = positions
-                    .entry(order.symbol.clone())
-                    .or_insert(Decimal::ZERO);
-                match order.side {
-                    OrderSide::Buy => *entry += order.quantity,
-                    OrderSide::Sell => *entry -= order.quantity,
-                }
-            }
-            let next_used = projected_portfolio
-                .calculate_used_margin(&prices_for_order, ctx.instruments);
-            let required_margin = (next_used - base_used).max(Decimal::ZERO);
+            let required_margin =
+                calc_required_margin_delta(order, ctx, &prices_for_order, ctx.portfolio);
 
             if required_margin.is_zero() {
                 return Ok(());
             }
 
+            let mut projected_portfolio = ctx.portfolio.clone();
             let mut committed_margin = Decimal::ZERO;
             for o in ctx.active_orders {
                 if o.status != crate::model::OrderStatus::New {
@@ -181,20 +169,19 @@ impl RiskRule for CashMarginRule {
                 };
                 let mut prices_for_active = ctx.current_prices.clone();
                 prices_for_active.insert(o.symbol.clone(), active_price);
+                committed_margin += calc_required_margin_delta(
+                    o,
+                    ctx,
+                    &prices_for_active,
+                    &projected_portfolio,
+                );
 
-                let before_used = projected_portfolio
-                    .calculate_used_margin(&prices_for_active, ctx.instruments);
-                {
-                    let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
-                    let entry = positions.entry(o.symbol.clone()).or_insert(Decimal::ZERO);
-                    match o.side {
-                        OrderSide::Buy => *entry += o.quantity,
-                        OrderSide::Sell => *entry -= o.quantity,
-                    }
+                let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
+                let entry = positions.entry(o.symbol.clone()).or_insert(Decimal::ZERO);
+                match o.side {
+                    OrderSide::Buy => *entry += o.quantity,
+                    OrderSide::Sell => *entry -= o.quantity,
                 }
-                let after_used = projected_portfolio
-                    .calculate_used_margin(&prices_for_active, ctx.instruments);
-                committed_margin += (after_used - before_used).max(Decimal::ZERO);
             }
 
             let free_margin = ctx
@@ -217,4 +204,68 @@ impl RiskRule for CashMarginRule {
     fn clone_box(&self) -> Box<dyn RiskRule> {
         Box::new(self.clone())
     }
+}
+
+fn stock_margin_delta(
+    order: &Order,
+    current_pos: Decimal,
+    price: Decimal,
+    multiplier: Decimal,
+    initial_margin_ratio: Decimal,
+) -> Decimal {
+    let current_abs = current_pos.abs();
+    let next_pos = match order.side {
+        OrderSide::Buy => current_pos + order.quantity,
+        OrderSide::Sell => current_pos - order.quantity,
+    };
+    let next_abs = next_pos.abs();
+    let current_margin = current_abs * price * multiplier * initial_margin_ratio;
+    let next_margin = next_abs * price * multiplier * initial_margin_ratio;
+    (next_margin - current_margin).max(Decimal::ZERO)
+}
+
+fn calc_required_margin_delta(
+    order: &Order,
+    ctx: &RiskCheckContext,
+    prices: &HashMap<String, Decimal>,
+    portfolio: &crate::portfolio::Portfolio,
+) -> Decimal {
+    if let Some(instr) = ctx.instruments.get(&order.symbol) {
+        if ctx.config.is_margin_account()
+            && (instr.asset_type == AssetType::Stock || instr.asset_type == AssetType::Fund)
+        {
+            let price = prices
+                .get(&order.symbol)
+                .copied()
+                .unwrap_or_else(|| order.price.unwrap_or(Decimal::ZERO));
+            if price <= Decimal::ZERO {
+                return Decimal::ZERO;
+            }
+            let current_pos = portfolio
+                .positions
+                .get(&order.symbol)
+                .copied()
+                .unwrap_or(Decimal::ZERO);
+            return stock_margin_delta(
+                order,
+                current_pos,
+                price,
+                instr.multiplier(),
+                ctx.config.stock_initial_margin_ratio(),
+            );
+        }
+    }
+
+    let mut projected_portfolio = portfolio.clone();
+    let base_used = projected_portfolio.calculate_used_margin(prices, ctx.instruments);
+    {
+        let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
+        let entry = positions.entry(order.symbol.clone()).or_insert(Decimal::ZERO);
+        match order.side {
+            OrderSide::Buy => *entry += order.quantity,
+            OrderSide::Sell => *entry -= order.quantity,
+        }
+    }
+    let next_used = projected_portfolio.calculate_used_margin(prices, ctx.instruments);
+    (next_used - base_used).max(Decimal::ZERO)
 }

--- a/src/risk/config.rs
+++ b/src/risk/config.rs
@@ -20,6 +20,22 @@ pub struct RiskConfig {
     pub check_cash: bool,
     #[pyo3(get, set)]
     pub safety_margin: f64,
+    #[pyo3(get, set)]
+    pub account_mode: String,
+    #[pyo3(get, set)]
+    pub enable_short_sell: bool,
+    #[pyo3(get, set)]
+    pub initial_margin_ratio: f64,
+    #[pyo3(get, set)]
+    pub maintenance_margin_ratio: f64,
+    #[pyo3(get, set)]
+    pub financing_rate_annual: f64,
+    #[pyo3(get, set)]
+    pub borrow_rate_annual: f64,
+    #[pyo3(get, set)]
+    pub allow_force_liquidation: bool,
+    #[pyo3(get, set)]
+    pub liquidation_priority: String,
 }
 
 #[pymethods]
@@ -34,6 +50,14 @@ impl RiskConfig {
             active: true,
             check_cash: true,
             safety_margin: 0.0001,
+            account_mode: "cash".to_string(),
+            enable_short_sell: false,
+            initial_margin_ratio: 1.0,
+            maintenance_margin_ratio: 0.3,
+            financing_rate_annual: 0.08,
+            borrow_rate_annual: 0.10,
+            allow_force_liquidation: true,
+            liquidation_priority: "short_first".to_string(),
         }
     }
 
@@ -78,5 +102,23 @@ impl RiskConfig {
             None => None,
         };
         Ok(())
+    }
+}
+
+impl RiskConfig {
+    pub fn is_margin_account(&self) -> bool {
+        self.account_mode.eq_ignore_ascii_case("margin")
+    }
+
+    pub fn stock_initial_margin_ratio(&self) -> Decimal {
+        Decimal::from_f64(self.initial_margin_ratio).unwrap_or(Decimal::ONE)
+    }
+
+    pub fn maintenance_margin_ratio_decimal(&self) -> Decimal {
+        Decimal::from_f64(self.maintenance_margin_ratio).unwrap_or(Decimal::ZERO)
+    }
+
+    pub fn liquidation_short_first(&self) -> bool {
+        !self.liquidation_priority.eq_ignore_ascii_case("long_first")
     }
 }

--- a/src/risk/manager.rs
+++ b/src/risk/manager.rs
@@ -84,6 +84,7 @@ impl RiskManager {
             current_time: 0,
             session: crate::model::TradingSession::Continuous,
             active_orders: &active_orders,
+            risk_config: &self.config,
         };
 
         match self.check_internal(order, &ctx) {
@@ -204,7 +205,14 @@ impl RiskManager {
 
                 if price > Decimal::ZERO {
                     let multiplier = instr.multiplier();
-                    let margin_ratio = instr.margin_ratio();
+                    let margin_ratio = if self.config.is_margin_account()
+                        && (instr.asset_type == AssetType::Stock
+                            || instr.asset_type == AssetType::Fund)
+                    {
+                        self.config.stock_initial_margin_ratio()
+                    } else {
+                        instr.margin_ratio()
+                    };
 
                     // Cost per unit = Price * Multiplier * MarginRatio
                     // For Stock, MarginRatio is usually 1.0 (or 100% cash)

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -154,6 +154,7 @@ mod tests {
             current_time: 1_700_000_000_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         assert!(manager.check_internal(&order, &ctx_high).is_ok());
 
@@ -169,6 +170,7 @@ mod tests {
             current_time: 1_700_000_100_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         let err = manager
             .check_internal(&order, &ctx_low)
@@ -213,6 +215,7 @@ mod tests {
             current_time: day1_open,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         assert!(manager.check_internal(&order, &ctx_day1_start).is_ok());
 
@@ -228,6 +231,7 @@ mod tests {
             current_time: day1_open + 10_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         let err = manager
             .check_internal(&order, &ctx_day1_drop)
@@ -247,6 +251,7 @@ mod tests {
             current_time: day1_open + 86_400_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         assert!(manager.check_internal(&order, &ctx_day2_start).is_ok());
     }
@@ -286,6 +291,7 @@ mod tests {
             current_time: 1_700_000_000_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         assert!(manager.check_internal(&order, &ctx_start).is_ok());
 
@@ -301,6 +307,7 @@ mod tests {
             current_time: 1_700_000_100_000_000_000,
             session: TradingSession::Continuous,
             active_orders: &[],
+            risk_config: &manager.config,
         };
         let err = manager
             .check_internal(&order, &ctx_drop)

--- a/src/risk/stock.rs
+++ b/src/risk/stock.rs
@@ -15,6 +15,9 @@ impl RiskRule for StockAvailablePositionRule {
 
     fn check(&self, order: &Order, ctx: &RiskCheckContext) -> Result<(), AkQuantError> {
         if order.side == OrderSide::Sell {
+            if ctx.config.is_margin_account() && ctx.config.enable_short_sell {
+                return Ok(());
+            }
             let available = ctx
                 .portfolio
                 .available_positions
@@ -215,5 +218,53 @@ mod tests {
         let rule = StockAvailablePositionRule;
         let result = rule.check(&new_sell, &ctx);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_margin_account_can_short_sell_without_available_position() {
+        let symbol = "sz300274".to_string();
+        let portfolio = Portfolio {
+            cash: Decimal::from(1_000_000),
+            positions: Arc::new(HashMap::new()),
+            available_positions: Arc::new(HashMap::new()),
+        };
+
+        let instrument = Instrument {
+            asset_type: AssetType::Stock,
+            inner: InstrumentEnum::Stock(StockInstrument {
+                symbol: symbol.clone(),
+                lot_size: Decimal::from(100),
+                tick_size: Decimal::new(1, 2),
+                expiry_date: None,
+            }),
+        };
+
+        let mut instruments = HashMap::new();
+        instruments.insert(symbol.clone(), instrument.clone());
+        let current_prices = HashMap::new();
+        let mut config = RiskConfig::new();
+        config.account_mode = "margin".to_string();
+        config.enable_short_sell = true;
+
+        let active_orders: Vec<Order> = vec![];
+        let ctx = make_context(
+            &portfolio,
+            &instrument,
+            &instruments,
+            &active_orders,
+            &current_prices,
+            &config,
+        );
+
+        let new_sell = make_order(
+            "o2",
+            &symbol,
+            OrderSide::Sell,
+            Decimal::from(100),
+            OrderStatus::New,
+        );
+        let rule = StockAvailablePositionRule;
+        let result = rule.check(&new_sell, &ctx);
+        assert!(result.is_ok());
     }
 }

--- a/src/settlement/manager.rs
+++ b/src/settlement/manager.rs
@@ -1,8 +1,10 @@
 use crate::market::manager::MarketManager;
 use crate::model::{Instrument, Order, OrderStatus, TimeInForce};
 use crate::portfolio::Portfolio;
+use crate::risk::RiskConfig;
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -16,6 +18,14 @@ pub struct SettlementContext<'a> {
     pub instruments: &'a HashMap<String, Instrument>,
     pub last_prices: &'a HashMap<String, Decimal>,
     pub market_manager: &'a MarketManager,
+    pub risk_config: &'a RiskConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SettlementOutcome {
+    pub daily_interest: Decimal,
+    pub forced_liquidation: bool,
+    pub liquidated_symbols: Vec<String>,
 }
 
 /// Settlement Manager
@@ -44,7 +54,9 @@ impl SettlementManager {
         active_orders: &mut Vec<Order>,
         expired_orders_out: &mut Vec<Order>,
         ctx: &SettlementContext,
-    ) {
+    ) -> SettlementOutcome {
+        let outcome = self.process_margin_interest_and_liquidation(portfolio, ctx);
+
         // 1. Market Settlement (T+1 logic)
         // Note: MarketManager::on_day_close handles T+1 by moving positions from 'positions' to 'available_positions'
         // But wait, `portfolio.positions` is T+0/Total, `available_positions` is Sellable.
@@ -113,11 +125,372 @@ impl SettlementManager {
             o.status = OrderStatus::Expired;
             expired_orders_out.push(o);
         }
+        outcome
     }
+
+    fn process_margin_interest_and_liquidation(
+        &self,
+        portfolio: &mut Portfolio,
+        ctx: &SettlementContext,
+    ) -> SettlementOutcome {
+        let mut outcome = SettlementOutcome::default();
+        if !ctx.risk_config.is_margin_account() {
+            return outcome;
+        }
+
+        let (_, _, short_market_value) =
+            compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
+
+        let borrowed_cash = (-portfolio.cash).max(Decimal::ZERO);
+        let financing_rate = Decimal::from_f64(ctx.risk_config.financing_rate_annual)
+            .unwrap_or(Decimal::ZERO);
+        let borrow_rate =
+            Decimal::from_f64(ctx.risk_config.borrow_rate_annual).unwrap_or(Decimal::ZERO);
+        let day_divisor = Decimal::from(365);
+        let financing_interest = borrowed_cash * financing_rate / day_divisor;
+        let borrow_interest = short_market_value * borrow_rate / day_divisor;
+        let total_interest = (financing_interest + borrow_interest).max(Decimal::ZERO);
+        if total_interest > Decimal::ZERO {
+            portfolio.cash -= total_interest;
+            outcome.daily_interest = total_interest;
+        }
+
+        if !ctx.risk_config.allow_force_liquidation {
+            return outcome;
+        }
+
+        let (_, equity, gross_exposure) =
+            compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
+        if gross_exposure <= Decimal::ZERO {
+            return outcome;
+        }
+        let maintenance_ratio = equity / gross_exposure;
+        if maintenance_ratio >= ctx.risk_config.maintenance_margin_ratio_decimal() {
+            return outcome;
+        }
+
+        let mut symbols_to_close: Vec<(String, Decimal)> = portfolio
+            .positions
+            .iter()
+            .filter_map(|(symbol, qty)| {
+                if qty.is_zero() {
+                    return None;
+                }
+                let price = ctx.last_prices.get(symbol).copied()?;
+                if price <= Decimal::ZERO {
+                    return None;
+                }
+                let multiplier = ctx
+                    .instruments
+                    .get(symbol)
+                    .map(|i| i.multiplier())
+                    .unwrap_or(Decimal::ONE);
+                Some((symbol.clone(), qty.abs() * price * multiplier))
+            })
+            .collect();
+        let short_first = ctx.risk_config.liquidation_short_first();
+        symbols_to_close.sort_by(|(left_symbol, left_exposure), (right_symbol, right_exposure)| {
+            let left_qty = portfolio
+                .positions
+                .get(left_symbol)
+                .copied()
+                .unwrap_or(Decimal::ZERO);
+            let right_qty = portfolio
+                .positions
+                .get(right_symbol)
+                .copied()
+                .unwrap_or(Decimal::ZERO);
+            let left_rank = if short_first {
+                if left_qty < Decimal::ZERO { 0 } else { 1 }
+            } else if left_qty > Decimal::ZERO {
+                0
+            } else {
+                1
+            };
+            let right_rank = if short_first {
+                if right_qty < Decimal::ZERO { 0 } else { 1 }
+            } else if right_qty > Decimal::ZERO {
+                0
+            } else {
+                1
+            };
+            left_rank
+                .cmp(&right_rank)
+                .then_with(|| right_exposure.cmp(left_exposure))
+        });
+
+        let symbols_to_close: Vec<String> =
+            symbols_to_close.into_iter().map(|(symbol, _)| symbol).collect();
+        for symbol in symbols_to_close {
+            let qty = portfolio
+                .positions
+                .get(&symbol)
+                .copied()
+                .unwrap_or(Decimal::ZERO);
+            if qty.is_zero() {
+                continue;
+            }
+            let Some(price) = ctx.last_prices.get(&symbol).copied() else {
+                continue;
+            };
+            let multiplier = ctx
+                .instruments
+                .get(&symbol)
+                .map(|i| i.multiplier())
+                .unwrap_or(Decimal::ONE);
+            portfolio.cash += qty * price * multiplier;
+
+            {
+                let positions = Arc::make_mut(&mut portfolio.positions);
+                positions.remove(&symbol);
+            }
+            {
+                let avail_pos = Arc::make_mut(&mut portfolio.available_positions);
+                avail_pos.remove(&symbol);
+            }
+            outcome.liquidated_symbols.push(symbol.clone());
+
+            let (_, next_equity, next_exposure) =
+                compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
+            if next_exposure <= Decimal::ZERO {
+                break;
+            }
+            let next_ratio = next_equity / next_exposure;
+            if next_ratio >= ctx.risk_config.maintenance_margin_ratio_decimal() {
+                break;
+            }
+        }
+        outcome.forced_liquidation = true;
+        outcome
+    }
+}
+
+fn compute_portfolio_metrics(
+    portfolio: &Portfolio,
+    prices: &HashMap<String, Decimal>,
+    instruments: &HashMap<String, Instrument>,
+) -> (Decimal, Decimal, Decimal) {
+    let mut gross_exposure = Decimal::ZERO;
+    for (symbol, quantity) in portfolio.positions.iter() {
+        if quantity.is_zero() {
+            continue;
+        }
+        let Some(price) = prices.get(symbol).copied() else {
+            continue;
+        };
+        if price <= Decimal::ZERO {
+            continue;
+        }
+        let multiplier = instruments
+            .get(symbol)
+            .map(|i| i.multiplier())
+            .unwrap_or(Decimal::ONE);
+        gross_exposure += quantity.abs() * price * multiplier;
+    }
+    let equity = portfolio.calculate_equity(prices, instruments);
+    (portfolio.cash, equity, gross_exposure)
 }
 
 impl Default for SettlementManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::instrument::{InstrumentEnum, StockInstrument};
+    use crate::model::types::AssetType;
+    use std::str::FromStr;
+
+    fn stock_instrument(symbol: &str) -> Instrument {
+        Instrument {
+            asset_type: AssetType::Stock,
+            inner: InstrumentEnum::Stock(StockInstrument {
+                symbol: symbol.to_string(),
+                lot_size: Decimal::ONE,
+                tick_size: Decimal::new(1, 2),
+                expiry_date: None,
+            }),
+        }
+    }
+
+    #[test]
+    fn test_margin_interest_is_deducted_daily() {
+        let mut portfolio = Portfolio {
+            cash: Decimal::from(-5000),
+            positions: Arc::new(HashMap::new()),
+            available_positions: Arc::new(HashMap::new()),
+        };
+        let mut instruments = HashMap::new();
+        instruments.insert("AAA".to_string(), stock_instrument("AAA"));
+        let mut prices = HashMap::new();
+        prices.insert("AAA".to_string(), Decimal::from(100));
+        let mut risk = RiskConfig::new();
+        risk.account_mode = "margin".to_string();
+        risk.financing_rate_annual = 36.5;
+        risk.borrow_rate_annual = 0.0;
+        risk.allow_force_liquidation = false;
+        let market_manager = MarketManager::new();
+
+        let ctx = SettlementContext {
+            date: NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date"),
+            instruments: &instruments,
+            last_prices: &prices,
+            market_manager: &market_manager,
+            risk_config: &risk,
+        };
+        let outcome = SettlementManager::new().process_daily_settlement(
+            &mut portfolio,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &ctx,
+        );
+        assert_eq!(portfolio.cash, Decimal::from(-5500));
+        assert_eq!(outcome.daily_interest, Decimal::from(500));
+        assert!(!outcome.forced_liquidation);
+    }
+
+    #[test]
+    fn test_margin_liquidation_closes_positions_when_maintenance_breached() {
+        let mut pos = HashMap::new();
+        pos.insert("AAA".to_string(), Decimal::from_str("150").expect("decimal"));
+        let mut portfolio = Portfolio {
+            cash: Decimal::from(-5000),
+            positions: Arc::new(pos),
+            available_positions: Arc::new(HashMap::new()),
+        };
+        let mut instruments = HashMap::new();
+        instruments.insert("AAA".to_string(), stock_instrument("AAA"));
+        let mut prices = HashMap::new();
+        prices.insert("AAA".to_string(), Decimal::from(20));
+        let mut risk = RiskConfig::new();
+        risk.account_mode = "margin".to_string();
+        risk.financing_rate_annual = 0.0;
+        risk.borrow_rate_annual = 0.0;
+        risk.allow_force_liquidation = true;
+        risk.maintenance_margin_ratio = 0.5;
+        let market_manager = MarketManager::new();
+
+        let ctx = SettlementContext {
+            date: NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date"),
+            instruments: &instruments,
+            last_prices: &prices,
+            market_manager: &market_manager,
+            risk_config: &risk,
+        };
+        let outcome = SettlementManager::new().process_daily_settlement(
+            &mut portfolio,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &ctx,
+        );
+        assert!(portfolio.positions.is_empty());
+        assert!(portfolio.available_positions.is_empty());
+        assert_eq!(portfolio.cash, Decimal::from(-2000));
+        assert!(outcome.forced_liquidation);
+        assert_eq!(outcome.liquidated_symbols, vec!["AAA".to_string()]);
+    }
+
+    #[test]
+    fn test_liquidation_priority_controls_close_order() {
+        let mut positions = HashMap::new();
+        positions.insert("LONG".to_string(), Decimal::from(100));
+        positions.insert("SHORT".to_string(), Decimal::from(-50));
+
+        let mut instruments = HashMap::new();
+        instruments.insert("LONG".to_string(), stock_instrument("LONG"));
+        instruments.insert("SHORT".to_string(), stock_instrument("SHORT"));
+
+        let mut prices = HashMap::new();
+        prices.insert("LONG".to_string(), Decimal::from(100));
+        prices.insert("SHORT".to_string(), Decimal::from(100));
+
+        let mut risk_short_first = RiskConfig::new();
+        risk_short_first.account_mode = "margin".to_string();
+        risk_short_first.allow_force_liquidation = true;
+        risk_short_first.financing_rate_annual = 0.0;
+        risk_short_first.borrow_rate_annual = 0.0;
+        risk_short_first.maintenance_margin_ratio = 0.5;
+        risk_short_first.liquidation_priority = "short_first".to_string();
+
+        let mut risk_long_first = risk_short_first.clone();
+        risk_long_first.liquidation_priority = "long_first".to_string();
+
+        let market_manager = MarketManager::new();
+        let date = NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date");
+
+        let mut portfolio_short_first = Portfolio {
+            cash: Decimal::from(2000),
+            positions: Arc::new(positions.clone()),
+            available_positions: Arc::new(HashMap::new()),
+        };
+        let ctx_short_first = SettlementContext {
+            date,
+            instruments: &instruments,
+            last_prices: &prices,
+            market_manager: &market_manager,
+            risk_config: &risk_short_first,
+        };
+        let outcome_short_first = SettlementManager::new().process_daily_settlement(
+            &mut portfolio_short_first,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &ctx_short_first,
+        );
+        assert_eq!(
+            portfolio_short_first
+                .positions
+                .get("SHORT")
+                .copied()
+                .unwrap_or(Decimal::ZERO),
+            Decimal::ZERO
+        );
+        assert_eq!(
+            portfolio_short_first
+                .positions
+                .get("LONG")
+                .copied()
+                .unwrap_or(Decimal::ZERO),
+            Decimal::from(100)
+        );
+        assert_eq!(outcome_short_first.liquidated_symbols, vec!["SHORT".to_string()]);
+
+        let mut portfolio_long_first = Portfolio {
+            cash: Decimal::from(2000),
+            positions: Arc::new(positions),
+            available_positions: Arc::new(HashMap::new()),
+        };
+        let ctx_long_first = SettlementContext {
+            date,
+            instruments: &instruments,
+            last_prices: &prices,
+            market_manager: &market_manager,
+            risk_config: &risk_long_first,
+        };
+        let outcome_long_first = SettlementManager::new().process_daily_settlement(
+            &mut portfolio_long_first,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &ctx_long_first,
+        );
+        assert_eq!(
+            portfolio_long_first
+                .positions
+                .get("LONG")
+                .copied()
+                .unwrap_or(Decimal::ZERO),
+            Decimal::ZERO
+        );
+        assert_eq!(
+            portfolio_long_first
+                .positions
+                .get("SHORT")
+                .copied()
+                .unwrap_or(Decimal::ZERO),
+            Decimal::from(-50)
+        );
+        assert_eq!(outcome_long_first.liquidated_symbols, vec!["LONG".to_string()]);
     }
 }

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -1,7 +1,7 @@
 use rust_decimal::prelude::*;
 use std::collections::HashMap;
 
-use crate::analysis::{BacktestResult, PositionSnapshot};
+use crate::analysis::{BacktestResult, LiquidationAudit, PositionSnapshot};
 use crate::model::Instrument;
 use crate::portfolio::Portfolio;
 
@@ -19,6 +19,8 @@ pub struct StatisticsManager {
     cash_curve: Vec<(i64, Decimal)>,
     /// 持仓快照 [(timestamp, snapshots)]
     pub snapshots: Vec<(i64, Vec<PositionSnapshot>)>,
+    /// 强平审计记录
+    pub liquidation_audits: Vec<LiquidationAudit>,
 }
 
 impl Default for StatisticsManager {
@@ -34,6 +36,7 @@ impl StatisticsManager {
             equity_curve: Vec::new(),
             cash_curve: Vec::new(),
             snapshots: Vec::new(),
+            liquidation_audits: Vec::new(),
         }
     }
 
@@ -54,6 +57,10 @@ impl StatisticsManager {
     ) {
         let snapshots = Self::create_snapshot(portfolio, instruments, last_prices, trade_tracker);
         self.snapshots.push((timestamp, snapshots));
+    }
+
+    pub fn record_liquidation_audit(&mut self, audit: LiquidationAudit) {
+        self.liquidation_audits.push(audit);
     }
 
     /// 创建持仓快照 (静态方法/无状态)
@@ -170,6 +177,7 @@ impl StatisticsManager {
             initial_cash,
             orders: order_manager.get_all_orders(),
             executions: order_manager.trades.clone(),
+            liquidation_audits: self.liquidation_audits.clone(),
         })
     }
 

--- a/tests/test_account_risk_rules.py
+++ b/tests/test_account_risk_rules.py
@@ -211,3 +211,199 @@ def test_short_option_margin_is_checked_and_account_margin_updates() -> None:
     assert any("Insufficient margin" in r for r in reasons), reasons
     assert ShortPutStrategy.account_snapshots
     assert any(s["margin"] > 0.0 for s in ShortPutStrategy.account_snapshots)
+
+
+def test_margin_account_allows_short_sell_when_enabled() -> None:
+    """Margin account should allow opening short stock positions."""
+
+    class ShortStockStrategy(Strategy):
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.sell(bar.symbol, 10)
+                self.ordered = True
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-01 10:01:00", tz="Asia/Shanghai"),
+        ],
+        [10.0, 10.0],
+        symbol="SHORTABLE",
+    )
+    result = run_backtest(
+        data=bars,
+        strategy=ShortStockStrategy,
+        symbol="SHORTABLE",
+        initial_cash=100000.0,
+        show_progress=False,
+        execution_mode="current_close",
+        lot_size=1,
+        risk_config=RiskConfig(account_mode="margin", enable_short_sell=True),
+    )
+
+    reasons = _reject_reasons(result)
+    assert all("Insufficient available position" not in r for r in reasons), reasons
+    sell_rows = result.orders_df[result.orders_df["side"].astype(str) == "sell"]
+    assert not sell_rows.empty
+    assert float(sell_rows["filled_quantity"].sum()) > 0.0
+
+
+def test_margin_account_stock_buy_uses_initial_margin_ratio() -> None:
+    """Margin account stock buying should apply initial margin ratio for sizing."""
+
+    class LeveragedBuyStrategy(Strategy):
+        account_snapshots: list[dict[str, Any]] = []
+
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.buy(bar.symbol, 1500)
+                self.ordered = True
+
+        def on_trade(self, trade: Any) -> None:
+            self.__class__.account_snapshots.append(self.get_account())
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-01 10:01:00", tz="Asia/Shanghai"),
+        ],
+        [100.0, 100.0],
+        symbol="MARGIN_BUY",
+    )
+    LeveragedBuyStrategy.account_snapshots = []
+    result = run_backtest(
+        data=bars,
+        strategy=LeveragedBuyStrategy,
+        symbol="MARGIN_BUY",
+        initial_cash=100000.0,
+        show_progress=False,
+        execution_mode="current_close",
+        lot_size=1,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            enable_short_sell=True,
+            initial_margin_ratio=0.5,
+        ),
+    )
+
+    reasons = _reject_reasons(result)
+    assert not any("Insufficient margin" in r for r in reasons), reasons
+    filled_qty = float(result.orders_df["filled_quantity"].sum())
+    assert filled_qty >= 1500.0
+    assert LeveragedBuyStrategy.account_snapshots
+    snap = LeveragedBuyStrategy.account_snapshots[-1]
+    assert "borrowed_cash" in snap
+    assert "short_market_value" in snap
+    assert "maintenance_ratio" in snap
+    assert snap.get("account_mode") == "margin"
+
+
+def test_margin_account_daily_financing_interest_is_deducted() -> None:
+    """Margin account financing interest should be deducted on day switch."""
+
+    class FinancingInterestStrategy(Strategy):
+        account_snapshots: list[dict[str, Any]] = []
+
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.buy(bar.symbol, 150)
+                self.ordered = True
+                return
+            self.__class__.account_snapshots.append(self.get_account())
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-01 14:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        ],
+        [100.0, 100.0, 100.0],
+        symbol="INTEREST",
+    )
+    FinancingInterestStrategy.account_snapshots = []
+    run_backtest(
+        data=bars,
+        strategy=FinancingInterestStrategy,
+        symbol="INTEREST",
+        initial_cash=10000.0,
+        show_progress=False,
+        execution_mode="current_close",
+        lot_size=1,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            initial_margin_ratio=0.5,
+            financing_rate_annual=36.5,
+            borrow_rate_annual=0.0,
+            allow_force_liquidation=False,
+        ),
+    )
+
+    assert len(FinancingInterestStrategy.account_snapshots) >= 2
+    day1_snapshot = FinancingInterestStrategy.account_snapshots[0]
+    day2_snapshot = FinancingInterestStrategy.account_snapshots[1]
+    day1_cash = float(day1_snapshot["cash"])
+    day2_cash = float(day2_snapshot["cash"])
+    assert day2_cash < day1_cash
+    assert float(day2_snapshot.get("accrued_interest", 0.0)) > 0.0
+    assert float(day2_snapshot.get("daily_interest", 0.0)) > 0.0
+
+
+def test_margin_account_force_liquidation_on_maintenance_breach() -> None:
+    """Margin account should force-liquidate positions when breached."""
+
+    class ForceLiquidationStrategy(Strategy):
+        pos_snapshots: list[float] = []
+
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.buy(bar.symbol, 150)
+                self.ordered = True
+            self.__class__.pos_snapshots.append(float(self.get_position(bar.symbol)))
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-01 14:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        ],
+        [100.0, 20.0, 20.0],
+        symbol="LIQ",
+    )
+    ForceLiquidationStrategy.pos_snapshots = []
+    result = run_backtest(
+        data=bars,
+        strategy=ForceLiquidationStrategy,
+        symbol="LIQ",
+        initial_cash=10000.0,
+        show_progress=False,
+        execution_mode="current_close",
+        lot_size=1,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            initial_margin_ratio=0.5,
+            maintenance_margin_ratio=0.5,
+            financing_rate_annual=0.0,
+            borrow_rate_annual=0.0,
+            allow_force_liquidation=True,
+        ),
+    )
+
+    assert ForceLiquidationStrategy.pos_snapshots
+    assert any(p > 0.0 for p in ForceLiquidationStrategy.pos_snapshots[:-1])
+    assert ForceLiquidationStrategy.pos_snapshots[-1] == 0.0
+    liquidation_df = result.liquidation_audit_df
+    assert not liquidation_df.empty
+    assert "liquidated_symbols" in liquidation_df.columns
+    assert "priority" in liquidation_df.columns

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -5,6 +5,7 @@ from typing import cast
 import pandas as pd
 import pytest
 from akquant import Bar, Strategy, run_backtest
+from akquant.config import RiskConfig
 from akquant.plot import (
     plot_dashboard,
     plot_pnl_vs_duration,
@@ -36,6 +37,21 @@ class NoTradeStrategy(Strategy):
     def on_bar(self, bar: Bar) -> None:
         """Do nothing on each bar."""
         _ = bar
+
+
+class MarginLiquidationStrategy(Strategy):
+    """Open a leveraged long to trigger forced liquidation on drawdown."""
+
+    def __init__(self) -> None:
+        """Initialize one-shot order flag."""
+        super().__init__()
+        self.ordered = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Buy once with leverage-like sizing."""
+        if not self.ordered:
+            self.buy(symbol=bar.symbol, quantity=150)
+            self.ordered = True
 
 
 def _build_data(symbol: str = "TEST", n: int = 5) -> list[Bar]:
@@ -105,11 +121,8 @@ def test_report_contains_new_analysis_sections(tmp_path: Path) -> None:
     assert "组合归因与容量分析 (Attribution & Capacity)" in html
     assert "最新净暴露比 (Latest Net Exposure %)" in html
     assert "平均换手率 (Avg Turnover)" in html
-    assert "暂无策略级风控拒单占比图" in html
-    assert "暂无策略级拒单原因占比图" in html
-    assert "暂无按日风控拒单趋势图" in html
-    assert "暂无按策略风控拒单趋势图" in html
-    assert "暂无按日拒单原因趋势图" in html
+    assert "策略风控拒单明细 (Risk Rejections by Strategy)" in html
+    assert "暂无策略归属风控拒单聚合数据" in html
     assert "未提供行情数据，已跳过 K 线复盘图" in html
 
 
@@ -140,8 +153,8 @@ def test_report_includes_trade_kline_with_market_data(tmp_path: Path) -> None:
     html = report_path.read_text(encoding="utf-8")
     assert "交易复盘 (K线买卖点)" in html
     assert "Strategy Analysis: TEST" in html
-    assert "净盈亏" in html
-    assert "持仓K线数" in html
+    assert "entry" in html
+    assert "exit" in html
 
 
 def test_report_handles_empty_trade_analysis_blocks(tmp_path: Path) -> None:
@@ -194,3 +207,65 @@ def test_plot_functions_return_figures_for_non_empty_result() -> None:
     assert fig_rolling is not None
     fig_returns = plot_returns_distribution(result.daily_returns)
     assert fig_returns is not None
+
+
+def test_report_contains_forced_liquidation_audit_section(tmp_path: Path) -> None:
+    """Report HTML should include forced liquidation audit section and entries."""
+    _skip_if_no_plotly()
+    bars = [
+        Bar(
+            timestamp=pd.Timestamp("2023-01-01 10:00:00").value,
+            open=100.0,
+            high=100.2,
+            low=99.8,
+            close=100.0,
+            volume=10000.0,
+            symbol="LIQ",
+        ),
+        Bar(
+            timestamp=pd.Timestamp("2023-01-01 14:00:00").value,
+            open=20.0,
+            high=20.2,
+            low=19.8,
+            close=20.0,
+            volume=10000.0,
+            symbol="LIQ",
+        ),
+        Bar(
+            timestamp=pd.Timestamp("2023-01-02 10:00:00").value,
+            open=20.0,
+            high=20.2,
+            low=19.8,
+            close=20.0,
+            volume=10000.0,
+            symbol="LIQ",
+        ),
+    ]
+    result = run_backtest(
+        data=bars,
+        strategy=MarginLiquidationStrategy,
+        symbol="LIQ",
+        initial_cash=10000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+        risk_config=RiskConfig(
+            account_mode="margin",
+            initial_margin_ratio=0.5,
+            maintenance_margin_ratio=0.5,
+            financing_rate_annual=0.0,
+            borrow_rate_annual=0.0,
+            allow_force_liquidation=True,
+            liquidation_priority="short_first",
+        ),
+    )
+    report_path = tmp_path / "report_with_liquidation_audit.html"
+    result.report(filename=str(report_path), show=False)
+    html = report_path.read_text(encoding="utf-8")
+    assert "强平审计明细 (Forced Liquidation Audit)" in html
+    assert "强平标的 (Liquidated Symbols)" in html
+    assert "LIQ" in html


### PR DESCRIPTION
- 新增 `RiskConfig.account_mode` 字段，支持 "cash"（默认）与 "margin" 模式
- 在 margin 模式下，股票/基金开仓使用 `initial_margin_ratio` 计算保证金
- 新增 `enable_short_sell` 允许股票开空，`allow_force_liquidation` 控制强平触发
- 每日结算时计算融资利息 (`financing_rate_annual`) 并记录至 `margin_accrued_interest`
- 维持担保比例跌破 `maintenance_margin_ratio` 时按 `liquidation_priority` 执行强平
- 强平审计记录通过 `result.liquidation_audit_df` 输出，包含日期、利息、标的与顺序
- 策略内 `get_account()` 返回扩展字段：borrowed_cash、short_market_value、maintenance_ratio 等
- 更新文档，涵盖信用账户配置、回测示例与审计数据查看方式