### PR TITLE
docs: 更新贡献指南与更新日志的版本管理规则

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `run_backtest` always uses the unified stream core; runtime rollback flag `_engine_mode` is removed.
 - Futures fee Engine API naming is standardized to `set_futures_fee_rules*`; legacy `set_future_fee_rules*` is removed.
 
-## [0.1.13] - 2026-02-09
+## [0.2.9] - 2026-04-15
+
+### Fixed
+- Fixed benchmark return series index normalization and improved validation for report generation.
+
+## [0.2.8] - 2026-04-14
 
 ### Added
-- Incremental learning support for `SklearnAdapter` (via `partial_fit`) and `PyTorchAdapter` (via weight reset control).
-- `incremental` parameter in `ValidationConfig`.
-- Updated `ml_guide.md` with new features and clarified API signatures.
+- Added strategy start-time configuration support to the engine.
 
 ### Changed
-- `PyTorchAdapter` now defaults to `incremental=False` for strict Walk-Forward Validation.
+- Improved futures margin risk handling.
 
-## [0.1.12] - Previous Release
-- Basic implementation of `BarAggregator`.
-- Rust-based performance optimizations.
-- Zero-copy data access via PyO3.
+## [0.2.7] - 2026-04-09
+
+### Fixed
+- Applied conditional open-price optimization according to the configured price-basis policy.
+
+## [0.2.6] - 2026-04-09
+
+### Added
+- Added walk-forward model lifecycle management for the ML workflow.
+- Added multi-symbol backtesting support and improved backtest window configuration.
+- Added dictionary-based multi-symbol input support to the optimization workflow.
+
+### Changed
+- Improved rolling-training scheduling in parameter optimization.
+
+## [0.2.5] - 2026-04-08
+
+### Fixed
+- Fixed missing `ctx.orders` in order-event callbacks.
+
+## [0.2.4] - 2026-04-07
+
+### Added
+- Added same-bar cash reuse for sell-then-buy flows.
+
+### Changed
+- Distinguished automatic quantity adjustment from explicitly sized orders.
+
+## [0.2.3] - 2026-04-06
+
+### Fixed
+- Fixed cross-category operator conflict detection in the factor-expression parser.
+
+### Changed
+- Cleaned up completed migration docs and outdated links.
+- Refined examples by removing unused imports and obsolete configuration parameters.
+
+## [0.2.2] - 2026-04-03
+
+### Added
+- Added `catalog_path` support for specifying the data directory in backtests.
+- Added Top 8 rejected-order reason summaries in backtest output.
+
+## [0.2.1] - 2026-04-02
+
+### Added
+- Added order-level execution overrides and strategy-level default execution settings.
+- Added `NextClose` execution mode and unified the `symbols` parameter behavior.
+
+### Changed
+- Replaced `ExecutionMode` with `ExecutionPolicyCore`.
+- Simplified the `price_basis` options under `fill_policy`.
+- Updated the execution-semantics documentation and migration guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,23 @@
     git push origin feature/my-new-feature
     ```
 
+### 5. 版本与 Changelog 规则 (Versioning & Changelog)
+
+为避免版本信息分散或互相冲突，AKQuant 统一采用以下规则：
+
+- `pyproject.toml` 中的 `project.version` 作为 Python 包版本号来源。
+- `Cargo.toml` 中的版本号必须与 `pyproject.toml` 保持一致。
+- 正式发布由形如 `v0.2.10` 的 Git tag 触发。
+- `CHANGELOG.md` 只保留 `Unreleased` 和当前 `0.2.x` 主线版本记录。
+- 更早的版本历史不再继续堆积在 `CHANGELOG.md` 中，统一以 Git tag、GitHub Releases 或历史提交记录为准。
+
+维护 `CHANGELOG.md` 时请遵循以下约定：
+
+- 日常开发只更新 `Unreleased` 区块。
+- 发版时，将 `Unreleased` 中与本次发布相关的内容整理为对应的 `0.2.x` 正式版本条目。
+- 变更说明优先写“用户可感知的行为变化”，避免只写纯内部重构细节。
+- 建议使用 `Added`、`Changed`、`Fixed`、`Removed` 分类。
+
 ### 6. 测试与验证 (Testing)
 
 为确保代码质量与回测结果的一致性，本项目引入了**黄金测试套件 (Golden Test Suite)**。


### PR DESCRIPTION
在 CONTRIBUTING.md 中新增“版本与 Changelog 规则”章节，明确 pyproject.toml 作为单一版本来源、Cargo.toml 版本同步以及 CHANGELOG.md 的维护约定。同时，将 CHANGELOG.md 中 0.1.x 的历史版本记录移除，并更新 0.2.x 版本的详细变更日志，以保持文档与当前开发主线一致。