### PR TITLE
feat(风控/回测): 支持同周期卖出再买入的现金复用并区分自动调整与明确数量订单

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.3"
+version = "0.2.4"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -2477,6 +2477,7 @@ class StrategyContext:
         fill_slippage_value: typing.Optional[float] = ...,
         fill_commission_type: typing.Optional[str] = ...,
         fill_commission_value: typing.Optional[float] = ...,
+        allow_quantity_auto_resize: bool = ...,
     ) -> str:
         r"""
         买入下单.

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -2813,6 +2813,13 @@ def run_backtest(
         resolved_policy.bar_offset,
         resolved_policy.temporal,
     )
+    default_fill_policy: FillPolicy = {
+        "price_basis": resolved_policy.price_basis,
+        "bar_offset": resolved_policy.bar_offset,
+        "temporal": resolved_policy.temporal,
+    }
+    for current_strategy in all_strategy_instances:
+        setattr(current_strategy, "_default_fill_policy", dict(default_fill_policy))
     timer_policy = resolved_policy.temporal
     if (
         not (resolved_policy.price_basis == "close" and resolved_policy.bar_offset == 0)

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -16,6 +16,21 @@ from .strategy_framework_hooks import (
 from .strategy_scheduler import flush_pending_schedules
 
 
+def _flush_deferred_target_value_orders(strategy: Any, event_symbol: str) -> None:
+    deferred_orders = getattr(strategy, "_deferred_target_value_orders", None)
+    if not deferred_orders:
+        return
+    remaining_orders = []
+    from .strategy_trading_api import order_target_value
+
+    for symbol, target_value, price, kwargs in deferred_orders:
+        if symbol == event_symbol:
+            order_target_value(strategy, target_value, symbol, price, **kwargs)
+        else:
+            remaining_orders.append((symbol, target_value, price, kwargs))
+    setattr(strategy, "_deferred_target_value_orders", remaining_orders)
+
+
 def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     """引擎调用的 Bar 回调 (Internal)."""
     ensure_framework_state(strategy)
@@ -56,6 +71,7 @@ def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
         mark_portfolio_dirty(strategy)
     dispatch_time_hooks(strategy)
     dispatch_portfolio_update(strategy)
+    _flush_deferred_target_value_orders(strategy, bar.symbol)
 
     strategy._bar_count += 1
 
@@ -102,6 +118,7 @@ def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
         mark_portfolio_dirty(strategy)
     dispatch_time_hooks(strategy)
     dispatch_portfolio_update(strategy)
+    _flush_deferred_target_value_orders(strategy, tick.symbol)
     call_user_callback(strategy, "on_tick", tick, payload=tick)
 
 

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -260,6 +260,7 @@ def _submit_buy_side(
     if ref_price is None:
         ref_price = strategy._last_prices.get(symbol, 0.0)
 
+    allow_quantity_auto_resize = quantity is None
     if quantity is None:
         quantity = strategy.sizer.get_size(
             ref_price, strategy.ctx.cash, strategy.ctx, symbol
@@ -289,7 +290,13 @@ def _submit_buy_side(
             return cast(
                 str,
                 strategy.ctx.buy(
-                    symbol, quantity, price, time_in_force, trigger_price, tag or ""
+                    symbol,
+                    quantity,
+                    price,
+                    time_in_force,
+                    trigger_price,
+                    tag or "",
+                    allow_quantity_auto_resize=allow_quantity_auto_resize,
                 ),
             )
         return cast(
@@ -311,6 +318,7 @@ def _submit_buy_side(
                 fill_slippage_value,
                 fill_commission_type,
                 fill_commission_value,
+                allow_quantity_auto_resize,
             ),
         )
     return ""
@@ -1019,6 +1027,26 @@ def order_target_weights(
 
     sell_legs = [item for item in planned if item[2] < 0]
     buy_legs = [item for item in planned if item[2] >= 0]
+    effective_fill_policy = _resolve_effective_order_fill_policy(
+        strategy,
+        cast(Optional[OrderFillPolicy], kwargs.get("fill_policy")),
+    )
+    if effective_fill_policy is None:
+        stored_fill_policy = cast(
+            Optional[OrderFillPolicy], getattr(strategy, "_default_fill_policy", None)
+        )
+        if stored_fill_policy is not None:
+            effective_fill_policy = dict(stored_fill_policy)
+    fill_price_basis, fill_bar_offset, fill_temporal = _normalize_order_fill_policy(
+        effective_fill_policy
+    )
+    defer_buy_legs = (
+        sell_legs
+        and buy_legs
+        and fill_price_basis == "close"
+        and fill_bar_offset == 0
+        and fill_temporal == "same_cycle"
+    )
 
     for symbol, target_value, _ in sorted(sell_legs, key=lambda item: item[2]):
         leg_price = price_map.get(symbol) if price_map else None
@@ -1028,6 +1056,14 @@ def order_target_weights(
         buy_legs, key=lambda item: item[2], reverse=True
     ):
         leg_price = price_map.get(symbol) if price_map else None
+        if defer_buy_legs:
+            deferred_orders = cast(
+                list[tuple[str, float, Optional[float], dict[str, Any]]],
+                getattr(strategy, "_deferred_target_value_orders", []),
+            )
+            deferred_orders.append((symbol, target_value, leg_price, dict(kwargs)))
+            setattr(strategy, "_deferred_target_value_orders", deferred_orders)
+            continue
         order_target_value(strategy, target_value, symbol, leg_price, **kwargs)
 
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -497,7 +497,7 @@ impl StrategyContext {
     /// :param trigger_price: 触发价格 (可选, 用于止损/止盈单)
     /// :param tag: 订单标签 (可选)
     /// :return: 订单 ID
-    #[pyo3(signature = (symbol, quantity, price=None, time_in_force=None, trigger_price=None, tag=None, order_type=None, trail_offset=None, trail_reference_price=None, fill_price_basis=None, fill_bar_offset=None, fill_temporal=None, fill_slippage_type=None, fill_slippage_value=None, fill_commission_type=None, fill_commission_value=None))]
+    #[pyo3(signature = (symbol, quantity, price=None, time_in_force=None, trigger_price=None, tag=None, order_type=None, trail_offset=None, trail_reference_price=None, fill_price_basis=None, fill_bar_offset=None, fill_temporal=None, fill_slippage_type=None, fill_slippage_value=None, fill_commission_type=None, fill_commission_value=None, allow_quantity_auto_resize=false))]
     #[allow(clippy::too_many_arguments)]
     fn buy(
         &mut self,
@@ -517,6 +517,7 @@ impl StrategyContext {
         fill_slippage_value: Option<&Bound<'_, PyAny>>,
         fill_commission_type: Option<String>,
         fill_commission_value: Option<&Bound<'_, PyAny>>,
+        allow_quantity_auto_resize: bool,
     ) -> PyResult<String> {
         let qty_decimal = extract_decimal(quantity)?;
         let price_decimal = if let Some(p) = price {
@@ -585,6 +586,7 @@ impl StrategyContext {
             tag: tag.unwrap_or_default(),
             reject_reason: String::new(),
             owner_strategy_id: self.strategy_id.clone(),
+            allow_quantity_auto_resize,
         };
         if let Some(tx) = &self.event_tx {
             let _ = tx.send(Event::OrderRequest(order));
@@ -691,6 +693,7 @@ impl StrategyContext {
             tag: tag.unwrap_or_default(),
             reject_reason: String::new(),
             owner_strategy_id: self.strategy_id.clone(),
+            allow_quantity_auto_resize: false,
         };
         if let Some(tx) = &self.event_tx {
             let _ = tx.send(Event::OrderRequest(order));

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -177,17 +177,25 @@ impl ExecutionClient for SimulatedExecutionClient {
         }
 
         // Track available margin for this step (snapshot of portfolio + changes in this loop)
-        let mut current_free_margin = ctx
-            .portfolio
-            .calculate_free_margin(ctx.last_prices, ctx.instruments);
+        let mut projected_portfolio = ctx.portfolio.clone();
+        let mut current_free_margin =
+            projected_portfolio.calculate_free_margin(ctx.last_prices, ctx.instruments);
 
-        // Split borrows
-        let orders = &mut self.orders;
-        let queue = &self.order_queue;
+        let mut queue: Vec<String> = self.order_queue.clone();
+        queue.sort_by_key(|order_id| {
+            self.orders
+                .get(order_id)
+                .map(|order| match order.side {
+                    crate::model::OrderSide::Sell => 0_u8,
+                    crate::model::OrderSide::Buy => 1_u8,
+                })
+                .unwrap_or(2_u8)
+        });
+
         let matchers = &self.matchers;
 
-        for order_id in queue {
-            if let Some(order) = orders.get_mut(order_id) {
+        for order_id in &queue {
+            if let Some(order) = self.orders.get_mut(order_id) {
                 if order.status == OrderStatus::Cancelled
                     || order.status == OrderStatus::Filled
                     || order.status == OrderStatus::Rejected
@@ -214,9 +222,11 @@ impl ExecutionClient for SimulatedExecutionClient {
                         let report_opt = matcher.match_order(order, &match_ctx);
 
                         if let Some(mut report) = report_opt {
-                            // Check for dynamic position sizing (margin check)
-                            if let Event::ExecutionReport(ref mut _r_order, Some(ref mut trade)) =
-                                report
+                            let mut replacement_report: Option<Event> = None;
+                            if let Event::ExecutionReport(
+                                ref mut report_order,
+                                Some(ref mut trade),
+                            ) = report
                                 && trade.side == crate::model::OrderSide::Buy
                             {
                                 // Calculate estimated commission
@@ -243,70 +253,96 @@ impl ExecutionClient for SimulatedExecutionClient {
                                 let total_required = margin_required + commission;
 
                                 if total_required > current_free_margin {
-                                    // Insufficient margin, reduce quantity
-                                    let unit_margin = trade.price * multiplier * margin_ratio;
-                                    let mut max_qty = if unit_margin > Decimal::ZERO {
-                                        if current_free_margin <= Decimal::ZERO {
-                                            Decimal::ZERO
+                                    if report_order.allow_quantity_auto_resize {
+                                        let unit_margin = trade.price * multiplier * margin_ratio;
+                                        let mut max_qty = if unit_margin > Decimal::ZERO {
+                                            if current_free_margin <= Decimal::ZERO {
+                                                Decimal::ZERO
+                                            } else {
+                                                current_free_margin / unit_margin
+                                            }
                                         } else {
-                                            current_free_margin / unit_margin
-                                        }
-                                    } else {
-                                        Decimal::ZERO
-                                    };
+                                            Decimal::ZERO
+                                        };
 
-                                    // Apply safety factor (Default 0.9999 if risk manager not available)
-                                    let safety_margin = 0.0001;
-                                    let safety_factor = Decimal::from_f64(1.0 - safety_margin)
+                                        let safety_margin = 0.0001;
+                                        let safety_factor = Decimal::from_f64(1.0 - safety_margin)
                                             .unwrap_or_else(|| {
                                                 log::warn!("Invalid safety factor calculation, defaulting to 0.9999");
                                                 Decimal::from_f64(0.9999).unwrap_or(Decimal::ZERO)
                                             });
-                                    max_qty *= safety_factor;
+                                        max_qty *= safety_factor;
 
-                                    let lot_size = instrument.lot_size();
-                                    let mut new_qty = max_qty.floor();
-                                    if lot_size > Decimal::ZERO {
-                                        new_qty = new_qty - (new_qty % lot_size);
-                                    }
-
-                                    // Recalculate to ensure it fits
-                                    let new_comm = ctx.market_model.calculate_commission(
-                                        instrument,
-                                        trade.side,
-                                        trade.price,
-                                        new_qty,
-                                    );
-                                    let new_margin =
-                                        trade.price * new_qty * multiplier * margin_ratio;
-
-                                    if new_margin + new_comm > current_free_margin {
-                                        if new_qty >= lot_size {
-                                            new_qty -= lot_size;
-                                        } else {
-                                            new_qty = Decimal::ZERO;
+                                        let lot_size = instrument.lot_size();
+                                        let mut new_qty = max_qty.floor();
+                                        if lot_size > Decimal::ZERO {
+                                            new_qty = new_qty - (new_qty % lot_size);
                                         }
+
+                                        let new_comm = ctx.market_model.calculate_commission(
+                                            instrument,
+                                            trade.side,
+                                            trade.price,
+                                            new_qty,
+                                        );
+                                        let new_margin =
+                                            trade.price * new_qty * multiplier * margin_ratio;
+
+                                        if new_margin + new_comm > current_free_margin {
+                                            if new_qty >= lot_size {
+                                                new_qty -= lot_size;
+                                            } else {
+                                                new_qty = Decimal::ZERO;
+                                            }
+                                        }
+
+                                        trade.quantity = new_qty;
+                                    } else {
+                                        let mut rejected_order = report_order.clone();
+                                        rejected_order.status = crate::model::OrderStatus::Rejected;
+                                        rejected_order.updated_at = ctx.current_time;
+                                        rejected_order.reject_reason = format!(
+                                            "Risk: Insufficient margin at execution. Required: {total_required}, Available: {current_free_margin}"
+                                        );
+                                        replacement_report =
+                                            Some(Event::ExecutionReport(rejected_order, None));
                                     }
-
-                                    // Update trade quantity
-                                    trade.quantity = new_qty;
                                 }
 
-                                // Deduct cost from current_free_margin for next orders in this loop
-                                if trade.quantity > Decimal::ZERO {
-                                    let final_comm = ctx.market_model.calculate_commission(
-                                        instrument,
-                                        trade.side,
-                                        trade.price,
-                                        trade.quantity,
-                                    );
-                                    let final_margin =
-                                        trade.price * trade.quantity * multiplier * margin_ratio;
-                                    current_free_margin -= final_margin + final_comm;
-                                }
                             }
 
-                            // Filter out zero quantity trades
+                            if let Some(new_report) = replacement_report {
+                                report = new_report;
+                            }
+
+                            if let Event::ExecutionReport(_, Some(ref trade)) = report
+                                && trade.quantity > Decimal::ZERO
+                            {
+                                let commission = ctx.market_model.calculate_commission(
+                                    instrument,
+                                    trade.side,
+                                    trade.price,
+                                    trade.quantity,
+                                );
+                                let cost = trade.price * trade.quantity * instrument.multiplier();
+                                projected_portfolio.adjust_cash(-commission);
+                                if trade.side == crate::model::OrderSide::Buy {
+                                    projected_portfolio.adjust_cash(-cost);
+                                    projected_portfolio.adjust_position(
+                                        &trade.symbol,
+                                        trade.quantity,
+                                    );
+                                } else {
+                                    projected_portfolio.adjust_cash(cost);
+                                    projected_portfolio.adjust_position(
+                                        &trade.symbol,
+                                        -trade.quantity,
+                                    );
+                                }
+                                current_free_margin = projected_portfolio
+                                    .calculate_free_margin(ctx.last_prices, ctx.instruments);
+                            }
+
                             let mut keep_report = true;
                             if let Event::ExecutionReport(_, Some(ref trade)) = report
                                 && trade.quantity <= Decimal::ZERO

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -124,6 +124,8 @@ pub struct Order {
     #[pyo3(get)]
     #[serde(default)]
     pub owner_strategy_id: Option<String>,
+    #[serde(default)]
+    pub allow_quantity_auto_resize: bool,
 }
 
 #[gen_stub_pymethods]
@@ -215,6 +217,7 @@ impl Order {
             tag: tag.unwrap_or_default(),
             reject_reason: String::new(),
             owner_strategy_id,
+            allow_quantity_auto_resize: false,
         })
     }
 
@@ -380,6 +383,7 @@ impl Order {
             tag: String::new(),
             reject_reason: String::new(),
             owner_strategy_id: None,
+            allow_quantity_auto_resize: false,
         }
     }
 }

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -198,6 +198,7 @@ impl OrderManager {
                 tag: plan.stop_tag.clone(),
                 reject_reason: String::new(),
                 owner_strategy_id: filled_order.owner_strategy_id.clone(),
+                allow_quantity_auto_resize: false,
             });
         }
 
@@ -230,6 +231,7 @@ impl OrderManager {
                 tag: plan.take_profit_tag.clone(),
                 reject_reason: String::new(),
                 owner_strategy_id: filled_order.owner_strategy_id.clone(),
+                allow_quantity_auto_resize: false,
             });
         }
 

--- a/src/risk/common.rs
+++ b/src/risk/common.rs
@@ -14,10 +14,6 @@ fn risk_overflow_error(symbol: &str, field: &str) -> AkQuantError {
     ))
 }
 
-fn checked_add_or_cap(lhs: Decimal, rhs: Decimal) -> Decimal {
-    lhs.checked_add(rhs).unwrap_or(Decimal::MAX)
-}
-
 fn checked_sub_or_zero(lhs: Decimal, rhs: Decimal) -> Decimal {
     lhs.checked_sub(rhs).unwrap_or(Decimal::ZERO)
 }
@@ -183,15 +179,7 @@ impl RiskRule for CashMarginRule {
             let mut prices_for_order = ctx.current_prices.clone();
             prices_for_order.insert(order.symbol.clone(), order_price);
 
-            let required_margin =
-                calc_required_margin_delta(order, ctx, &prices_for_order, ctx.portfolio)?;
-
-            if required_margin.is_zero() {
-                return Ok(());
-            }
-
             let mut projected_portfolio = ctx.portfolio.clone();
-            let mut committed_margin = Decimal::ZERO;
             for o in ctx.active_orders {
                 if o.status != crate::model::OrderStatus::New {
                     continue;
@@ -203,38 +191,41 @@ impl RiskRule for CashMarginRule {
                 } else {
                     continue;
                 };
-                let mut prices_for_active = ctx.current_prices.clone();
-                prices_for_active.insert(o.symbol.clone(), active_price);
-                committed_margin = checked_add_or_cap(
-                    committed_margin,
-                    calc_required_margin_delta(o, ctx, &prices_for_active, &projected_portfolio)?,
-                );
-
-                let positions = std::sync::Arc::make_mut(&mut projected_portfolio.positions);
-                let entry = positions.entry(o.symbol.clone()).or_insert(Decimal::ZERO);
-                match o.side {
-                    OrderSide::Buy => *entry += o.quantity,
-                    OrderSide::Sell => *entry -= o.quantity,
+                if let Some(instr) = ctx.instruments.get(&o.symbol) {
+                    let cost = active_price * o.quantity * instr.multiplier();
+                    match o.side {
+                        OrderSide::Buy => {
+                            projected_portfolio.adjust_cash(-cost);
+                            projected_portfolio.adjust_position(&o.symbol, o.quantity);
+                        }
+                        OrderSide::Sell => {
+                            projected_portfolio.adjust_cash(cost);
+                            projected_portfolio.adjust_position(&o.symbol, -o.quantity);
+                        }
+                    }
                 }
             }
 
-            let free_margin = ctx
-                .portfolio
-                .calculate_free_margin(ctx.current_prices, ctx.instruments);
+            let required_margin =
+                calc_required_margin_delta(order, ctx, &prices_for_order, &projected_portfolio)?;
+
+            if required_margin.is_zero() {
+                return Ok(());
+            }
+
+            let free_margin =
+                projected_portfolio.calculate_free_margin(ctx.current_prices, ctx.instruments);
             let safety_margin = ctx.config.safety_margin;
             let safety_factor = Decimal::from_f64(1.0 - safety_margin)
                 .unwrap_or(Decimal::from_f64(0.9999).unwrap());
-            let available_margin = checked_sub_or_zero(
-                free_margin
-                    .checked_mul(safety_factor)
-                    .unwrap_or(Decimal::ZERO),
-                committed_margin,
-            )
-            .max(Decimal::ZERO);
+            let available_margin = free_margin
+                .checked_mul(safety_factor)
+                .unwrap_or(Decimal::ZERO)
+                .max(Decimal::ZERO);
 
             if required_margin > available_margin {
                 return Err(AkQuantError::OrderError(format!(
-                    "Risk: Insufficient margin. Required: {required_margin}, Available: {available_margin} (Free: {free_margin}, Committed: {committed_margin}, Safety: {safety_margin})",
+                    "Risk: Insufficient margin. Required: {required_margin}, Available: {available_margin} (Free: {free_margin}, Safety: {safety_margin})",
                 )));
             }
         }

--- a/src/risk/manager.rs
+++ b/src/risk/manager.rs
@@ -192,7 +192,9 @@ impl RiskManager {
             let err_msg = err.to_string();
             // Check for insufficient cash/margin to attempt auto-reduction
             // This logic was moved from OrderManager
-            if (err_msg.contains("Insufficient cash") || err_msg.contains("Insufficient margin"))
+            if order.allow_quantity_auto_resize
+                && (err_msg.contains("Insufficient cash")
+                    || err_msg.contains("Insufficient margin"))
                 && order.side == crate::model::OrderSide::Buy
                 && let Some(instr) = ctx.instruments.get(&order.symbol)
             {

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -206,13 +206,13 @@ class TargetWeightsStrategy(Strategy):
 
         if self.rebalance_count == 0:
             self.order_target_weights(
-                {"AAA": 1.0},
+                {"AAA": 0.9},
                 liquidate_unmentioned=True,
                 rebalance_tolerance=0.0,
             )
         elif self.rebalance_count in (1, 2):
             self.order_target_weights(
-                {"BBB": 1.0},
+                {"BBB": 0.9},
                 liquidate_unmentioned=True,
                 rebalance_tolerance=0.0,
             )
@@ -246,6 +246,55 @@ class TargetWeightsSplitStrategy(Strategy):
             self.rebalanced = True
 
 
+class TargetWeightsSellThenBuyStrategy(Strategy):
+    """Strategy for validating same-cycle sell-then-buy cash release."""
+
+    def __init__(self, symbols: list[str]) -> None:
+        """Initialize staged rotation state."""
+        super().__init__()
+        self.symbols = symbols
+        self.pending: dict[int, set[str]] = defaultdict(set)
+        self.rebalance_count = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        """Rotate from AAA to BBB on the second completed timestamp."""
+        bucket = self.pending[bar.timestamp]
+        bucket.add(bar.symbol)
+        if len(bucket) < len(self.symbols):
+            return
+        self.pending.pop(bar.timestamp, None)
+
+        if self.rebalance_count == 0:
+            self.order_target_weights(
+                {"AAA": 0.9},
+                liquidate_unmentioned=True,
+                rebalance_tolerance=0.0,
+            )
+        elif self.rebalance_count == 1:
+            self.order_target_weights(
+                {"BBB": 0.9},
+                liquidate_unmentioned=True,
+                rebalance_tolerance=0.0,
+            )
+        self.rebalance_count += 1
+
+
+class ExplicitQuantityRejectStrategy(Strategy):
+    """Strategy for validating explicit buy quantity rejects."""
+
+    def __init__(self) -> None:
+        """Initialize single-submit state."""
+        super().__init__()
+        self.submitted = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit one oversized explicit buy order."""
+        if self.submitted:
+            return
+        self.buy(symbol=bar.symbol, quantity=20_000.0)
+        self.submitted = True
+
+
 def test_order_target_weights_rotation_liquidates_unmentioned_symbols() -> None:
     """Target weights should support one-call rotation and clear old holdings."""
     timestamps = [
@@ -253,10 +302,11 @@ def test_order_target_weights_rotation_liquidates_unmentioned_symbols() -> None:
         pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
         pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai"),
         pd.Timestamp("2023-01-05 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-06 10:00:00", tz="Asia/Shanghai"),
     ]
     data_map = {
-        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0, 10.0, 10.0]),
-        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0, 10.0, 10.0]),
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0, 10.0, 10.0, 10.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0, 10.0, 10.0, 10.0]),
     }
 
     result = run_backtest(
@@ -276,6 +326,47 @@ def test_order_target_weights_rotation_liquidates_unmentioned_symbols() -> None:
     final_positions = result.positions.iloc[-1]
     assert float(final_positions.get("AAA", 0.0)) == 0.0
     assert float(final_positions.get("BBB", 0.0)) > 0.0
+
+
+def test_order_target_weights_uses_sell_proceeds_before_same_cycle_buy() -> None:
+    """Rotation should use pending sell proceeds instead of shrinking the buy leg."""
+    timestamps = [
+        pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai"),
+    ]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0, 10.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0, 10.0]),
+    }
+
+    result = run_backtest(
+        data=data_map,
+        strategy=TargetWeightsSellThenBuyStrategy,
+        symbols=["AAA", "BBB"],
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        show_progress=False,
+    )
+
+    orders_df = result.orders_df.sort_values("created_at").reset_index(drop=True)
+    assert len(orders_df) == 3
+    assert sorted(orders_df["symbol"].astype(str).tolist()) == ["AAA", "AAA", "BBB"]
+    assert sorted(orders_df["side"].astype(str).tolist()) == ["buy", "buy", "sell"]
+    assert sorted(orders_df["quantity"].astype(float).tolist()) == [
+        9000.0,
+        9000.0,
+        9000.0,
+    ]
+    assert set(orders_df["status"].astype(str).str.lower()) == {"filled"}
+    final_positions = result.positions.iloc[-1]
+    assert float(final_positions.get("AAA", 0.0)) == 0.0
+    assert float(final_positions.get("BBB", 0.0)) == 9000.0
 
 
 def test_order_target_weights_split_allocation_is_close_to_target() -> None:
