### PR TITLE
fix: 修复订单事件回调中遗漏ctx.orders的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.4"
+version = "0.2.5"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -29,6 +29,7 @@ def _flush_deferred_target_value_orders(strategy: Any, event_symbol: str) -> Non
         else:
             remaining_orders.append((symbol, target_value, price, kwargs))
     setattr(strategy, "_deferred_target_value_orders", remaining_orders)
+    strategy._check_order_events()
 
 
 def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:

--- a/python/akquant/strategy_order_events.py
+++ b/python/akquant/strategy_order_events.py
@@ -34,6 +34,14 @@ def check_order_events(strategy: Any) -> None:
             strategy._known_orders[oid] = order
             _emit_order_callback(strategy, order)
 
+    if hasattr(strategy.ctx, "orders"):
+        for order in strategy.ctx.orders:
+            oid = getattr(order, "id", "")
+            if not oid or oid in strategy._known_orders:
+                continue
+            strategy._known_orders[oid] = order
+            _emit_order_callback(strategy, order)
+
     current_active_ids: set[str] = set()
     if hasattr(strategy.ctx, "active_orders"):
         for order in strategy.ctx.active_orders:

--- a/src/context.rs
+++ b/src/context.rs
@@ -588,6 +588,7 @@ impl StrategyContext {
             owner_strategy_id: self.strategy_id.clone(),
             allow_quantity_auto_resize,
         };
+        self.orders.push(order.clone());
         if let Some(tx) = &self.event_tx {
             let _ = tx.send(Event::OrderRequest(order));
         } else if let Ok(mut orders) = self.orders_arc.write() {
@@ -695,6 +696,7 @@ impl StrategyContext {
             owner_strategy_id: self.strategy_id.clone(),
             allow_quantity_auto_resize: false,
         };
+        self.orders.push(order.clone());
         if let Some(tx) = &self.event_tx {
             let _ = tx.send(Event::OrderRequest(order));
         } else if let Ok(mut orders) = self.orders_arc.write() {

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -255,6 +255,8 @@ class TargetWeightsSellThenBuyStrategy(Strategy):
         self.symbols = symbols
         self.pending: dict[int, set[str]] = defaultdict(set)
         self.rebalance_count = 0
+        self.order_event_ids: list[str] = []
+        self.trade_order_ids: list[str] = []
 
     def on_bar(self, bar: Bar) -> None:
         """Rotate from AAA to BBB on the second completed timestamp."""
@@ -277,6 +279,14 @@ class TargetWeightsSellThenBuyStrategy(Strategy):
                 rebalance_tolerance=0.0,
             )
         self.rebalance_count += 1
+
+    def on_order(self, order: Any) -> None:
+        """Record order ids observed through callbacks."""
+        self.order_event_ids.append(str(order.id))
+
+    def on_trade(self, trade: Any) -> None:
+        """Record trade order ids observed through callbacks."""
+        self.trade_order_ids.append(str(trade.order_id))
 
 
 class ExplicitQuantityRejectStrategy(Strategy):
@@ -367,6 +377,9 @@ def test_order_target_weights_uses_sell_proceeds_before_same_cycle_buy() -> None
     final_positions = result.positions.iloc[-1]
     assert float(final_positions.get("AAA", 0.0)) == 0.0
     assert float(final_positions.get("BBB", 0.0)) == 9000.0
+    strategy = result.strategy
+    assert strategy is not None
+    assert set(strategy.trade_order_ids).issubset(set(strategy.order_event_ids))
 
 
 def test_order_target_weights_split_allocation_is_close_to_target() -> None:


### PR DESCRIPTION
在策略上下文提交订单请求时，将订单添加到ctx.orders列表，确保check_order_events能正确遍历所有订单并触发回调。同时更新相关测试以验证订单事件回调的完整性。