### PR TITLE
feat(backtest): 添加保证金曲线及日频曲线支持

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.96"
+version = "0.1.97"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.96"
+version = "0.1.97"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.96"
+version = "0.1.97"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -201,6 +201,7 @@ class BacktestResult:
 
     :ivar equity_curve: 权益曲线 [(timestamp, equity)]
     :ivar cash_curve: 现金曲线 [(timestamp, cash)]
+    :ivar margin_curve: 保证金曲线 [(timestamp, margin)]
     :ivar metrics: 绩效指标对象
     :ivar trade_metrics: 交易统计对象
     :ivar trades: 平仓交易列表
@@ -211,6 +212,7 @@ class BacktestResult:
 
     equity_curve: list[tuple[int, float]]
     cash_curve: list[tuple[int, float]]
+    margin_curve: list[tuple[int, float]]
     metrics: PerformanceMetrics
     trade_metrics: TradePnL
     trades: list[ClosedTrade]

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -140,6 +140,67 @@ class BacktestResult:
         return df["cash"]
 
     @property
+    def margin_curve(self) -> pd.Series:
+        """
+        Get the margin curve as a Pandas Series.
+
+        Index: Datetime (Timezone-aware)
+        Values: Used margin
+        """
+        if not hasattr(self._raw, "margin_curve") or not self._raw.margin_curve:
+            return pd.Series(dtype=float)
+
+        df = pd.DataFrame(self._raw.margin_curve, columns=["timestamp", "margin"])
+        df["timestamp"] = pd.to_datetime(
+            df["timestamp"], unit="ns", utc=True
+        ).dt.tz_convert(self._timezone)
+        df.set_index("timestamp", inplace=True)
+        return df["margin"]
+
+    @staticmethod
+    def _to_daily_curve(series: pd.Series) -> pd.Series:
+        """
+        Convert a curve series to daily end-of-day values.
+
+        :param series: Input curve series with DatetimeIndex.
+        :return: Daily curve using last value per day.
+        """
+        if series.empty:
+            return pd.Series(dtype=float)
+        daily_series = series.resample("D").last().dropna()
+        return cast(pd.Series, daily_series)
+
+    @property
+    def equity_curve_daily(self) -> pd.Series:
+        """
+        Get daily equity curve as a Pandas Series.
+
+        Index: Datetime (Timezone-aware)
+        Values: Daily end-of-day equity
+        """
+        return self._to_daily_curve(self.equity_curve)
+
+    @property
+    def cash_curve_daily(self) -> pd.Series:
+        """
+        Get daily cash curve as a Pandas Series.
+
+        Index: Datetime (Timezone-aware)
+        Values: Daily end-of-day cash
+        """
+        return self._to_daily_curve(self.cash_curve)
+
+    @property
+    def margin_curve_daily(self) -> pd.Series:
+        """
+        Get daily margin curve as a Pandas Series.
+
+        Index: Datetime (Timezone-aware)
+        Values: Daily end-of-day used margin
+        """
+        return self._to_daily_curve(self.margin_curve)
+
+    @property
     def trades(self) -> List[ClosedTrade]:
         """
         Get closed trades as a list of raw objects (Raw Access).
@@ -1413,6 +1474,7 @@ class BacktestResult:
         market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
         plot_symbol: Optional[str] = None,
         include_trade_kline: bool = True,
+        curve_freq: str = "raw",
     ) -> None:
         """
         生成 HTML 策略回测报告 (便捷方法).
@@ -1426,6 +1488,7 @@ class BacktestResult:
         :param market_data: 可选行情数据，用于绘制 K 线买卖点图
         :param plot_symbol: 可选标的代码，指定 K 线复盘标的
         :param include_trade_kline: 是否在报告中包含 K 线复盘图
+        :param curve_freq: 曲线频率，"raw" 为原始频率，"D" 为日频末值
         """
         # 延迟导入，避免循环引用和非必要的 Plotly 依赖
         try:
@@ -1443,4 +1506,5 @@ class BacktestResult:
             market_data=market_data,
             plot_symbol=plot_symbol,
             include_trade_kline=include_trade_kline,
+            curve_freq=curve_freq,
         )

--- a/python/akquant/plot/dashboard.py
+++ b/python/akquant/plot/dashboard.py
@@ -17,6 +17,7 @@ def plot_dashboard(
     theme: str = "light",
     show: bool = True,
     filename: Optional[str] = None,
+    equity_series: Optional[pd.Series] = None,
 ) -> Optional["go.Figure"]:
     """
     Plot comprehensive dashboard for backtest result.
