### PR TITLE
chore: 版本号升级至 0.1.96 并修复代码格式及验证逻辑

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.95"
+version = "0.1.96"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.95"
+version = "0.1.96"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.95"
+version = "0.1.96"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -59,19 +59,28 @@ impl TradeTracker {
     }
 
     pub fn on_split(&mut self, symbol: &str, ratio: Decimal) {
-        // Adjust Long Inventory
+        let safe_ratio = ratio.abs();
+        if safe_ratio <= Decimal::ZERO {
+            return;
+        }
+
         if let Some(queue) = self.long_inventory.get_mut(symbol) {
             for entry in queue.iter_mut() {
-                entry.quantity *= ratio;
-                entry.price /= ratio;
+                entry.quantity = entry
+                    .quantity
+                    .checked_mul(safe_ratio)
+                    .unwrap_or(Decimal::MAX);
+                entry.price = entry.price.checked_div(safe_ratio).unwrap_or(Decimal::ZERO);
             }
         }
 
-        // Adjust Short Inventory
         if let Some(queue) = self.short_inventory.get_mut(symbol) {
             for entry in queue.iter_mut() {
-                entry.quantity *= ratio;
-                entry.price /= ratio;
+                entry.quantity = entry
+                    .quantity
+                    .checked_mul(safe_ratio)
+                    .unwrap_or(Decimal::MAX);
+                entry.price = entry.price.checked_div(safe_ratio).unwrap_or(Decimal::ZERO);
             }
         }
     }

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -577,8 +577,12 @@ impl Engine {
             .strategy_slots
             .get(slot_index)
             .map(|slot| slot.strategy_id.clone());
-        let ctx =
-            self.create_context(active_orders, step_trades, step_rejected_orders, strategy_id);
+        let ctx = self.create_context(
+            active_orders,
+            step_trades,
+            step_rejected_orders,
+            strategy_id,
+        );
         let (py_ctx, persistent_ref) = Python::attach(|py| {
             let py_ctx = Py::new(py, ctx).unwrap();
             Ok::<_, PyErr>((py_ctx.clone_ref(py), py_ctx.clone_ref(py)))
@@ -912,13 +916,12 @@ impl Engine {
         match event {
             Event::Bar(b) => {
                 self.last_prices.insert(b.symbol.clone(), b.close);
-                let py_ctx =
-                    self.get_or_create_strategy_context(
-                        slot_index,
-                        active_orders,
-                        step_trades,
-                        step_rejected_orders,
-                    )?;
+                let py_ctx = self.get_or_create_strategy_context(
+                    slot_index,
+                    active_orders,
+                    step_trades,
+                    step_rejected_orders,
+                )?;
 
                 let args = Python::attach(|py| {
                     let bar = b.clone();
@@ -948,13 +951,12 @@ impl Engine {
             }
             Event::Tick(t) => {
                 self.last_prices.insert(t.symbol.clone(), t.price);
-                let py_ctx =
-                    self.get_or_create_strategy_context(
-                        slot_index,
-                        active_orders,
-                        step_trades,
-                        step_rejected_orders,
-                    )?;
+                let py_ctx = self.get_or_create_strategy_context(
+                    slot_index,
+                    active_orders,
+                    step_trades,
+                    step_rejected_orders,
+                )?;
 
                 let args = Python::attach(|py| {
                     let tick = t.clone();
@@ -982,13 +984,12 @@ impl Engine {
                 Ok((new_orders, new_timers, canceled_ids))
             }
             Event::Timer(timer) => {
-                let py_ctx =
-                    self.get_or_create_strategy_context(
-                        slot_index,
-                        active_orders,
-                        step_trades,
-                        step_rejected_orders,
-                    )?;
+                let py_ctx = self.get_or_create_strategy_context(
+                    slot_index,
+                    active_orders,
+                    step_trades,
+                    step_rejected_orders,
+                )?;
 
                 let args = Python::attach(|py| {
                     let payload = timer.payload.as_str();

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -785,11 +785,7 @@ impl Engine {
         self.market_manager.set_futures_fee_rules(commission_rate);
     }
 
-    pub fn set_futures_fee_rules_by_prefix(
-        &mut self,
-        symbol_prefix: String,
-        commission_rate: f64,
-    ) {
+    pub fn set_futures_fee_rules_by_prefix(&mut self, symbol_prefix: String, commission_rate: f64) {
         self.market_manager
             .set_futures_fee_rules_by_prefix(symbol_prefix, commission_rate);
     }
@@ -805,11 +801,12 @@ impl Engine {
         enforce_tick_size: Option<bool>,
         enforce_lot_size: Option<bool>,
     ) {
-        self.execution_model.set_futures_validation_options_by_prefix(
-            symbol_prefix,
-            enforce_tick_size,
-            enforce_lot_size,
-        );
+        self.execution_model
+            .set_futures_validation_options_by_prefix(
+                symbol_prefix,
+                enforce_tick_size,
+                enforce_lot_size,
+            );
     }
 
     /// 设置基金费率规则

--- a/src/execution/futures.rs
+++ b/src/execution/futures.rs
@@ -172,9 +172,7 @@ impl Default for FuturesMatcher {
 mod tests {
     use super::*;
     use crate::model::instrument::{FuturesInstrument, InstrumentEnum};
-    use crate::model::{
-        AssetType, ExecutionMode, Instrument, OrderRole, OrderSide, TimeInForce,
-    };
+    use crate::model::{AssetType, ExecutionMode, Instrument, OrderRole, OrderSide, TimeInForce};
     use rust_decimal::prelude::FromStr;
     use rust_decimal_macros::dec;
 

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -86,11 +86,7 @@ impl ExecutionClient for SimulatedExecutionClient {
         self.matchers.insert(asset_type, matcher);
     }
 
-    fn set_futures_validation_options(
-        &mut self,
-        enforce_tick_size: bool,
-        enforce_lot_size: bool,
-    ) {
+    fn set_futures_validation_options(&mut self, enforce_tick_size: bool, enforce_lot_size: bool) {
         self.futures_enforce_tick_size = enforce_tick_size;
         self.futures_enforce_lot_size = enforce_lot_size;
         self.rebuild_futures_matcher();
@@ -116,8 +112,11 @@ impl ExecutionClient for SimulatedExecutionClient {
             }
         }
         if !updated {
-            self.futures_validation_by_prefix
-                .push((normalized, enforce_tick_size, enforce_lot_size));
+            self.futures_validation_by_prefix.push((
+                normalized,
+                enforce_tick_size,
+                enforce_lot_size,
+            ));
         }
         self.rebuild_futures_matcher();
     }

--- a/src/indicators/momentum_oscillators.rs
+++ b/src/indicators/momentum_oscillators.rs
@@ -65,7 +65,11 @@ impl RSI {
         Some(rsi)
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -138,7 +142,10 @@ impl WILLR {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -214,7 +221,11 @@ impl CMO {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/momentum_rates.rs
+++ b/src/indicators/momentum_rates.rs
@@ -42,7 +42,11 @@ impl ROC {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -95,7 +99,11 @@ impl ROCP {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -148,7 +156,11 @@ impl ROCR {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -201,7 +213,11 @@ impl ROCR100 {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -250,7 +266,11 @@ impl MOM {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/moving_average_compound.rs
+++ b/src/indicators/moving_average_compound.rs
@@ -105,7 +105,11 @@ impl DEMA {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -162,7 +166,11 @@ impl TRIX {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -207,7 +215,11 @@ impl TEMA {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -276,7 +288,11 @@ impl KAMA {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -327,7 +343,11 @@ impl APO {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -382,7 +402,11 @@ impl PPO {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -444,7 +468,11 @@ impl T3 {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -501,7 +529,11 @@ impl HT_TRENDLINE {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -578,7 +610,10 @@ impl MAMA {
                 second.push(f64::NAN);
             }
         }
-        (PyArray1::from_vec(py, first), PyArray1::from_vec(py, second))
+        (
+            PyArray1::from_vec(py, first),
+            PyArray1::from_vec(py, second),
+        )
     }
 
     #[getter]

--- a/src/indicators/moving_average_core.rs
+++ b/src/indicators/moving_average_core.rs
@@ -39,7 +39,11 @@ impl SMA {
         }
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -96,7 +100,11 @@ impl EMA {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -150,7 +158,11 @@ impl WMA {
         self.value()
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -199,7 +211,11 @@ impl TRIMA {
         self.value()
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/moving_average_transforms.rs
+++ b/src/indicators/moving_average_transforms.rs
@@ -28,7 +28,11 @@ macro_rules! define_unary_indicator {
                 self.current_value
             }
 
-            pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+            pub fn update_many<'py>(
+                &mut self,
+                py: Python<'py>,
+                values: Vec<f64>,
+            ) -> Bound<'py, PyArray1<f64>> {
                 let mut out = Vec::with_capacity(values.len());
                 for value in values {
                     out.push(self.update(value).unwrap_or(f64::NAN));
@@ -202,7 +206,9 @@ impl CLIP {
         max_values: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
         if values.len() != min_values.len() || values.len() != max_values.len() {
-            return Err(PyValueError::new_err("values/min_values/max_values length mismatch"));
+            return Err(PyValueError::new_err(
+                "values/min_values/max_values length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(values.len());
         for (value, (min_value, max_value)) in values

--- a/src/indicators/moving_average_windowed.rs
+++ b/src/indicators/moving_average_windowed.rs
@@ -39,7 +39,11 @@ impl MIDPOINT {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -88,7 +92,11 @@ impl MAX {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -137,7 +145,11 @@ impl MIN {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -197,7 +209,11 @@ impl MAXINDEX {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -257,7 +273,11 @@ impl MININDEX {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -339,7 +359,10 @@ impl MINMAXINDEX {
                 second.push(f64::NAN);
             }
         }
-        (PyArray1::from_vec(py, first), PyArray1::from_vec(py, second))
+        (
+            PyArray1::from_vec(py, first),
+            PyArray1::from_vec(py, second),
+        )
     }
 
     #[getter]
@@ -400,7 +423,10 @@ impl MINMAX {
                 second.push(f64::NAN);
             }
         }
-        (PyArray1::from_vec(py, first), PyArray1::from_vec(py, second))
+        (
+            PyArray1::from_vec(py, first),
+            PyArray1::from_vec(py, second),
+        )
     }
 
     #[getter]
@@ -448,7 +474,11 @@ impl SUM {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -499,7 +529,11 @@ impl AVGDEV {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -549,7 +583,11 @@ impl RANGE {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -589,7 +627,11 @@ impl LN {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/trend.rs
+++ b/src/indicators/trend.rs
@@ -82,7 +82,10 @@ impl CCI {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))

--- a/src/indicators/trend_directional.rs
+++ b/src/indicators/trend_directional.rs
@@ -129,7 +129,10 @@ impl ADX {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -242,7 +245,10 @@ impl DX {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -303,7 +309,10 @@ impl ADXR {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -400,7 +409,10 @@ impl PLUS_DI {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -497,7 +509,10 @@ impl MINUS_DI {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))

--- a/src/indicators/trend_oscillators.rs
+++ b/src/indicators/trend_oscillators.rs
@@ -104,7 +104,10 @@ impl STOCH {
         }
         let mut out_first = Vec::with_capacity(highs.len());
         let mut out_second = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             if let Some((first, second)) = self.update(high, low, close) {
                 out_first.push(first);
                 out_second.push(second);
@@ -204,7 +207,10 @@ impl AROON {
                 second.push(f64::NAN);
             }
         }
-        Ok((PyArray1::from_vec(py, first), PyArray1::from_vec(py, second)))
+        Ok((
+            PyArray1::from_vec(py, first),
+            PyArray1::from_vec(py, second),
+        ))
     }
 
     #[getter]
@@ -483,7 +489,10 @@ impl ULTOSC {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))

--- a/src/indicators/trend_regression.rs
+++ b/src/indicators/trend_regression.rs
@@ -55,7 +55,11 @@ impl LINEARREG {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -119,7 +123,11 @@ impl LINEARREG_SLOPE {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -184,7 +192,11 @@ impl LINEARREG_INTERCEPT {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -249,7 +261,11 @@ impl LINEARREG_ANGLE {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -314,7 +330,11 @@ impl TSF {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -609,7 +629,11 @@ impl LINEARREG_R2 {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/volatility_price.rs
+++ b/src/indicators/volatility_price.rs
@@ -81,7 +81,10 @@ impl TYPPRICE {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -126,7 +129,10 @@ impl WCLPRICE {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -169,7 +175,9 @@ impl AVGPRICE {
         closes: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
         if opens.len() != highs.len() || opens.len() != lows.len() || opens.len() != closes.len() {
-            return Err(PyValueError::new_err("opens/highs/lows/closes length mismatch"));
+            return Err(PyValueError::new_err(
+                "opens/highs/lows/closes length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(opens.len());
         for ((open, high), (low, close)) in opens

--- a/src/indicators/volatility_stats.rs
+++ b/src/indicators/volatility_stats.rs
@@ -156,7 +156,10 @@ impl ATR {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -212,7 +215,10 @@ impl NATR {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -269,7 +275,10 @@ impl TRANGE {
             return Err(PyValueError::new_err("highs/lows/closes length mismatch"));
         }
         let mut out = Vec::with_capacity(highs.len());
-        for (high, (low, close)) in highs.into_iter().zip(lows.into_iter().zip(closes.into_iter())) {
+        for (high, (low, close)) in highs
+            .into_iter()
+            .zip(lows.into_iter().zip(closes.into_iter()))
+        {
             out.push(self.update(high, low, close).unwrap_or(f64::NAN));
         }
         Ok(PyArray1::from_vec(py, out))
@@ -328,7 +337,11 @@ impl STDDEV {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));
@@ -389,7 +402,11 @@ impl VAR {
         self.current_value
     }
 
-    pub fn update_many<'py>(&mut self, py: Python<'py>, values: Vec<f64>) -> Bound<'py, PyArray1<f64>> {
+    pub fn update_many<'py>(
+        &mut self,
+        py: Python<'py>,
+        values: Vec<f64>,
+    ) -> Bound<'py, PyArray1<f64>> {
         let mut out = Vec::with_capacity(values.len());
         for value in values {
             out.push(self.update(value).unwrap_or(f64::NAN));

--- a/src/indicators/volume.rs
+++ b/src/indicators/volume.rs
@@ -144,8 +144,11 @@ impl MFI {
         closes: Vec<f64>,
         volumes: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
-        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len() {
-            return Err(PyValueError::new_err("highs/lows/closes/volumes length mismatch"));
+        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len()
+        {
+            return Err(PyValueError::new_err(
+                "highs/lows/closes/volumes length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(highs.len());
         for ((high, low), (close, volume)) in highs
@@ -201,7 +204,9 @@ impl BOP {
         closes: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
         if opens.len() != highs.len() || opens.len() != lows.len() || opens.len() != closes.len() {
-            return Err(PyValueError::new_err("opens/highs/lows/closes length mismatch"));
+            return Err(PyValueError::new_err(
+                "opens/highs/lows/closes length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(opens.len());
         for ((open, high), (low, close)) in opens
@@ -260,8 +265,11 @@ impl AD {
         closes: Vec<f64>,
         volumes: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
-        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len() {
-            return Err(PyValueError::new_err("highs/lows/closes/volumes length mismatch"));
+        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len()
+        {
+            return Err(PyValueError::new_err(
+                "highs/lows/closes/volumes length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(highs.len());
         for ((high, low), (close, volume)) in highs
@@ -345,8 +353,11 @@ impl ADOSC {
         closes: Vec<f64>,
         volumes: Vec<f64>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
-        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len() {
-            return Err(PyValueError::new_err("highs/lows/closes/volumes length mismatch"));
+        if highs.len() != lows.len() || highs.len() != closes.len() || highs.len() != volumes.len()
+        {
+            return Err(PyValueError::new_err(
+                "highs/lows/closes/volumes length mismatch",
+            ));
         }
         let mut out = Vec::with_capacity(highs.len());
         for ((high, low), (close, volume)) in highs

--- a/src/margin/calculator.rs
+++ b/src/margin/calculator.rs
@@ -1,6 +1,14 @@
 use crate::model::Instrument;
 use rust_decimal::Decimal;
 
+fn checked_mul_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_mul(rhs).unwrap_or(Decimal::MAX)
+}
+
+fn checked_add_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_add(rhs).unwrap_or(Decimal::MAX)
+}
+
 /// Trait for calculating margin requirements for a position.
 pub trait MarginCalculator: Send + Sync {
     /// Calculate the margin required for a position.
@@ -35,9 +43,11 @@ impl MarginCalculator for LinearMarginCalculator {
         instrument: &Instrument,
         _underlying_price: Option<Decimal>,
     ) -> Decimal {
-        let multiplier = instrument.multiplier();
-        let margin_ratio = instrument.margin_ratio();
-        (quantity * price * multiplier).abs() * margin_ratio
+        let multiplier = instrument.multiplier().abs();
+        let margin_ratio = instrument.margin_ratio().abs();
+        let notional = checked_mul_or_cap(quantity.abs(), price.abs());
+        let gross = checked_mul_or_cap(notional, multiplier);
+        checked_mul_or_cap(gross, margin_ratio)
     }
 }
 
@@ -54,9 +64,11 @@ impl MarginCalculator for FuturesMarginCalculator {
         instrument: &Instrument,
         _underlying_price: Option<Decimal>,
     ) -> Decimal {
-        let multiplier = instrument.multiplier();
-        let margin_ratio = instrument.margin_ratio();
-        (quantity * price * multiplier).abs() * margin_ratio
+        let multiplier = instrument.multiplier().abs();
+        let margin_ratio = instrument.margin_ratio().abs();
+        let notional = checked_mul_or_cap(quantity.abs(), price.abs());
+        let gross = checked_mul_or_cap(notional, multiplier);
+        checked_mul_or_cap(gross, margin_ratio)
     }
 }
 
@@ -76,27 +88,78 @@ impl MarginCalculator for OptionMarginCalculator {
         use rust_decimal::prelude::*;
 
         if quantity > Decimal::ZERO {
-            // Long Option: No maintenance margin (premium paid upfront)
-            // But some brokers might require full value if not paid?
-            // Standard practice is 0 for maintenance margin if fully paid.
             Decimal::ZERO
         } else {
-            // Short Option: Complex margin
-            // Simplified Model: (OptionPrice + UnderlyingPrice * MarginRatio) * Multiplier * Abs(Qty)
-            // If underlying price not available, fallback to OptionPrice * (1 + MarginRatio)
             let abs_qty = quantity.abs();
-            let underlying_price = underlying_price.unwrap_or(Decimal::ZERO);
-            let multiplier = instrument.multiplier();
-            let margin_ratio = instrument.margin_ratio();
+            let underlying_price = underlying_price.unwrap_or(Decimal::ZERO).abs();
+            let multiplier = instrument.multiplier().abs();
+            let margin_ratio = instrument.margin_ratio().abs();
+            let option_price = price.abs();
 
             let margin_per_unit = if underlying_price > Decimal::ZERO {
-                price + (underlying_price * margin_ratio)
+                checked_add_or_cap(
+                    option_price,
+                    checked_mul_or_cap(underlying_price, margin_ratio),
+                )
             } else {
-                // Fallback: assume margin ratio applies to option value itself (e.g. 100% + extra)
-                price * (Decimal::ONE + margin_ratio)
+                checked_mul_or_cap(option_price, checked_add_or_cap(Decimal::ONE, margin_ratio))
             };
 
-            margin_per_unit * multiplier * abs_qty
+            checked_mul_or_cap(checked_mul_or_cap(margin_per_unit, multiplier), abs_qty)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::instrument::{FuturesInstrument, InstrumentEnum, OptionInstrument};
+    use crate::model::types::{AssetType, OptionType};
+
+    #[test]
+    fn linear_margin_caps_on_overflow() {
+        let instrument = Instrument {
+            asset_type: AssetType::Futures,
+            inner: InstrumentEnum::Futures(FuturesInstrument {
+                symbol: "FUT".to_string(),
+                multiplier: Decimal::MAX,
+                margin_ratio: Decimal::MAX,
+                tick_size: Decimal::ONE,
+                expiry_date: None,
+                settlement_type: None,
+                settlement_price: None,
+            }),
+        };
+
+        let calc = LinearMarginCalculator;
+        let margin = calc.calculate_margin(Decimal::MAX, Decimal::MAX, &instrument, None);
+        assert_eq!(margin, Decimal::MAX);
+    }
+
+    #[test]
+    fn option_margin_caps_on_overflow() {
+        let instrument = Instrument {
+            asset_type: AssetType::Option,
+            inner: InstrumentEnum::Option(OptionInstrument {
+                symbol: "OPT".to_string(),
+                multiplier: Decimal::MAX,
+                margin_ratio: Decimal::MAX,
+                tick_size: Decimal::ONE,
+                option_type: OptionType::Call,
+                strike_price: Decimal::ZERO,
+                expiry_date: 0,
+                underlying_symbol: "UL".to_string(),
+                settlement_type: None,
+            }),
+        };
+
+        let calc = OptionMarginCalculator;
+        let margin = calc.calculate_margin(
+            Decimal::NEGATIVE_ONE,
+            Decimal::MAX,
+            &instrument,
+            Some(Decimal::MAX),
+        );
+        assert_eq!(margin, Decimal::MAX);
     }
 }

--- a/src/market/corporate_action.rs
+++ b/src/market/corporate_action.rs
@@ -2,8 +2,30 @@ use crate::analysis::tracker::TradeTracker;
 use crate::model::corporate_action::{CorporateAction, CorporateActionType};
 use crate::portfolio::Portfolio;
 use chrono::NaiveDate;
+use rust_decimal::Decimal;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+const CORP_ACTION_ALERT_PREFIX: &str = "AKQ-CORP-ACTION-ALERT";
+const MIN_SPLIT_RATIO_SCALE: i64 = 1;
+const MIN_SPLIT_RATIO_DP: u32 = 4;
+const MAX_SPLIT_RATIO_SCALE: i64 = 10000;
+const MAX_SPLIT_RATIO_DP: u32 = 0;
+
+fn checked_mul_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_mul(rhs).unwrap_or(Decimal::MAX)
+}
+
+fn checked_add_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_add(rhs).unwrap_or(Decimal::MAX)
+}
+
+fn split_ratio_bounds() -> (Decimal, Decimal) {
+    (
+        Decimal::new(MIN_SPLIT_RATIO_SCALE, MIN_SPLIT_RATIO_DP),
+        Decimal::new(MAX_SPLIT_RATIO_SCALE, MAX_SPLIT_RATIO_DP),
+    )
+}
 
 pub struct CorporateActionManager {
     actions: HashMap<NaiveDate, Vec<CorporateAction>>,
@@ -36,36 +58,131 @@ impl CorporateActionManager {
             for action in actions {
                 match action.action_type {
                     CorporateActionType::Split => {
-                        // Split: ratio > 1.0 (e.g. 2.0 means 1 share becomes 2)
-                        // Reverse Split: ratio < 1.0 (e.g. 0.5 means 2 shares become 1)
-                        // Quantity *= ratio, AvgCost /= ratio
-                        let ratio = action.value;
+                        let ratio = action.value.abs();
+                        let (min_ratio, max_ratio) = split_ratio_bounds();
+                        if ratio <= Decimal::ZERO || ratio < min_ratio || ratio > max_ratio {
+                            eprintln!(
+                                "[{CORP_ACTION_ALERT_PREFIX}] skip split action for {} on {} due to abnormal ratio {}",
+                                action.symbol, action.date, action.value
+                            );
+                            continue;
+                        }
 
                         let positions = Arc::make_mut(&mut portfolio.positions);
                         if let Some(qty) = positions.get_mut(&action.symbol) {
-                            *qty *= ratio;
+                            *qty = checked_mul_or_cap(*qty, ratio);
                         }
 
                         let available = Arc::make_mut(&mut portfolio.available_positions);
                         if let Some(avail) = available.get_mut(&action.symbol) {
-                            *avail *= ratio;
+                            *avail = checked_mul_or_cap(*avail, ratio);
                         }
 
-                        // Update TradeTracker (Inventory Cost Basis)
                         trade_tracker.on_split(&action.symbol, ratio);
                     }
                     CorporateActionType::Dividend => {
-                        // Dividend: value is cash per share
-                        // Cash += Quantity * value
                         if let Some(qty) = portfolio.positions.get(&action.symbol)
                             && !qty.is_zero()
                         {
-                            let dividend_amount = qty * action.value;
-                            portfolio.cash += dividend_amount;
+                            let dividend_amount = checked_mul_or_cap(*qty, action.value);
+                            portfolio.cash = checked_add_or_cap(portfolio.cash, dividend_amount);
                         }
                     }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::corporate_action::CorporateAction;
+    use chrono::NaiveDate;
+
+    #[test]
+    fn split_caps_position_on_overflow() {
+        let mut manager = CorporateActionManager::new();
+        manager.add(CorporateAction {
+            symbol: "AAPL".to_string(),
+            date: NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date"),
+            action_type: CorporateActionType::Split,
+            value: Decimal::MAX,
+        });
+
+        let mut portfolio = Portfolio {
+            cash: Decimal::ZERO,
+            positions: Arc::new(HashMap::from([("AAPL".to_string(), Decimal::MAX)])),
+            available_positions: Arc::new(HashMap::from([("AAPL".to_string(), Decimal::MAX)])),
+        };
+        let mut tracker = TradeTracker::new();
+
+        manager.process_date(
+            NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date"),
+            &mut portfolio,
+            &mut tracker,
+        );
+
+        assert_eq!(portfolio.positions.get("AAPL"), Some(&Decimal::MAX));
+        assert_eq!(
+            portfolio.available_positions.get("AAPL"),
+            Some(&Decimal::MAX)
+        );
+    }
+
+    #[test]
+    fn dividend_caps_cash_on_overflow() {
+        let mut manager = CorporateActionManager::new();
+        manager.add(CorporateAction {
+            symbol: "AAPL".to_string(),
+            date: NaiveDate::from_ymd_opt(2025, 1, 2).expect("valid date"),
+            action_type: CorporateActionType::Dividend,
+            value: Decimal::MAX,
+        });
+
+        let mut portfolio = Portfolio {
+            cash: Decimal::MAX,
+            positions: Arc::new(HashMap::from([("AAPL".to_string(), Decimal::MAX)])),
+            available_positions: Arc::new(HashMap::new()),
+        };
+        let mut tracker = TradeTracker::new();
+
+        manager.process_date(
+            NaiveDate::from_ymd_opt(2025, 1, 2).expect("valid date"),
+            &mut portfolio,
+            &mut tracker,
+        );
+
+        assert_eq!(portfolio.cash, Decimal::MAX);
+    }
+
+    #[test]
+    fn split_out_of_range_ratio_is_skipped() {
+        let mut manager = CorporateActionManager::new();
+        manager.add(CorporateAction {
+            symbol: "AAPL".to_string(),
+            date: NaiveDate::from_ymd_opt(2025, 1, 3).expect("valid date"),
+            action_type: CorporateActionType::Split,
+            value: Decimal::new(1, 5),
+        });
+
+        let mut portfolio = Portfolio {
+            cash: Decimal::ZERO,
+            positions: Arc::new(HashMap::from([("AAPL".to_string(), Decimal::from(100))])),
+            available_positions: Arc::new(HashMap::from([("AAPL".to_string(), Decimal::from(80))])),
+        };
+        let mut tracker = TradeTracker::new();
+
+        manager.process_date(
+            NaiveDate::from_ymd_opt(2025, 1, 3).expect("valid date"),
+            &mut portfolio,
+            &mut tracker,
+        );
+
+        assert_eq!(portfolio.positions.get("AAPL"), Some(&Decimal::from(100)));
+        assert_eq!(
+            portfolio.available_positions.get("AAPL"),
+            Some(&Decimal::from(80))
+        );
     }
 }

--- a/src/market/manager.rs
+++ b/src/market/manager.rs
@@ -132,11 +132,7 @@ impl MarketManager {
         }
     }
 
-    pub fn set_futures_fee_rules_by_prefix(
-        &mut self,
-        symbol_prefix: String,
-        commission_rate: f64,
-    ) {
+    pub fn set_futures_fee_rules_by_prefix(&mut self, symbol_prefix: String, commission_rate: f64) {
         if let MarketConfig::China(ref mut c) = self.config {
             let prefix = symbol_prefix.trim().to_uppercase();
             if prefix.is_empty() {

--- a/src/model/corporate_action.rs
+++ b/src/model/corporate_action.rs
@@ -1,7 +1,54 @@
 use chrono::NaiveDate;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+
+const CORP_ACTION_VALIDATION_PREFIX: &str = "AKQ-CORP-ACTION-VALIDATION";
+const MIN_SPLIT_RATIO_SCALE: i64 = 1;
+const MIN_SPLIT_RATIO_DP: u32 = 4;
+const MAX_SPLIT_RATIO_SCALE: i64 = 10000;
+const MAX_SPLIT_RATIO_DP: u32 = 0;
+
+fn validation_err(message: &str) -> PyErr {
+    PyValueError::new_err(format!("[{CORP_ACTION_VALIDATION_PREFIX}] {message}"))
+}
+
+fn split_ratio_bounds() -> (Decimal, Decimal) {
+    (
+        Decimal::new(MIN_SPLIT_RATIO_SCALE, MIN_SPLIT_RATIO_DP),
+        Decimal::new(MAX_SPLIT_RATIO_SCALE, MAX_SPLIT_RATIO_DP),
+    )
+}
+
+fn validate_corporate_action_value(
+    symbol: &str,
+    action_type: CorporateActionType,
+    value: Decimal,
+) -> PyResult<()> {
+    if symbol.trim().is_empty() {
+        return Err(validation_err("symbol must not be empty"));
+    }
+    match action_type {
+        CorporateActionType::Split => {
+            if value <= Decimal::ZERO {
+                return Err(validation_err("split ratio must be > 0"));
+            }
+            let (min_ratio, max_ratio) = split_ratio_bounds();
+            if value < min_ratio || value > max_ratio {
+                return Err(validation_err(&format!(
+                    "split ratio must be within [{min_ratio}, {max_ratio}]",
+                )));
+            }
+        }
+        CorporateActionType::Dividend => {
+            if value < Decimal::ZERO {
+                return Err(validation_err("dividend value must be >= 0"));
+            }
+        }
+    }
+    Ok(())
+}
 
 #[pyclass(eq, eq_int, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -43,6 +90,8 @@ impl CorporateAction {
     ) -> PyResult<Self> {
         use crate::model::market_data::extract_decimal;
         let val = extract_decimal(value)?;
+        let symbol = symbol.trim().to_string();
+        validate_corporate_action_value(&symbol, action_type.clone(), val)?;
         Ok(Self {
             symbol,
             date,
@@ -60,7 +109,38 @@ impl CorporateAction {
     #[setter]
     fn set_value(&mut self, value: &Bound<'_, PyAny>) -> PyResult<()> {
         use crate::model::market_data::extract_decimal;
-        self.value = extract_decimal(value)?;
+        let val = extract_decimal(value)?;
+        validate_corporate_action_value(&self.symbol, self.action_type.clone(), val)?;
+        self.value = val;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_corporate_action_rejects_invalid_split_ratio() {
+        let result =
+            validate_corporate_action_value("AAPL", CorporateActionType::Split, Decimal::ZERO);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_corporate_action_rejects_negative_dividend() {
+        let result = validate_corporate_action_value(
+            "AAPL",
+            CorporateActionType::Dividend,
+            Decimal::new(-1, 2),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_corporate_action_rejects_out_of_range_split_ratio() {
+        let result =
+            validate_corporate_action_value("AAPL", CorporateActionType::Split, Decimal::new(1, 5));
+        assert!(result.is_err());
     }
 }

--- a/src/model/instrument.rs
+++ b/src/model/instrument.rs
@@ -1,10 +1,71 @@
 use super::market_data::extract_decimal;
 use super::types::{AssetType, OptionType, SettlementType};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
+
+const INSTRUMENT_VALIDATION_PREFIX: &str = "AKQ-INSTRUMENT-VALIDATION";
+
+fn validation_err(message: &str) -> PyErr {
+    PyValueError::new_err(format!("[{INSTRUMENT_VALIDATION_PREFIX}] {message}"))
+}
+
+fn ensure_positive(value: Decimal, field: &str) -> PyResult<()> {
+    if value <= Decimal::ZERO {
+        return Err(validation_err(&format!("{field} must be > 0")));
+    }
+    Ok(())
+}
+
+fn ensure_non_negative(value: Decimal, field: &str) -> PyResult<()> {
+    if value < Decimal::ZERO {
+        return Err(validation_err(&format!("{field} must be >= 0")));
+    }
+    Ok(())
+}
+
+fn validate_instrument_inputs(
+    symbol: &str,
+    asset_type: AssetType,
+    multiplier: Decimal,
+    margin_ratio: Decimal,
+    tick_size: Decimal,
+    lot_size: Decimal,
+    strike_price: Option<Decimal>,
+    underlying_symbol: Option<&str>,
+    settlement_price: Option<Decimal>,
+) -> PyResult<()> {
+    if symbol.trim().is_empty() {
+        return Err(validation_err("symbol must not be empty"));
+    }
+    ensure_positive(tick_size, "tick_size")?;
+    ensure_positive(lot_size, "lot_size")?;
+    ensure_positive(multiplier, "multiplier")?;
+    ensure_non_negative(margin_ratio, "margin_ratio")?;
+    if let Some(v) = settlement_price {
+        ensure_positive(v, "settlement_price")?;
+    }
+    if asset_type == AssetType::Option {
+        if let Some(v) = strike_price {
+            ensure_non_negative(v, "strike_price")?;
+        }
+        if let Some(us) = underlying_symbol {
+            if us.trim().is_empty() {
+                return Err(validation_err(
+                    "underlying_symbol must not be empty for option",
+                ));
+            }
+        } else {
+            return Err(validation_err(
+                "underlying_symbol must not be empty for option",
+            ));
+        }
+    }
+    Ok(())
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StockInstrument {
@@ -121,6 +182,7 @@ impl Instrument {
         settlement_type: Option<SettlementType>,
         settlement_price: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
+        let clean_symbol = symbol.trim().to_string();
         let multiplier_val = multiplier
             .map(extract_decimal)
             .transpose()?
@@ -138,21 +200,34 @@ impl Instrument {
             .transpose()?
             .unwrap_or(Decimal::ONE);
         let settlement_price_val = settlement_price.map(extract_decimal).transpose()?;
+        let strike_price_val = strike_price.map(extract_decimal).transpose()?;
+        let underlying_symbol_value = underlying_symbol.as_deref();
+        validate_instrument_inputs(
+            &clean_symbol,
+            asset_type,
+            multiplier_val,
+            margin_val,
+            tick_val,
+            lot_val,
+            strike_price_val,
+            underlying_symbol_value,
+            settlement_price_val,
+        )?;
 
         let inner = match asset_type {
             AssetType::Stock => InstrumentEnum::Stock(StockInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 lot_size: lot_val,
                 tick_size: tick_val,
                 expiry_date,
             }),
             AssetType::Fund => InstrumentEnum::Fund(FundInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 lot_size: lot_val,
                 tick_size: tick_val,
             }),
             AssetType::Futures => InstrumentEnum::Futures(FuturesInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 multiplier: multiplier_val,
                 margin_ratio: margin_val,
                 tick_size: tick_val,
@@ -161,27 +236,24 @@ impl Instrument {
                 settlement_price: settlement_price_val,
             }),
             AssetType::Option => InstrumentEnum::Option(OptionInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 multiplier: multiplier_val,
                 margin_ratio: margin_val,
                 tick_size: tick_val,
                 option_type: option_type.unwrap_or(OptionType::Call),
-                strike_price: strike_price
-                    .map(extract_decimal)
-                    .transpose()?
-                    .unwrap_or(Decimal::ZERO),
+                strike_price: strike_price_val.unwrap_or(Decimal::ZERO),
                 expiry_date: expiry_date.unwrap_or(0),
                 underlying_symbol: underlying_symbol.unwrap_or_default(),
                 settlement_type,
             }),
             AssetType::Crypto => InstrumentEnum::Crypto(CryptoInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 lot_size: lot_val,
                 tick_size: tick_val,
                 multiplier: multiplier_val,
             }),
             AssetType::Forex => InstrumentEnum::Forex(ForexInstrument {
-                symbol: symbol.clone(),
+                symbol: clean_symbol.clone(),
                 lot_size: lot_val,
                 tick_size: tick_val,
                 multiplier: multiplier_val,
@@ -313,5 +385,61 @@ impl Instrument {
             InstrumentEnum::Futures(f) => f.settlement_price,
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_instrument_new_rejects_empty_symbol() {
+        let result = validate_instrument_inputs(
+            "   ",
+            AssetType::Stock,
+            Decimal::ONE,
+            Decimal::ONE,
+            Decimal::new(1, 2),
+            Decimal::ONE,
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_instrument_new_rejects_non_positive_tick_size() {
+        let result = validate_instrument_inputs(
+            "AAPL",
+            AssetType::Stock,
+            Decimal::ONE,
+            Decimal::ONE,
+            Decimal::ZERO,
+            Decimal::ONE,
+            None,
+            None,
+            None,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_instrument_new_rejects_option_without_underlying() {
+        let result = Instrument::new(
+            "OPT".to_string(),
+            AssetType::Option,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(20260101),
+            None,
+            Some("".to_string()),
+            None,
+            None,
+        );
+        assert!(result.is_err());
     }
 }

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -1,10 +1,54 @@
 use super::market_data::extract_decimal;
 use super::types::{OrderRole, OrderSide, OrderStatus, OrderType, TimeInForce};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
+
+const ORDER_VALIDATION_PREFIX: &str = "AKQ-ORDER-VALIDATION";
+
+fn validation_err(message: &str) -> PyErr {
+    PyValueError::new_err(format!("[{ORDER_VALIDATION_PREFIX}] {message}"))
+}
+
+fn ensure_positive(value: Decimal, field: &str) -> PyResult<()> {
+    if value <= Decimal::ZERO {
+        return Err(validation_err(&format!("{field} must be > 0")));
+    }
+    Ok(())
+}
+
+fn ensure_non_negative(value: Decimal, field: &str) -> PyResult<()> {
+    if value < Decimal::ZERO {
+        return Err(validation_err(&format!("{field} must be >= 0")));
+    }
+    Ok(())
+}
+
+fn validate_order_inputs(
+    quantity: Decimal,
+    price: Option<Decimal>,
+    trigger_price: Option<Decimal>,
+    trail_offset: Option<Decimal>,
+    trail_reference_price: Option<Decimal>,
+) -> PyResult<()> {
+    ensure_positive(quantity, "quantity")?;
+    if let Some(v) = price {
+        ensure_positive(v, "price")?;
+    }
+    if let Some(v) = trigger_price {
+        ensure_positive(v, "trigger_price")?;
+    }
+    if let Some(v) = trail_offset {
+        ensure_non_negative(v, "trail_offset")?;
+    }
+    if let Some(v) = trail_reference_price {
+        ensure_positive(v, "trail_reference_price")?;
+    }
+    Ok(())
+}
 
 #[gen_stub_pyclass]
 #[pyclass(from_py_object)]
@@ -109,29 +153,41 @@ impl Order {
         trail_reference_price: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         let created_at_ts = created_at.unwrap_or(0);
+        let quantity_dec = extract_decimal(quantity)?;
+        let price_dec = match price {
+            Some(p) => Some(extract_decimal(p)?),
+            None => None,
+        };
+        let trigger_dec = match trigger_price {
+            Some(p) => Some(extract_decimal(p)?),
+            None => None,
+        };
+        let trail_offset_dec = match trail_offset {
+            Some(v) => Some(extract_decimal(v)?),
+            None => None,
+        };
+        let trail_reference_dec = match trail_reference_price {
+            Some(v) => Some(extract_decimal(v)?),
+            None => None,
+        };
+        validate_order_inputs(
+            quantity_dec,
+            price_dec,
+            trigger_dec,
+            trail_offset_dec,
+            trail_reference_dec,
+        )?;
         Ok(Order {
             id,
             symbol,
             side,
             order_type,
-            quantity: extract_decimal(quantity)?,
-            price: match price {
-                Some(p) => Some(extract_decimal(p)?),
-                None => None,
-            },
+            quantity: quantity_dec,
+            price: price_dec,
             time_in_force: time_in_force.unwrap_or(TimeInForce::Day),
-            trigger_price: match trigger_price {
-                Some(p) => Some(extract_decimal(p)?),
-                None => None,
-            },
-            trail_offset: match trail_offset {
-                Some(v) => Some(extract_decimal(v)?),
-                None => None,
-            },
-            trail_reference_price: match trail_reference_price {
-                Some(v) => Some(extract_decimal(v)?),
-                None => None,
-            },
+            trigger_price: trigger_dec,
+            trail_offset: trail_offset_dec,
+            trail_reference_price: trail_reference_dec,
             graph_id,
             parent_order_id,
             order_role: order_role.unwrap_or_default(),
@@ -185,7 +241,9 @@ impl Order {
     #[setter]
     fn set_trail_offset(&mut self, value: Option<&Bound<'_, PyAny>>) -> PyResult<()> {
         if let Some(v) = value {
-            self.trail_offset = Some(extract_decimal(v)?);
+            let dec = extract_decimal(v)?;
+            ensure_non_negative(dec, "trail_offset")?;
+            self.trail_offset = Some(dec);
         } else {
             self.trail_offset = None;
         }
@@ -203,7 +261,9 @@ impl Order {
     #[setter]
     fn set_trail_reference_price(&mut self, value: Option<&Bound<'_, PyAny>>) -> PyResult<()> {
         if let Some(v) = value {
-            self.trail_reference_price = Some(extract_decimal(v)?);
+            let dec = extract_decimal(v)?;
+            ensure_positive(dec, "trail_reference_price")?;
+            self.trail_reference_price = Some(dec);
         } else {
             self.trail_reference_price = None;
         }
@@ -219,7 +279,9 @@ impl Order {
 
     #[setter]
     fn set_filled_quantity(&mut self, value: &Bound<'_, PyAny>) -> PyResult<()> {
-        self.filled_quantity = extract_decimal(value)?;
+        let dec = extract_decimal(value)?;
+        ensure_non_negative(dec, "filled_quantity")?;
+        self.filled_quantity = dec;
         Ok(())
     }
 
@@ -234,7 +296,9 @@ impl Order {
     #[setter]
     fn set_average_filled_price(&mut self, value: Option<&Bound<'_, PyAny>>) -> PyResult<()> {
         if let Some(v) = value {
-            self.average_filled_price = Some(extract_decimal(v)?);
+            let dec = extract_decimal(v)?;
+            ensure_positive(dec, "average_filled_price")?;
+            self.average_filled_price = Some(dec);
         } else {
             self.average_filled_price = None;
         }
@@ -461,5 +525,17 @@ mod tests {
         let trade: Trade =
             rmp_serde::from_slice(&bytes).expect("deserialize trade from legacy payload");
         assert!(trade.owner_strategy_id.is_none());
+    }
+
+    #[test]
+    fn test_order_new_rejects_non_positive_quantity() {
+        let result = validate_order_inputs(Decimal::ZERO, None, None, None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_order_new_rejects_non_positive_price() {
+        let result = validate_order_inputs(Decimal::from(1), Some(Decimal::ZERO), None, None, None);
+        assert!(result.is_err());
     }
 }

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -479,15 +479,21 @@ mod tests {
     #[test]
     fn test_cancel_active_order_updates_status_and_cleans_oco_mapping() {
         let mut manager = OrderManager::new();
-        manager.active_orders.push(make_order("order-a", OrderStatus::Submitted));
-        manager.active_orders.push(make_order("order-b", OrderStatus::Submitted));
+        manager
+            .active_orders
+            .push(make_order("order-a", OrderStatus::Submitted));
+        manager
+            .active_orders
+            .push(make_order("order-b", OrderStatus::Submitted));
         manager.register_oco_group(
             "oco-1".to_string(),
             "order-a".to_string(),
             "order-b".to_string(),
         );
 
-        let cancelled = manager.cancel_active_order("order-b", 123).expect("cancelled");
+        let cancelled = manager
+            .cancel_active_order("order-b", 123)
+            .expect("cancelled");
         assert_eq!(cancelled.status, OrderStatus::Cancelled);
         assert_eq!(cancelled.updated_at, 123);
         assert!(!manager.oco_order_to_group.contains_key("order-b"));

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -5,8 +5,8 @@ use crate::event::Event;
 use crate::model::{Bar, ExecutionMode, Order, OrderStatus, TradingSession};
 use crate::pipeline::processor::{Processor, ProcessorResult};
 use pyo3::prelude::*;
-use rust_decimal::prelude::*;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
@@ -237,10 +237,8 @@ impl Processor for ChannelProcessor {
                                         "filled_qty",
                                         cancelled_order_snapshot.filled_quantity.to_string(),
                                     );
-                                    cancel_payload.insert(
-                                        "symbol",
-                                        cancelled_order_snapshot.symbol.clone(),
-                                    );
+                                    cancel_payload
+                                        .insert("symbol", cancelled_order_snapshot.symbol.clone());
                                     cancel_payload.insert(
                                         "owner_strategy_id",
                                         cancelled_order_snapshot
@@ -270,7 +268,9 @@ impl Processor for ChannelProcessor {
                                     .order_manager
                                     .consume_bracket_activation_on_fill(&filled_order_snapshot);
                                 for bracket_order in bracket_exit_orders {
-                                    let _ = engine.event_manager.send(Event::OrderRequest(bracket_order));
+                                    let _ = engine
+                                        .event_manager
+                                        .send(Event::OrderRequest(bracket_order));
                                 }
                             }
                         }
@@ -343,7 +343,8 @@ impl Processor for ChannelProcessor {
                 let has_sell = pending_order_requests
                     .iter()
                     .any(|order| order.side == crate::model::OrderSide::Sell);
-                let can_do_two_phase = has_buy && has_sell && should_run_post_strategy_match_now(engine);
+                let can_do_two_phase =
+                    has_buy && has_sell && should_run_post_strategy_match_now(engine);
 
                 if can_do_two_phase {
                     let mut sell_orders = Vec::new();
@@ -490,8 +491,7 @@ impl Processor for DataProcessor {
                     }
                     let mut progress_payload = HashMap::new();
                     progress_payload.insert("processed", engine.bar_count.to_string());
-                    progress_payload
-                        .insert("total", engine.progress_total_steps.to_string());
+                    progress_payload.insert("total", engine.progress_total_steps.to_string());
                     engine.emit_stream_event(py, "progress", None, "info", progress_payload);
                 }
                 self.last_timestamp = timestamp;
@@ -555,7 +555,13 @@ impl Processor for DataProcessor {
                             "accrued_interest",
                             engine.margin_accrued_interest.to_string(),
                         );
-                        engine.emit_stream_event(py, "settlement", None, "info", settlement_payload);
+                        engine.emit_stream_event(
+                            py,
+                            "settlement",
+                            None,
+                            "info",
+                            settlement_payload,
+                        );
                     }
                     if settlement_outcome.forced_liquidation {
                         let liquidated_symbols = settlement_outcome.liquidated_symbols.clone();
@@ -575,14 +581,9 @@ impl Processor for DataProcessor {
                         );
                         let mut risk_payload = HashMap::new();
                         risk_payload.insert("date", local_date.to_string());
-                        risk_payload.insert(
-                            "liquidated_count",
-                            liquidated_symbols.len().to_string(),
-                        );
-                        risk_payload.insert(
-                            "liquidated_symbols",
-                            liquidated_symbols.join(","),
-                        );
+                        risk_payload
+                            .insert("liquidated_count", liquidated_symbols.len().to_string());
+                        risk_payload.insert("liquidated_symbols", liquidated_symbols.join(","));
                         risk_payload.insert("priority", priority);
                         engine.emit_stream_event(py, "risk", None, "warn", risk_payload);
                     }
@@ -685,7 +686,15 @@ fn flush_pending_engine_bracket_plans(
     if pending_plans.is_empty() {
         return Ok(());
     }
-    for (entry_order_id, stop_trigger_price, take_profit_price, time_in_force, stop_tag, take_profit_tag) in pending_plans {
+    for (
+        entry_order_id,
+        stop_trigger_price,
+        take_profit_price,
+        time_in_force,
+        stop_tag,
+        take_profit_tag,
+    ) in pending_plans
+    {
         let stop_trigger_decimal = stop_trigger_price.and_then(rust_decimal::Decimal::from_f64);
         let take_profit_decimal = take_profit_price.and_then(rust_decimal::Decimal::from_f64);
         engine.state.order_manager.register_bracket_plan(

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -12,6 +12,14 @@ use std::collections::HashMap;
 
 use std::sync::Arc;
 
+fn checked_mul_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_mul(rhs).unwrap_or(Decimal::MAX)
+}
+
+fn checked_add_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_add(rhs).unwrap_or(Decimal::MAX)
+}
+
 #[gen_stub_pyclass]
 #[pyclass(from_py_object)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -212,7 +220,9 @@ impl Portfolio {
                 } else {
                     Decimal::ONE
                 };
-                equity += quantity * price * multiplier;
+                let exposure =
+                    checked_mul_or_cap(checked_mul_or_cap(*quantity, *price), multiplier);
+                equity = checked_add_or_cap(equity, exposure);
             }
         }
         equity
@@ -253,11 +263,10 @@ impl Portfolio {
                         }
                         _ => linear_calc.calculate_margin(*quantity, *price, instr, None),
                     };
-                    used_margin += margin;
+                    used_margin = checked_add_or_cap(used_margin, margin);
                 } else {
-                    // If no instrument info, assume 100% margin (Spot like)
-                    let position_value = (quantity * price).abs();
-                    used_margin += position_value;
+                    let position_value = checked_mul_or_cap(quantity.abs(), price.abs());
+                    used_margin = checked_add_or_cap(used_margin, position_value);
                 }
             }
         }

--- a/src/risk/common.rs
+++ b/src/risk/common.rs
@@ -6,6 +6,42 @@ use std::collections::HashMap;
 
 use super::rule::{RiskCheckContext, RiskRule};
 
+const RISK_OVERFLOW_PREFIX: &str = "AKQ-RISK-OVERFLOW";
+
+fn risk_overflow_error(symbol: &str, field: &str) -> AkQuantError {
+    AkQuantError::OrderError(format!(
+        "[{RISK_OVERFLOW_PREFIX}] overflow while calculating margin for {symbol} at {field}",
+    ))
+}
+
+fn checked_add_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_add(rhs).unwrap_or(Decimal::MAX)
+}
+
+fn checked_sub_or_zero(lhs: Decimal, rhs: Decimal) -> Decimal {
+    lhs.checked_sub(rhs).unwrap_or(Decimal::ZERO)
+}
+
+fn checked_mul_or_err(
+    lhs: Decimal,
+    rhs: Decimal,
+    symbol: &str,
+    field: &str,
+) -> Result<Decimal, AkQuantError> {
+    lhs.checked_mul(rhs)
+        .ok_or_else(|| risk_overflow_error(symbol, field))
+}
+
+fn checked_sub_or_err(
+    lhs: Decimal,
+    rhs: Decimal,
+    symbol: &str,
+    field: &str,
+) -> Result<Decimal, AkQuantError> {
+    lhs.checked_sub(rhs)
+        .ok_or_else(|| risk_overflow_error(symbol, field))
+}
+
 /// Check restricted list
 #[derive(Debug, Clone)]
 pub struct RestrictedListRule;
@@ -148,7 +184,7 @@ impl RiskRule for CashMarginRule {
             prices_for_order.insert(order.symbol.clone(), order_price);
 
             let required_margin =
-                calc_required_margin_delta(order, ctx, &prices_for_order, ctx.portfolio);
+                calc_required_margin_delta(order, ctx, &prices_for_order, ctx.portfolio)?;
 
             if required_margin.is_zero() {
                 return Ok(());
@@ -169,11 +205,9 @@ impl RiskRule for CashMarginRule {
                 };
                 let mut prices_for_active = ctx.current_prices.clone();
                 prices_for_active.insert(o.symbol.clone(), active_price);
-                committed_margin += calc_required_margin_delta(
-                    o,
-                    ctx,
-                    &prices_for_active,
-                    &projected_portfolio,
+                committed_margin = checked_add_or_cap(
+                    committed_margin,
+                    calc_required_margin_delta(o, ctx, &prices_for_active, &projected_portfolio)?,
                 );
 
                 let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
@@ -190,7 +224,13 @@ impl RiskRule for CashMarginRule {
             let safety_margin = ctx.config.safety_margin;
             let safety_factor = Decimal::from_f64(1.0 - safety_margin)
                 .unwrap_or(Decimal::from_f64(0.9999).unwrap());
-            let available_margin = (free_margin * safety_factor - committed_margin).max(Decimal::ZERO);
+            let available_margin = checked_sub_or_zero(
+                free_margin
+                    .checked_mul(safety_factor)
+                    .unwrap_or(Decimal::ZERO),
+                committed_margin,
+            )
+            .max(Decimal::ZERO);
 
             if required_margin > available_margin {
                 return Err(AkQuantError::OrderError(format!(
@@ -212,16 +252,51 @@ fn stock_margin_delta(
     price: Decimal,
     multiplier: Decimal,
     initial_margin_ratio: Decimal,
-) -> Decimal {
+) -> Result<Decimal, AkQuantError> {
     let current_abs = current_pos.abs();
+    let safe_price = price.abs();
+    let safe_multiplier = multiplier.abs();
+    let safe_initial_margin_ratio = initial_margin_ratio.abs();
     let next_pos = match order.side {
         OrderSide::Buy => current_pos + order.quantity,
         OrderSide::Sell => current_pos - order.quantity,
     };
     let next_abs = next_pos.abs();
-    let current_margin = current_abs * price * multiplier * initial_margin_ratio;
-    let next_margin = next_abs * price * multiplier * initial_margin_ratio;
-    (next_margin - current_margin).max(Decimal::ZERO)
+    let current_notional = checked_mul_or_err(
+        current_abs,
+        safe_price,
+        &order.symbol,
+        "current_abs * price",
+    )?;
+    let current_gross = checked_mul_or_err(
+        current_notional,
+        safe_multiplier,
+        &order.symbol,
+        "current_notional * multiplier",
+    )?;
+    let current_margin = checked_mul_or_err(
+        current_gross,
+        safe_initial_margin_ratio,
+        &order.symbol,
+        "current_gross * initial_margin_ratio",
+    )?;
+
+    let next_notional =
+        checked_mul_or_err(next_abs, safe_price, &order.symbol, "next_abs * price")?;
+    let next_gross = checked_mul_or_err(
+        next_notional,
+        safe_multiplier,
+        &order.symbol,
+        "next_notional * multiplier",
+    )?;
+    let next_margin = checked_mul_or_err(
+        next_gross,
+        safe_initial_margin_ratio,
+        &order.symbol,
+        "next_gross * initial_margin_ratio",
+    )?;
+
+    Ok(checked_sub_or_zero(next_margin, current_margin).max(Decimal::ZERO))
 }
 
 fn calc_required_margin_delta(
@@ -229,7 +304,7 @@ fn calc_required_margin_delta(
     ctx: &RiskCheckContext,
     prices: &HashMap<String, Decimal>,
     portfolio: &crate::portfolio::Portfolio,
-) -> Decimal {
+) -> Result<Decimal, AkQuantError> {
     if let Some(instr) = ctx.instruments.get(&order.symbol) {
         if ctx.config.is_margin_account()
             && (instr.asset_type == AssetType::Stock || instr.asset_type == AssetType::Fund)
@@ -239,7 +314,7 @@ fn calc_required_margin_delta(
                 .copied()
                 .unwrap_or_else(|| order.price.unwrap_or(Decimal::ZERO));
             if price <= Decimal::ZERO {
-                return Decimal::ZERO;
+                return Ok(Decimal::ZERO);
             }
             let current_pos = portfolio
                 .positions
@@ -258,14 +333,23 @@ fn calc_required_margin_delta(
 
     let mut projected_portfolio = portfolio.clone();
     let base_used = projected_portfolio.calculate_used_margin(prices, ctx.instruments);
+    if base_used == Decimal::MAX {
+        return Err(risk_overflow_error(&order.symbol, "base_used_margin"));
+    }
     {
         let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
-        let entry = positions.entry(order.symbol.clone()).or_insert(Decimal::ZERO);
+        let entry = positions
+            .entry(order.symbol.clone())
+            .or_insert(Decimal::ZERO);
         match order.side {
             OrderSide::Buy => *entry += order.quantity,
             OrderSide::Sell => *entry -= order.quantity,
         }
     }
     let next_used = projected_portfolio.calculate_used_margin(prices, ctx.instruments);
-    (next_used - base_used).max(Decimal::ZERO)
+    if next_used == Decimal::MAX {
+        return Err(risk_overflow_error(&order.symbol, "next_used_margin"));
+    }
+    let delta = checked_sub_or_err(next_used, base_used, &order.symbol, "next_used - base_used")?;
+    Ok(delta.max(Decimal::ZERO))
 }

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -315,4 +315,36 @@ mod tests {
             .to_string();
         assert!(err.contains("stop-loss threshold"));
     }
+
+    #[test]
+    fn test_check_returns_overflow_error_in_margin_path() {
+        let mut manager = RiskManager::default();
+        manager.config.account_mode = "margin".to_string();
+        manager.config.check_cash = true;
+
+        let portfolio = Portfolio {
+            cash: Decimal::from(1_000_000),
+            positions: Arc::new(HashMap::new()),
+            available_positions: Arc::new(HashMap::new()),
+        };
+
+        let mut instruments = HashMap::new();
+        instruments.insert(
+            "AAPL".to_string(),
+            create_test_instrument("AAPL", AssetType::Stock),
+        );
+
+        let mut order = create_test_order("AAPL", Decimal::MAX, Some(Decimal::MAX));
+        order.side = OrderSide::Buy;
+
+        let mut prices = HashMap::new();
+        prices.insert("AAPL".to_string(), f64::MAX);
+
+        let err = manager
+            .check(&order, &portfolio, instruments, vec![], Some(prices))
+            .expect("overflow should return reject reason");
+        assert!(err.contains("AKQ-RISK-OVERFLOW"));
+        assert!(err.contains("overflow while calculating margin"));
+        assert!(err.contains("AAPL"));
+    }
 }

--- a/src/risk/stock.rs
+++ b/src/risk/stock.rs
@@ -62,7 +62,13 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    fn make_order(id: &str, symbol: &str, side: OrderSide, qty: Decimal, status: OrderStatus) -> Order {
+    fn make_order(
+        id: &str,
+        symbol: &str,
+        side: OrderSide,
+        qty: Decimal,
+        status: OrderStatus,
+    ) -> Order {
         Order {
             id: id.to_string(),
             symbol: symbol.to_string(),

--- a/src/settlement/expiry.rs
+++ b/src/settlement/expiry.rs
@@ -1,5 +1,5 @@
-use crate::model::types::{AssetType, SettlementType};
 use crate::model::Instrument;
+use crate::model::types::{AssetType, SettlementType};
 use crate::portfolio::Portfolio;
 use chrono::{Datelike, NaiveDate};
 use rust_decimal::Decimal;
@@ -40,9 +40,9 @@ impl SettlementHandler for ExpirySettlementHandler {
             }
             let maybe_price = if instr.asset_type == AssetType::Futures {
                 match instr.settlement_type().unwrap_or(SettlementType::Cash) {
-                    SettlementType::Cash => instr.settlement_price().or_else(|| {
-                        last_prices.get(symbol).copied()
-                    }),
+                    SettlementType::Cash => instr
+                        .settlement_price()
+                        .or_else(|| last_prices.get(symbol).copied()),
                     SettlementType::Physical => last_prices.get(symbol).copied(),
                     SettlementType::ForceClose => last_prices.get(symbol).copied(),
                 }

--- a/src/settlement/manager.rs
+++ b/src/settlement/manager.rs
@@ -142,8 +142,8 @@ impl SettlementManager {
             compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
 
         let borrowed_cash = (-portfolio.cash).max(Decimal::ZERO);
-        let financing_rate = Decimal::from_f64(ctx.risk_config.financing_rate_annual)
-            .unwrap_or(Decimal::ZERO);
+        let financing_rate =
+            Decimal::from_f64(ctx.risk_config.financing_rate_annual).unwrap_or(Decimal::ZERO);
         let borrow_rate =
             Decimal::from_f64(ctx.risk_config.borrow_rate_annual).unwrap_or(Decimal::ZERO);
         let day_divisor = Decimal::from(365);
@@ -189,38 +189,42 @@ impl SettlementManager {
             })
             .collect();
         let short_first = ctx.risk_config.liquidation_short_first();
-        symbols_to_close.sort_by(|(left_symbol, left_exposure), (right_symbol, right_exposure)| {
-            let left_qty = portfolio
-                .positions
-                .get(left_symbol)
-                .copied()
-                .unwrap_or(Decimal::ZERO);
-            let right_qty = portfolio
-                .positions
-                .get(right_symbol)
-                .copied()
-                .unwrap_or(Decimal::ZERO);
-            let left_rank = if short_first {
-                if left_qty < Decimal::ZERO { 0 } else { 1 }
-            } else if left_qty > Decimal::ZERO {
-                0
-            } else {
-                1
-            };
-            let right_rank = if short_first {
-                if right_qty < Decimal::ZERO { 0 } else { 1 }
-            } else if right_qty > Decimal::ZERO {
-                0
-            } else {
-                1
-            };
-            left_rank
-                .cmp(&right_rank)
-                .then_with(|| right_exposure.cmp(left_exposure))
-        });
+        symbols_to_close.sort_by(
+            |(left_symbol, left_exposure), (right_symbol, right_exposure)| {
+                let left_qty = portfolio
+                    .positions
+                    .get(left_symbol)
+                    .copied()
+                    .unwrap_or(Decimal::ZERO);
+                let right_qty = portfolio
+                    .positions
+                    .get(right_symbol)
+                    .copied()
+                    .unwrap_or(Decimal::ZERO);
+                let left_rank = if short_first {
+                    if left_qty < Decimal::ZERO { 0 } else { 1 }
+                } else if left_qty > Decimal::ZERO {
+                    0
+                } else {
+                    1
+                };
+                let right_rank = if short_first {
+                    if right_qty < Decimal::ZERO { 0 } else { 1 }
+                } else if right_qty > Decimal::ZERO {
+                    0
+                } else {
+                    1
+                };
+                left_rank
+                    .cmp(&right_rank)
+                    .then_with(|| right_exposure.cmp(left_exposure))
+            },
+        );
 
-        let symbols_to_close: Vec<String> =
-            symbols_to_close.into_iter().map(|(symbol, _)| symbol).collect();
+        let symbols_to_close: Vec<String> = symbols_to_close
+            .into_iter()
+            .map(|(symbol, _)| symbol)
+            .collect();
         for symbol in symbols_to_close {
             let qty = portfolio
                 .positions
@@ -355,7 +359,10 @@ mod tests {
     #[test]
     fn test_margin_liquidation_closes_positions_when_maintenance_breached() {
         let mut pos = HashMap::new();
-        pos.insert("AAA".to_string(), Decimal::from_str("150").expect("decimal"));
+        pos.insert(
+            "AAA".to_string(),
+            Decimal::from_str("150").expect("decimal"),
+        );
         let mut portfolio = Portfolio {
             cash: Decimal::from(-5000),
             positions: Arc::new(pos),
@@ -455,7 +462,10 @@ mod tests {
                 .unwrap_or(Decimal::ZERO),
             Decimal::from(100)
         );
-        assert_eq!(outcome_short_first.liquidated_symbols, vec!["SHORT".to_string()]);
+        assert_eq!(
+            outcome_short_first.liquidated_symbols,
+            vec!["SHORT".to_string()]
+        );
 
         let mut portfolio_long_first = Portfolio {
             cash: Decimal::from(2000),
@@ -491,6 +501,9 @@ mod tests {
                 .unwrap_or(Decimal::ZERO),
             Decimal::from(-50)
         );
-        assert_eq!(outcome_long_first.liquidated_symbols, vec!["LONG".to_string()]);
+        assert_eq!(
+            outcome_long_first.liquidated_symbols,
+            vec!["LONG".to_string()]
+        );
     }
 }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4129,3 +4129,51 @@ def test_instrument_config_accepts_enum_inputs() -> None:
     assert conf.asset_type == "FUTURES"
     assert conf.option_type == "CALL"
     assert conf.settlement_type == "cash"
+
+
+def test_order_rejects_non_positive_quantity() -> None:
+    """Order should reject zero quantity at constructor boundary."""
+    with pytest.raises(ValueError, match=r"AKQ-ORDER-VALIDATION.*quantity must be > 0"):
+        _ = akquant.Order(
+            "o-invalid-qty",
+            "AAPL",
+            akquant.OrderSide.Buy,
+            akquant.OrderType.Limit,
+            0.0,
+            100.0,
+        )
+
+
+def test_instrument_rejects_non_positive_tick_size() -> None:
+    """Instrument should reject non-positive tick size."""
+    with pytest.raises(
+        ValueError, match=r"AKQ-INSTRUMENT-VALIDATION.*tick_size must be > 0"
+    ):
+        _ = akquant.Instrument("AAPL", akquant.AssetType.Stock, tick_size=0.0)
+
+
+def test_instrument_option_rejects_empty_underlying_symbol() -> None:
+    """Option instrument should require non-empty underlying symbol."""
+    with pytest.raises(
+        ValueError,
+        match=r"AKQ-INSTRUMENT-VALIDATION.*underlying_symbol must not be empty",
+    ):
+        _ = akquant.Instrument(
+            "OPT_BAD",
+            akquant.AssetType.Option,
+            expiry_date=20260101,
+            underlying_symbol="",
+        )
+
+
+def test_corporate_action_split_rejects_non_positive_ratio() -> None:
+    """CorporateAction split should reject non-positive ratio."""
+    with pytest.raises(
+        ValueError, match=r"AKQ-CORP-ACTION-VALIDATION.*split ratio must be > 0"
+    ):
+        _ = akquant.CorporateAction(
+            "AAPL",
+            date(2025, 1, 1),
+            akquant.CorporateActionType.Split,
+            0.0,
+        )


### PR DESCRIPTION
- 升级 Cargo.toml、Cargo.lock 和 pyproject.toml 中的版本号至 0.1.96。
- 修复多个源文件中的代码格式问题，包括长行格式化、导入顺序和括号对齐。
- 在订单、公司行动和投资组合模块中添加输入验证，防止非正数值导致运行时错误。
- 在风险管理和保证金计算中添加溢出保护，使用安全包装函数防止算术溢出。
- 添加新的单元测试以覆盖边界情况和验证逻辑。