@@ -310,6 +401,36 @@ def test_order_target_weights_split_allocation_is_close_to_target() -> None:
 
     assert abs(aaa_value / total_value - 0.6) < 0.02
     assert abs(bbb_value / total_value - 0.3) < 0.02
+
+
+def test_explicit_buy_quantity_is_rejected_without_resizing() -> None:
+    """Explicit oversized buy quantity should reject and preserve the requested size."""
+    timestamps = [pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai")]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0]),
+    }
+
+    result = run_backtest(
+        data=data_map,
+        strategy=ExplicitQuantityRejectStrategy,
+        symbols=["AAA"],
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        show_progress=False,
+    )
+
+    orders_df = result.orders_df
+    assert len(orders_df) == 1
+    row = orders_df.iloc[0]
+    assert str(row["symbol"]) == "AAA"
+    assert float(row["quantity"]) == 20_000.0
+    assert str(row["status"]).lower() == "rejected"
+    assert "insufficient" in str(row["reject_reason"]).lower()
 
 
 def _build_validation_strategy() -> Strategy:


### PR DESCRIPTION
- 在 order_target_weights 中，当使用 close 价格且在同周期执行时，将买入订单延迟到对应标的的 bar/tick 事件中处理，确保卖出释放的现金可用于后续买入
- 为 Order 模型新增 allow_quantity_auto_resize 字段，区分由 sizer 自动计算的数量（允许在风控和模拟执行中自动调整）与用户明确指定的数量（拒绝时保持原数量）
- 调整风险管理和模拟执行逻辑，仅对允许自动调整的买单在资金不足时进行数量缩减，明确指定的数量则直接拒绝
- 修复 CashMarginRule 中已提交订单的保证金计算逻辑，改为模拟现金和持仓变化以更准确反映可用资金
- 更新相关测试以验证新行为