### PR TITLE
feat(backtest): 支持通过 catalog_path 参数指定数据目录并展示拒单原因 Top 8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.1"
+version = "0.2.2"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -1537,6 +1537,7 @@ def run_backtest(
     show_progress: Optional[bool] = None,
     start_time: Optional[Union[str, Any]] = None,
     end_time: Optional[Union[str, Any]] = None,
+    catalog_path: Optional[str] = None,
     config: Optional[BacktestConfig] = None,
     custom_matchers: Optional[Dict[AssetType, Any]] = None,
     risk_config: Optional[Union[Dict[str, Any], RiskConfig]] = None,
@@ -1627,6 +1628,8 @@ def run_backtest(
                        config.start_time.
     :param end_time: 回测结束时间 (e.g., "2020-12-31 15:00"). 优先级高于
                      config.end_time.
+    :param catalog_path: 当 data 未显式传入时，按该目录加载 ParquetDataCatalog 数据。
+                         不传则使用 ParquetDataCatalog 默认目录。
     :param config: BacktestConfig 配置对象 (可选)
     :param strategy_runtime_config: 策略运行时配置对象或字典 (可选)
     :param runtime_config_override: 是否覆盖策略实例内已有 runtime_config (默认 True)
@@ -2442,7 +2445,8 @@ def run_backtest(
         if not symbols:
             logger.warning("No symbols specified and no data provided.")
 
-        catalog = ParquetDataCatalog()
+        catalog = ParquetDataCatalog(root_path=catalog_path)
+        logger.info(f"Loading backtest data from catalog root: {catalog.root}")
         # start_time / end_time already resolved above
 
         loaded_count = 0

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -1119,13 +1119,22 @@ class BacktestResult:
 
     def _risk_reason_masks(self, rejected: pd.DataFrame) -> dict[str, pd.Series]:
         reason_lower = rejected["reject_reason"].fillna("").astype(str).str.lower()
-        daily_loss_mask = reason_lower.str.contains("daily loss", regex=False)
+        daily_loss_mask = reason_lower.str.contains(
+            "daily loss", regex=False
+        ) | reason_lower.str.contains("stop-loss threshold", regex=False)
         drawdown_mask = reason_lower.str.contains("drawdown", regex=False)
-        reduce_only_mask = reason_lower.str.contains("reduce_only mode", regex=False)
+        reduce_only_mask = reason_lower.str.contains(
+            "reduce_only mode", regex=False
+        ) | reason_lower.str.contains("cooldown", regex=False)
         position_limit_mask = reason_lower.str.contains(
             "projected position", regex=False
+        ) | reason_lower.str.contains("available position", regex=False)
+        position_limit_mask = position_limit_mask | reason_lower.str.contains(
+            "is restricted", regex=False
         )
-        order_size_mask = reason_lower.str.contains("order quantity", regex=False)
+        order_size_mask = reason_lower.str.contains(
+            "order quantity", regex=False
+        ) | reason_lower.str.contains("lot size", regex=False)
         order_value_mask = reason_lower.str.contains("order value", regex=False)
         strategy_budget_mask = reason_lower.str.contains(
             "risk budget", regex=False
@@ -1154,6 +1163,51 @@ class BacktestResult:
             "portfolio_risk_budget_reject_count": portfolio_budget_mask.astype(int),
             "other_risk_reject_count": (~known_mask).astype(int),
         }
+
+    def top_reject_reasons(self, top_n: int = 10) -> pd.DataFrame:
+        """Get Top-N rejection reasons from orders."""
+        columns = ["reject_reason", "count", "ratio"]
+        if top_n <= 0:
+            return pd.DataFrame(columns=columns)
+
+        orders = self.orders_df.copy()
+        if orders.empty:
+            return pd.DataFrame(columns=columns)
+
+        if "reject_reason" not in orders.columns:
+            orders["reject_reason"] = ""
+        if "status" not in orders.columns:
+            orders["status"] = ""
+        reject_reason = orders["reject_reason"].fillna("").astype(str)
+        status = orders["status"].fillna("").astype(str)
+        rejected_mask = (reject_reason.str.len() > 0) | status.str.contains(
+            "Rejected", case=False, regex=False
+        )
+        rejected = orders.loc[rejected_mask].copy()
+        if rejected.empty:
+            return pd.DataFrame(columns=columns)
+
+        cleaned_reason = (
+            rejected["reject_reason"]
+            .fillna("")
+            .astype(str)
+            .str.strip()
+            .replace("", "(empty reject reason)")
+        )
+        all_counts = cleaned_reason.value_counts()
+        counts = all_counts.head(top_n)
+        total = int(all_counts.sum())
+        if total <= 0:
+            return pd.DataFrame(columns=columns)
+
+        frame = pd.DataFrame(
+            {
+                "reject_reason": counts.index.astype(str),
+                "count": counts.values.astype(int),
+            }
+        )
+        frame["ratio"] = frame["count"] / float(total)
+        return cast(pd.DataFrame, frame.reset_index(drop=True))
 
     def risk_rejections_by_strategy(self) -> pd.DataFrame:
         """Get strategy-level risk rejection breakdown table."""

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -1096,6 +1096,7 @@ def _build_chart_html_sections(
     risk_reject_trend_html = "<div>暂无按日风控拒单趋势图</div>"
     risk_reject_trend_by_strategy_html = "<div>暂无按策略风控拒单趋势图</div>"
     risk_reason_trend_html = "<div>暂无按日拒单原因趋势图</div>"
+    risk_other_reason_table_html = ""
     has_risk_ratio_chart = False
     has_risk_reason_ratio_chart = False
     has_risk_trend_chart = False
@@ -1109,6 +1110,34 @@ def _build_chart_html_sections(
         if hasattr(result, "risk_rejections_by_strategy")
         else pd.DataFrame()
     )
+    top_reasons_df = (
+        result.top_reject_reasons(top_n=8)
+        if hasattr(result, "top_reject_reasons")
+        else pd.DataFrame()
+    )
+    if not top_reasons_df.empty:
+        top_reasons_view = _rename_table_columns(
+            top_reasons_df,
+            {
+                "reject_reason": "拒单原因 (Reject Reason)",
+                "count": "拒单数 (Count)",
+                "ratio": "占比 (Ratio)",
+            },
+        )
+        top_reasons_table_html = _format_table(
+            top_reasons_view,
+            max_rows=8,
+            percentage_columns={"占比 (Ratio)"},
+            compact_currency=False,
+        )
+        risk_other_reason_table_html = (
+            '<div class="chart-container" style="margin-top: 20px;">'
+            "<h3 style='margin: 0 0 10px 0;'>"
+            "拒单原因 Top 8 明细 (Top Reject Reasons)"
+            "</h3>"
+            f"{top_reasons_table_html}"
+            "</div>"
+        )
     if not risk_df.empty and "risk_reject_count" in risk_df.columns:
         risk_base_df = risk_df.copy()
         if "owner_strategy_id" not in risk_base_df.columns:
@@ -1474,6 +1503,8 @@ def _build_chart_html_sections(
         append_risk_chart_block(liquidation_count_chart_html)
     if has_liquidation_interest_chart:
         append_risk_chart_block(liquidation_interest_chart_html)
+    if risk_other_reason_table_html:
+        risk_chart_blocks.append(risk_other_reason_table_html)
 
     if risk_chart_blocks:
         risk_charts_html = "".join(risk_chart_blocks)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from akquant.backtest import engine as backtest_engine
+from akquant.data import ParquetDataCatalog
 
 
 def test_engine_initialization() -> None:
@@ -682,6 +683,66 @@ def test_fill_policy_next_event_matches_legacy_parameters() -> None:
 
     assert strategy.timer_timestamp is not None
     assert strategy.trade_timestamp != strategy.timer_timestamp
+
+
+def test_run_backtest_catalog_path_loads_data(tmp_path: Path) -> None:
+    """run_backtest should load bars from explicit catalog_path when data is None."""
+    symbol = "CATALOG_PATH_OK"
+    catalog_root = tmp_path / "catalog"
+    catalog = ParquetDataCatalog(root_path=str(catalog_root))
+    data = pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-02", periods=3, freq="D"),
+            "open": [10.0, 11.0, 12.0],
+            "high": [10.0, 11.0, 12.0],
+            "low": [10.0, 11.0, 12.0],
+            "close": [10.0, 11.0, 12.0],
+            "volume": [1000.0, 1000.0, 1000.0],
+            "symbol": [symbol, symbol, symbol],
+        }
+    ).set_index("date")
+    _ = catalog.write(symbol, data)
+
+    result = akquant.run_backtest(
+        strategy=SingleBuyStrategy,
+        symbols=symbol,
+        catalog_path=str(catalog_root),
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert not result.orders_df.empty
+    assert str(result.orders_df["symbol"].iloc[0]) == symbol
+
+
+def test_backtest_result_top_reject_reasons_and_lot_size_category() -> None:
+    """Lot-size rejects should be included in top reasons and order-size bucket."""
+    symbol = "LOT_SIZE_REASON"
+    bars = _build_regression_bars(symbol)
+
+    result = akquant.run_backtest(
+        data=bars,
+        strategy=SingleBuyStrategy,
+        symbols=symbol,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=100,
+        show_progress=False,
+    )
+
+    top_reasons = result.top_reject_reasons(top_n=5)
+    assert not top_reasons.empty
+    assert "reject_reason" in top_reasons.columns
+    assert "count" in top_reasons.columns
+    assert "ratio" in top_reasons.columns
+    assert any(
+        "lot size" in reason
+        for reason in top_reasons["reject_reason"].fillna("").astype(str).tolist()
+    )
+
+    risk_df = result.risk_rejections_by_strategy()
+    assert not risk_df.empty
+    assert int(risk_df["order_size_limit_reject_count"].sum()) >= 1
 
 
 def test_policy_resolver_next_close_same_cycle_sets_timer_same_cycle() -> None:


### PR DESCRIPTION
- 为 run_backtest 函数新增 catalog_path 参数，当未显式传入 data 时，用于加载 ParquetDataCatalog 数据
- 在回测结果报告中新增拒单原因 Top 8 明细表格
- 扩展风险拒单原因分类，包含止损、冷却、持仓限制及手数限制等
- 新增 top_reject_reasons 方法用于获取拒单原因排名
- 添加相关单元测试验证功能
- 更新项目版本至 0.2.2