### PR TITLE
feat: 新增保证金曲线与日频曲线属性，支持报告频率选择

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.1.97"
+version = "0.1.98"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.1.97"
+version = "0.1.98"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -17,6 +17,7 @@ result.report(
     filename="report.html",
     show=True,  # Set to True to open in browser automatically (default is False)
     compact_currency=True,  # Format amount columns as K/M/B in report tables
+    curve_freq="raw",  # "raw" keeps all bars, "D" uses end-of-day points
 )
 ```
 
@@ -27,6 +28,7 @@ result.report(
     title="My Strategy Report",
     filename="report_raw_amount.html",
     compact_currency=False,
+    curve_freq="D",
 )
 ```
 
@@ -139,14 +141,24 @@ aqp.plot_pnl_vs_duration(result.trades_df)
 *   **SQN**: System Quality Number. Measures system stability.
 *   **Kelly Criterion**: Optimal position size based on win rate and payoff ratio.
 
-## Equity & Cash Curves
+## Equity, Cash & Margin Curves
 
-The `result` object provides equity and cash curves over time, useful for plotting and analysis.
+The `result` object provides equity/cash/margin curves over time, useful for plotting and risk analysis.
 
 | Property | Description | Type | Explanation |
 | :--- | :--- | :--- | :--- |
 | `equity_curve` | Equity Curve | `pandas.Series` | Index is `Datetime`, values are Total Equity. Shows the trend of net asset value. |
 | `cash_curve` | Cash Curve | `pandas.Series` | Index is `Datetime`, values are Available Cash. Shows the trend of liquid capital, useful for money management analysis. |
+| `margin_curve` | Margin Curve | `pandas.Series` | Index is `Datetime`, values are Used Margin. Useful for leveraged/margin account monitoring. |
+| `equity_curve_daily` | Daily Equity Curve | `pandas.Series` | End-of-day `equity_curve` values, useful for fast reporting and long-horizon comparisons. |
+| `cash_curve_daily` | Daily Cash Curve | `pandas.Series` | End-of-day `cash_curve` values. |
+| `margin_curve_daily` | Daily Margin Curve | `pandas.Series` | End-of-day `margin_curve` values. |
+
+For long intraday backtests, you can speed up HTML report rendering by using daily curve mode:
+
+```python
+result.report(filename="report_daily.html", curve_freq="D")
+```
 
 ## Trades
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -844,6 +844,10 @@ Backtest result object.
 *   `positions_df`: Daily position details.
 *   `equity_curve`: Equity curve.
 *   `cash_curve`: Cash curve.
+*   `margin_curve`: Margin curve (used margin over time).
+*   `equity_curve_daily`: Daily end-of-day equity curve.
+*   `cash_curve_daily`: Daily end-of-day cash curve.
+*   `margin_curve_daily`: Daily end-of-day margin curve.
 
 **Analysis Methods:**
 
@@ -853,6 +857,7 @@ Backtest result object.
 *   `orders_by_strategy()`: Strategy-ownership order aggregation by `owner_strategy_id`.
 *   `executions_by_strategy()`: Strategy-ownership execution aggregation by `owner_strategy_id`.
 *   `get_event_stats()`: Unified stream summary stats (for example `processed_events`, `dropped_event_count`, `callback_error_count`, `backpressure_policy`, `stream_mode`).
+*   `report(..., curve_freq="raw" | "D")`: Generate HTML report with raw or daily curve frequency.
 
 ```python
 orders_by_strategy = result.orders_by_strategy()

--- a/docs/en/start/quickstart.md
+++ b/docs/en/start/quickstart.md
@@ -240,13 +240,27 @@ result.report(
     show=True,
     filename="report.html",
     compact_currency=True,
+    curve_freq="raw",
 )
 
 result.report(
     show=False,
     filename="report_raw_amount.html",
     compact_currency=False,
+    curve_freq="D",
 )
+```
+
+Curve outputs are also directly reusable:
+
+```python
+equity = result.equity_curve
+cash = result.cash_curve
+margin = result.margin_curve
+
+equity_daily = result.equity_curve_daily
+cash_daily = result.cash_curve_daily
+margin_daily = result.margin_curve_daily
 ```
 
 You can also reuse structured analysis outputs for downstream research:

--- a/docs/en/textbook/10_analysis.md
+++ b/docs/en/textbook/10_analysis.md
@@ -4,6 +4,7 @@ This chapter is currently maintained in Chinese first.
 
 - Chinese chapter: [第 10 章：策略评价体系与风险指标](../../zh/textbook/10_analysis.md)
 - Textbook home: [Chinese textbook index](../../zh/textbook/index.md)
