### PR TITLE
fix(optimize): 修复JSON序列化中时间戳和特殊数值的处理

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.92"
+version = "0.1.93"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.92"
+version = "0.1.93"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.92"
+version = "0.1.93"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/optimize.py
+++ b/python/akquant/optimize.py
@@ -11,6 +11,8 @@ import pickle
 import threading
 import time
 from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from datetime import time as datetime_time
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Type, Union, cast
 
 import numpy as np
@@ -162,10 +164,26 @@ class JSONEncoder(json.JSONEncoder):
 
     def default(self, obj: Any) -> Any:
         """Encode object."""
+        if obj is pd.NaT:
+            return None
+        if isinstance(obj, pd.Timestamp):
+            if pd.isna(obj):
+                return None
+            return obj.isoformat()
+        if isinstance(obj, pd.Timedelta):
+            return obj.total_seconds()
+        if isinstance(obj, (datetime, date, datetime_time)):
+            return obj.isoformat()
+        if isinstance(obj, timedelta):
+            return obj.total_seconds()
         if isinstance(obj, (np.integer, np.int64, np.int32)):
             return int(obj)
         elif isinstance(obj, (np.floating, np.float64, np.float32)):
+            if np.isnan(obj) or np.isinf(obj):
+                return None
             return float(obj)
+        elif isinstance(obj, np.bool_):
+            return bool(obj)
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         return super().default(obj)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 import time
 import warnings
 from datetime import date, datetime, timezone
+from pathlib import Path
 from typing import Any, cast
 
 import akquant
@@ -3691,6 +3692,43 @@ def test_run_grid_search_single_worker_accepts_camelcase_execution_mode() -> Non
     assert float(results.iloc[0]["end_market_value"]) > float(
         results.iloc[0]["initial_market_value"]
     )
+
+
+def test_run_grid_search_db_path_serializes_timestamp_metrics(
+    tmp_path: Path,
+) -> None:
+    """Grid search cache should serialize Timestamp metrics into JSON strings."""
+    import json
+    import sqlite3
+
+    symbol = "OPT_DB_TS_SERIALIZE"
+    data = _build_benchmark_data(n=40, symbol=symbol)
+    db_path = tmp_path / "walk_forward_cache.db"
+
+    results = akquant.run_grid_search(
+        strategy=NoopStrategy,
+        param_grid={"dummy": [1]},
+        data=data,
+        symbol=symbol,
+        max_workers=1,
+        return_df=True,
+        show_progress=False,
+        db_path=str(db_path),
+    )
+
+    assert isinstance(results, pd.DataFrame)
+    assert len(results) == 1
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT metrics_json FROM optimization_results WHERE strategy_name = ?",
+            (NoopStrategy.__name__,),
+        ).fetchone()
+
+    assert row is not None
+    metrics = json.loads(cast(str, row[0]))
+    assert isinstance(metrics.get("start_time"), str)
+    assert isinstance(metrics.get("end_time"), str)
 
 
 def test_run_backtest_expiry_date_str_is_rejected() -> None:


### PR DESCRIPTION
扩展JSONEncoder以正确处理pandas时间戳、NaT、Timedelta、datetime对象以及numpy特殊数值（NaN、inf）。 添加测试验证网格搜索缓存能正确序列化时间戳指标到数据库。