@@ -29,12 +30,12 @@ def plot_dashboard(
     if not check_plotly():
         return None
 
-    equity_series = result.equity_curve
-    if equity_series.empty:
+    series = equity_series if equity_series is not None else result.equity_curve
+    if series.empty:
         print("No equity curve data available.")
         return None
 
-    equity_df = equity_series.to_frame(name="equity")
+    equity_df = series.to_frame(name="equity")
 
     # Calculate Drawdown
     equity_df["max_equity"] = equity_df["equity"].cummax()

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -551,9 +551,37 @@ def _rename_table_columns(df: pd.DataFrame, mapping: dict[str, str]) -> pd.DataF
     return cast(pd.DataFrame, renamed)
 
 
-def _build_summary_context(result: Any) -> dict[str, str]:
+def _normalize_curve_freq(curve_freq: str) -> str:
+    """Normalize curve frequency option."""
+    value = str(curve_freq).strip()
+    if value.lower() == "raw":
+        return "raw"
+    if value.upper() == "D":
+        return "D"
+    raise ValueError("curve_freq must be 'raw' or 'D'")
+
+
+def _resolve_equity_curve(result: Any, curve_freq: str) -> pd.Series:
+    """Resolve equity curve for report rendering."""
+    if curve_freq == "D" and hasattr(result, "equity_curve_daily"):
+        series = cast(pd.Series, result.equity_curve_daily)
+        if not series.empty:
+            return series
+    return cast(pd.Series, result.equity_curve)
+
+
+def _build_daily_returns_from_equity(equity_curve: pd.Series) -> pd.Series:
+    """Build daily returns from equity curve."""
+    if equity_curve.empty:
+        return pd.Series(dtype=float)
+    daily_equity = equity_curve.resample("D").last().ffill()
+    returns = daily_equity.pct_change().fillna(0.0)
+    return cast(pd.Series, returns)
+
+
+def _build_summary_context(result: Any, curve_freq: str = "raw") -> dict[str, str]:
     """Build summary text values for report header."""
-    equity_curve = result.equity_curve
+    equity_curve = _resolve_equity_curve(result, curve_freq)
     start_date = "N/A"
     end_date = "N/A"
     duration_str = "N/A"
@@ -752,6 +780,7 @@ def _build_chart_html_sections(
     market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
     plot_symbol: Optional[str] = None,
     include_trade_kline: bool = True,
+    curve_freq: str = "raw",
 ) -> dict[str, str]:
     """Build chart HTML sections from plot figures."""
     config = {"responsive": True}
@@ -762,14 +791,17 @@ def _build_chart_html_sections(
         "doubleClick": "reset",
     }
 
-    fig_dashboard = plot_dashboard(result, show=False, theme="light")
+    equity_curve = _resolve_equity_curve(result, curve_freq)
+    fig_dashboard = plot_dashboard(
+        result, show=False, theme="light", equity_series=equity_curve
+    )
     dashboard_html = (
         fig_dashboard.to_html(full_html=False, include_plotlyjs=False, config=config)
         if fig_dashboard
         else "<div>暂无数据</div>"
     )
 
-    returns_series = result.daily_returns
+    returns_series = _build_daily_returns_from_equity(equity_curve)
     fig_rolling = plot_rolling_metrics(returns_series, theme="light")
     rolling_metrics_html = (
         fig_rolling.to_html(full_html=False, include_plotlyjs=False, config=config)
@@ -1576,6 +1608,7 @@ def plot_report(
     market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
     plot_symbol: Optional[str] = None,
     include_trade_kline: bool = True,
+    curve_freq: str = "raw",
 ) -> None:
     """
     生成类似 QuantStats 的整合版 HTML 报告 (中文优化版).
@@ -1586,21 +1619,24 @@ def plot_report(
     3. 交易分布与持仓时间分析 (Trade Analysis)
 
     :param compact_currency: 是否将金额列按 K/M/B 紧凑显示
+    :param curve_freq: 曲线频率，"raw" 为原始频率，"D" 为日频末值
     """
     if not check_plotly():
         return
+    normalized_curve_freq = _normalize_curve_freq(curve_freq)
 
     # Prepare Icon
     icon_b64 = base64.b64encode(AKQUANT_ICON_SVG.encode("utf-8")).decode("utf-8")
     favicon_uri = f"data:image/svg+xml;base64,{icon_b64}"
 
-    summary_context = _build_summary_context(result)
+    summary_context = _build_summary_context(result, curve_freq=normalized_curve_freq)
     metrics_html = _build_metrics_html(result)
     chart_sections = _build_chart_html_sections(
         result=result,
         market_data=market_data,
         plot_symbol=plot_symbol,
         include_trade_kline=include_trade_kline,
+        curve_freq=normalized_curve_freq,
     )
     analysis_sections = _build_analysis_table_sections(
         result, compact_currency=compact_currency

--- a/src/analysis/result.rs
+++ b/src/analysis/result.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 pub struct CalculatorInput {
     pub equity_curve_decimal: Vec<(i64, Decimal)>,
     pub cash_curve_decimal: Vec<(i64, Decimal)>,
+    pub margin_curve_decimal: Vec<(i64, Decimal)>,
     pub snapshots: Vec<(i64, Vec<PositionSnapshot>)>,
     pub trade_pnl: TradePnL,
     pub trades: Vec<ClosedTrade>,
@@ -26,6 +27,7 @@ pub struct CalculatorInput {
 ///
 /// :ivar equity_curve: 权益曲线 [(timestamp, equity)]
 /// :ivar cash_curve: 现金曲线 [(timestamp, cash)]
+/// :ivar margin_curve: 保证金曲线 [(timestamp, margin)]
 /// :ivar metrics: 绩效指标对象
 /// :ivar trade_metrics: 交易统计对象
 /// :ivar trades: 平仓交易列表
@@ -38,6 +40,8 @@ pub struct BacktestResult {
     pub equity_curve: Vec<(i64, f64)>,
     #[pyo3(get)]
     pub cash_curve: Vec<(i64, f64)>,
+    #[pyo3(get)]
+    pub margin_curve: Vec<(i64, f64)>,
     #[pyo3(get)]
     pub metrics: PerformanceMetrics,
     #[pyo3(get)]
@@ -68,11 +72,17 @@ impl BacktestResult {
             .iter()
             .map(|(t, d)| (*t, d.to_f64().unwrap_or_default()))
             .collect();
+        let margin_curve: Vec<(i64, f64)> = input
+            .margin_curve_decimal
+            .iter()
+            .map(|(t, d)| (*t, d.to_f64().unwrap_or_default()))
+            .collect();
 
         if input.equity_curve_decimal.is_empty() {
             return BacktestResult {
                 equity_curve,
                 cash_curve,
+                margin_curve,
                 metrics: PerformanceMetrics {
                     total_return: 0.0,
                     annualized_return: 0.0,
@@ -335,6 +345,7 @@ impl BacktestResult {
         BacktestResult {
             equity_curve,
             cash_curve,
+            margin_curve,
             metrics: PerformanceMetrics {
                 total_return: total_return_f64,
                 annualized_return,

--- a/src/analysis/tests.rs
+++ b/src/analysis/tests.rs
@@ -161,6 +161,7 @@ fn test_max_drawdown_logic() {
     let result = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl.clone(),
         trades: vec![],
@@ -181,6 +182,7 @@ fn test_max_drawdown_logic() {
     let result_2 = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve_2,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl.clone(),
         trades: vec![],
@@ -201,6 +203,7 @@ fn test_max_drawdown_logic() {
     let result_3 = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve_3,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl.clone(),
         trades: vec![],
@@ -224,6 +227,7 @@ fn test_max_drawdown_logic() {
     let result_4 = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve_4,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl.clone(),
         trades: vec![],
@@ -257,6 +261,7 @@ fn test_ulcer_index_logic() {
     let result = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl.clone(),
         trades: vec![],
@@ -281,6 +286,7 @@ fn test_calmar_uses_raw_drawdown_ratio_not_pct() {
     let result = BacktestResult::calculate(crate::analysis::CalculatorInput {
         equity_curve_decimal: equity_curve,
         cash_curve_decimal: vec![],
+        margin_curve_decimal: vec![],
         snapshots: vec![],
         trade_pnl: empty_pnl,
         trades: vec![],

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -895,13 +895,18 @@ impl Processor for StatisticsProcessor {
                 .state
                 .portfolio
                 .calculate_equity(&engine.last_prices, &engine.instruments);
+            let margin = engine
+                .state
+                .portfolio
+                .calculate_used_margin(&engine.last_prices, &engine.instruments);
             engine
                 .statistics_manager
-                .update(timestamp, equity, engine.state.portfolio.cash);
+                .update(timestamp, equity, engine.state.portfolio.cash, margin);
             let mut payload = HashMap::new();
             payload.insert("timestamp", timestamp.to_string());
             payload.insert("equity", equity.to_string());
             payload.insert("cash", engine.state.portfolio.cash.to_string());
+            payload.insert("margin", margin.to_string());
             engine.emit_stream_event(py, "equity", None, "info", payload);
         }
         Ok(ProcessorResult::Next)

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -17,6 +17,8 @@ pub struct StatisticsManager {
     equity_curve: Vec<(i64, Decimal)>,
     /// 现金曲线 [(timestamp, cash)]
     cash_curve: Vec<(i64, Decimal)>,
+    /// 保证金曲线 [(timestamp, used_margin)]
+    margin_curve: Vec<(i64, Decimal)>,
     /// 持仓快照 [(timestamp, snapshots)]
     pub snapshots: Vec<(i64, Vec<PositionSnapshot>)>,
     /// 强平审计记录
@@ -35,15 +37,17 @@ impl StatisticsManager {
         Self {
             equity_curve: Vec::new(),
             cash_curve: Vec::new(),
+            margin_curve: Vec::new(),
             snapshots: Vec::new(),
             liquidation_audits: Vec::new(),
         }
     }
 
     /// 更新权益和现金曲线
-    pub fn update(&mut self, timestamp: i64, equity: Decimal, cash: Decimal) {
+    pub fn update(&mut self, timestamp: i64, equity: Decimal, cash: Decimal, margin: Decimal) {
         self.equity_curve.push((timestamp, equity));
         self.cash_curve.push((timestamp, cash));
+        self.margin_curve.push((timestamp, margin));
     }
 
     /// 记录持仓快照
@@ -140,6 +144,7 @@ impl StatisticsManager {
         // Prepare data for result creation
         let mut equity_curve = self.equity_curve.clone();
         let mut cash_curve = self.cash_curve.clone();
+        let mut margin_curve = self.margin_curve.clone();
         let mut snapshots = self.snapshots.clone();
 
         // Add final snapshot if needed
@@ -154,6 +159,11 @@ impl StatisticsManager {
             // Append final cash point if not present
             if cash_curve.last().is_none_or(|(t, _)| *t != ts) {
                 cash_curve.push((ts, portfolio.cash));
+            }
+
+            if margin_curve.last().is_none_or(|(t, _)| *t != ts) {
+                let margin = portfolio.calculate_used_margin(last_prices, instruments);
+                margin_curve.push((ts, margin));
             }
 
             // Append final position snapshot if not present
@@ -171,6 +181,7 @@ impl StatisticsManager {
         BacktestResult::calculate(crate::analysis::CalculatorInput {
             equity_curve_decimal: equity_curve,
             cash_curve_decimal: cash_curve,
+            margin_curve_decimal: margin_curve,
             snapshots,
             trade_pnl,
             trades: order_manager.trade_tracker.closed_trades.to_vec(),
@@ -191,5 +202,10 @@ impl StatisticsManager {
     /// 获取当前的现金曲线（只读）
     pub fn cash_curve(&self) -> &Vec<(i64, Decimal)> {
         &self.cash_curve
+    }
+
+    /// 获取当前的保证金曲线（只读）
+    pub fn margin_curve(&self) -> &Vec<(i64, Decimal)> {
+        &self.margin_curve
     }
 }

--- a/tests/test_account_risk_rules.py
+++ b/tests/test_account_risk_rules.py
@@ -211,6 +211,9 @@ def test_short_option_margin_is_checked_and_account_margin_updates() -> None:
     assert any("Insufficient margin" in r for r in reasons), reasons
     assert ShortPutStrategy.account_snapshots
     assert any(s["margin"] > 0.0 for s in ShortPutStrategy.account_snapshots)
+    assert not result.margin_curve.empty
+    assert len(result.margin_curve) == len(result.equity_curve)
+    assert float(result.margin_curve.max()) > 0.0
 
 
 def test_margin_account_allows_short_sell_when_enabled() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1450,6 +1450,8 @@ def test_run_backtest_without_on_event_keeps_legacy_semantics() -> None:
     )
     assert result.metrics.initial_market_value == pytest.approx(100000.0, rel=1e-9)
     assert len(result.equity_curve) == len(data)
+    assert len(result.cash_curve) == len(data)
+    assert len(result.margin_curve) == len(data)
 
 
 def test_run_backtest_strategy_id_propagates_to_orders() -> None:

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -73,6 +73,29 @@ def _build_data(symbol: str = "TEST", n: int = 5) -> list[Bar]:
     return data
 
 
+def _build_intraday_data(symbol: str = "TEST") -> list[Bar]:
+    data: list[Bar] = []
+    timestamps = [
+        pd.Timestamp("2023-01-01 10:00:00"),
+        pd.Timestamp("2023-01-01 14:00:00"),
+        pd.Timestamp("2023-01-02 10:00:00"),
+    ]
+    closes = [10.0, 10.5, 11.0]
+    for ts, close in zip(timestamps, closes):
+        data.append(
+            Bar(
+                timestamp=ts.value,
+                open=close,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=10000.0,
+                symbol=symbol,
+            )
+        )
+    return data
+
+
 def _build_market_df(symbol: str = "TEST", n: int = 5) -> pd.DataFrame:
     rows = []
     for bar in _build_data(symbol=symbol, n=n):
@@ -207,6 +230,72 @@ def test_plot_functions_return_figures_for_non_empty_result() -> None:
     assert fig_rolling is not None
     fig_returns = plot_returns_distribution(result.daily_returns)
     assert fig_returns is not None
+
+
+def test_daily_curve_properties_reduce_intraday_points() -> None:
+    """Daily curve properties should downsample intraday points to day-end."""
+    result = run_backtest(
+        data=_build_intraday_data(),
+        strategy=NoTradeStrategy,
+        symbol="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert len(result.equity_curve) == 3
+    assert len(result.cash_curve) == 3
+    assert len(result.margin_curve) == 3
+    assert len(result.equity_curve_daily) == 2
+    assert len(result.cash_curve_daily) == 2
+    assert len(result.margin_curve_daily) == 2
+
+
+def test_report_accepts_curve_freq_daily(tmp_path: Path) -> None:
+    """Report generation should support daily curve frequency mode."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_intraday_data(),
+        strategy=NoTradeStrategy,
+        symbol="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+    )
+    report_path = tmp_path / "report_curve_freq_daily.html"
+    result.report(filename=str(report_path), show=False, curve_freq="D")
+    assert report_path.exists()
+
+
+def test_report_rejects_invalid_curve_freq(tmp_path: Path) -> None:
+    """Report generation should reject unsupported curve frequency values."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_intraday_data(),
+        strategy=NoTradeStrategy,
+        symbol="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        execution_mode="current_close",
+        lot_size=1,
+        show_progress=False,
+    )
+    report_path = tmp_path / "report_curve_freq_invalid.html"
+    with pytest.raises(ValueError):
+        result.report(filename=str(report_path), show=False, curve_freq="W")
 
 
 def test_report_contains_forced_liquidation_audit_section(tmp_path: Path) -> None:


### PR DESCRIPTION
- 在回测结果中新增 margin_curve 字段，记录保证金使用情况
- 为 equity_curve、cash_curve 和 margin_curve 添加对应的 daily 属性，提供日频末值曲线
- 报告生成支持 curve_freq 参数，可选择原始频率或日频模式
- 更新相关测试以确保新功能正常工作
- 将版本号从 0.1.96 升级至 0.1.97