+- Note: `BacktestResult` now includes `margin_curve` plus daily curve properties (`*_curve_daily`), and `result.report(curve_freq="D")` for faster long-range HTML reports.
 - Practice links:
   - Primary example: [examples/textbook/ch10_analysis.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch10_analysis.py)
   - Extended example: [examples/33_report_and_analysis_outputs.py](https://github.com/akfamily/akquant/blob/main/examples/33_report_and_analysis_outputs.py)

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -80,14 +80,18 @@
 *   **系统质量指数 (SQN)**: 衡量交易系统的稳定性。SQN 越高，越容易通过加大仓位来获利。一般认为 >2.0 为合格，>3.0 为优秀，>7.0 为圣杯。
 *   **凯利公式 (Kelly Criterion)**: 基于胜率和盈亏比计算的理论最佳仓位比例。注意凯利公式通常过于激进，实盘中常使用 "半凯利" (Half-Kelly) 甚至更低比例。
 
-## 权益与现金曲线 (Curves)
+## 权益、现金与保证金曲线 (Curves)
 
-`result` 对象提供了权益和现金随时间变化的曲线数据，方便进行绘图和分析。
+`result` 对象提供了权益、现金与保证金随时间变化的曲线数据，方便进行绘图和风控分析。
 
 | 属性名称 (Property) | 含义 (Description) | 类型 (Type) | 说明 |
 | :--- | :--- | :--- | :--- |
 | `equity_curve` | 权益曲线 | `pandas.Series` | 索引为时间 (`Datetime`)，值为账户总权益 (`Equity`)。反映账户资产净值的变化趋势。 |
 | `cash_curve` | 现金曲线 | `pandas.Series` | 索引为时间 (`Datetime`)，值为账户可用现金 (`Cash`)。反映账户流动资金的变化情况，有助于资金管理分析。 |
+| `margin_curve` | 保证金曲线 | `pandas.Series` | 索引为时间 (`Datetime`)，值为账户占用保证金 (`Margin`)。适用于杠杆/保证金账户监控。 |
+| `equity_curve_daily` | 日频权益曲线 | `pandas.Series` | `equity_curve` 按日取最后一个点，适合长周期对比与报告提速。 |
+| `cash_curve_daily` | 日频现金曲线 | `pandas.Series` | `cash_curve` 按日取最后一个点。 |
+| `margin_curve_daily` | 日频保证金曲线 | `pandas.Series` | `margin_curve` 按日取最后一个点。 |
 | `daily_returns` | 日收益率 | `pandas.Series` | 索引为时间 (`Datetime`)，值为每日收益率。用于计算夏普、波动率等指标。 |
 
 ## 交易明细 (Trades)
@@ -173,6 +177,7 @@ result.report(
     filename="report.html",
     show=True,  # 设为 True 以自动在浏览器中打开 (默认为 False)
     compact_currency=True,  # 金额列使用 K/M/B 紧凑显示 (默认为 True)
+    curve_freq="raw",  # "raw" 保留原始频率，"D" 使用日频末值
 )
 ```
 
@@ -183,6 +188,7 @@ result.report(
     title="我的策略报告",
     filename="report_raw_amount.html",
     compact_currency=False,
+    curve_freq="D",
 )
 ```
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -907,6 +907,11 @@ class RiskConfig:
 *   `executions_df`: 所有成交流水表格（优先使用 Rust IPC/dict 快速导出）。
 *   `positions_df`: 每日持仓详情。
 *   `equity_curve`: 权益曲线 (List[Tuple[timestamp, value]])。
+*   `cash_curve`: 现金曲线 (List[Tuple[timestamp, value]])。
+*   `margin_curve`: 保证金曲线 (List[Tuple[timestamp, value]])。
+*   `equity_curve_daily`: 日频权益曲线（按日末值聚合）。
+*   `cash_curve_daily`: 日频现金曲线（按日末值聚合）。
+*   `margin_curve_daily`: 日频保证金曲线（按日末值聚合）。
 *   `trades`: `ClosedTrade` 对象列表。
 *   `executions`: `Trade` 对象列表 (所有成交流水)。
 *   `snapshots`: 每日 `PositionSnapshot` 列表。
@@ -919,6 +924,7 @@ class RiskConfig:
 *   `orders_by_strategy()`: 按 `owner_strategy_id` 聚合订单统计。
 *   `executions_by_strategy()`: 按 `owner_strategy_id` 聚合成交流水统计。
 *   `get_event_stats()`: 返回流式事件统计摘要（如 `processed_events`、`dropped_event_count`、`callback_error_count`、`backpressure_policy`、`stream_mode`）。
+*   `report(..., curve_freq="raw" | "D")`: 生成 HTML 报告时，可选原始频率或日频末值曲线。
 
 ```python
 orders_by_strategy = result.orders_by_strategy()

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -274,13 +274,27 @@ result.report(
     show=True,
     filename="report.html",
     compact_currency=True,
+    curve_freq="raw",
 )
 
 result.report(
     show=False,
     filename="report_raw_amount.html",
     compact_currency=False,
+    curve_freq="D",
 )
+```
+
+你也可以直接复用曲线数据做二次分析：
+
+```python
+equity = result.equity_curve
+cash = result.cash_curve
+margin = result.margin_curve
+
+equity_daily = result.equity_curve_daily
+cash_daily = result.cash_curve_daily
+margin_daily = result.margin_curve_daily
 ```
 
 你也可以直接获取结构化分析结果用于二次研究：

--- a/docs/zh/textbook/10_analysis.md
+++ b/docs/zh/textbook/10_analysis.md
@@ -139,7 +139,25 @@ avg_loss = abs(trades[trades['pnl'] < 0]['pnl'].mean())
 pl_ratio = avg_profit / avg_loss
 ```
 
-### 10.5.3 代码示例
+### 10.5.3 曲线与报告频率
+
+在杠杆/保证金场景下，建议同时观察权益、现金与保证金曲线：
+
+```python
+equity = result.equity_curve
+cash = result.cash_curve
+margin = result.margin_curve
+
+# 日频末值（用于长周期对比或加速报告渲染）
+equity_daily = result.equity_curve_daily
+cash_daily = result.cash_curve_daily
+margin_daily = result.margin_curve_daily
+
+# 报告可选使用日频曲线
+result.report(filename="report_daily.html", curve_freq="D")
+```
+
+### 10.5.4 代码示例
 
 下面的代码演示了如何运行策略并生成详细的性能分析报告。
 

--- a/examples/textbook/ch10_analysis.py
+++ b/examples/textbook/ch10_analysis.py
@@ -121,6 +121,16 @@ def analyze_results(result: Any) -> None:
     else:
         print("无交易记录")
 
+    print("\n" + "=" * 40)
+    print("3. 曲线与报告频率 (Curves & Report Frequency)")
+    print("=" * 40)
+    print(f"权益曲线点数: {len(result.equity_curve)}")
+    print(f"现金曲线点数: {len(result.cash_curve)}")
+    print(f"保证金曲线点数: {len(result.margin_curve)}")
+    print(f"日频权益点数: {len(result.equity_curve_daily)}")
+    print(f"日频现金点数: {len(result.cash_curve_daily)}")
+    print(f"日频保证金点数: {len(result.margin_curve_daily)}")
+
 
 if __name__ == "__main__":
     df = generate_mock_data()
@@ -132,3 +142,6 @@ if __name__ == "__main__":
 
     # 执行分析函数
     analyze_results(result)
+    result.report(
+        filename="ch10_analysis_report_daily.html", show=False, curve_freq="D"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.1.97"
+version = "0.1.98"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_time.py
+++ b/python/akquant/strategy_time.py
@@ -17,9 +17,15 @@ def format_time(strategy: Any, timestamp: int, fmt: str = "%Y-%m-%d %H:%M:%S") -
 def now(strategy: Any) -> Optional[pd.Timestamp]:
     """获取当前回测时间的本地时间表示."""
     ts = None
-    if strategy.current_bar:
+    ctx = getattr(strategy, "ctx", None)
+    if ctx is not None:
+        current_time = int(getattr(ctx, "current_time", 0))
+        if current_time > 0:
+            ts = current_time
+
+    if ts is None and strategy.current_bar:
         ts = strategy.current_bar.timestamp
-    elif strategy.current_tick:
+    elif ts is None and strategy.current_tick:
         ts = strategy.current_tick.timestamp
 
     if ts is not None:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -793,6 +793,32 @@ def test_callback_sequence_on_timer() -> None:
     ]
 
 
+def test_now_uses_context_time_for_timer_event() -> None:
+    """Now should use context current_time during timer callbacks."""
+    strategy = SequenceStrategy()
+
+    bar_ctx = _build_ctx_with_order_and_trade("bar_order")
+    bar_ts = pd.Timestamp("2023-01-01 09:59:00", tz="Asia/Shanghai").value
+    bar_ctx.current_time = bar_ts
+    bar = Bar(
+        timestamp=bar_ts,
+        open=100.0,
+        high=100.0,
+        low=100.0,
+        close=100.0,
+        volume=100.0,
+        symbol="AAPL",
+    )
+    strategy._on_bar_event(bar, bar_ctx)
+
+    timer_ctx = _build_ctx_with_order_and_trade("timer_order")
+    timer_ts = pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai").value
+    timer_ctx.current_time = timer_ts
+    strategy._on_timer_event("rebalance", timer_ctx)
+
+    assert strategy.now == pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai")
+
+
 class WarmStartE2EStrategy(Strategy):
     """Strategy for warm start end-to-end test."""
 


### PR DESCRIPTION
- 为 BacktestResult 新增 margin_curve 属性，用于监控杠杆账户保证金占用
- 新增 *_curve_daily 属性（equity_curve_daily、cash_curve_daily、margin_curve_daily），提供日频末值聚合曲线
- 为 result.report() 添加 curve_freq 参数，支持 "raw"（原始频率）或 "D"（日频）两种曲线模式
- 修复 strategy.now() 在定时器回调中优先使用上下文时间的问题
- 更新中英文文档、API 参考和示例代码
- 提升版本至 0.1.98