### PR TITLE
feat: 为订单和成交添加可读时间字符串属性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.10] - 2026-04-15
+
 ### Added
 - `run_backtest` now supports optional `on_event` callback and can emit stream events directly.
 - Added `ChinaOptionsConfig` with prefix-level option fee configuration (`fee_by_symbol_prefix`).
 - Added Engine API `set_options_fee_rules_by_prefix(symbol_prefix, commission_per_contract)`.
+- Added readable time-string properties for `Trade.timestamp`, `Order.created_at`, and `Order.updated_at`.
 
 ### Changed
 - `run_backtest_stream` is removed; stream scenarios should call `run_backtest(..., on_event=...)`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.9"
+version = "0.2.10"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.9"
+version = "0.2.10"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -880,7 +880,9 @@ class Order:
     time_in_force: akquant.TimeInForce
     status: akquant.OrderStatus
     created_at: int
+    created_at_str: str
     updated_at: int
+    updated_at_str: str
     tag: str
     reject_reason: str
     owner_strategy_id: typing.Optional[str]
@@ -2587,6 +2589,7 @@ class Trade:
     symbol: str
     side: akquant.OrderSide
     timestamp: int
+    timestamp_str: str
     bar_index: int
     quantity: float
     price: float

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -1,5 +1,6 @@
 use super::market_data::extract_decimal;
 use super::types::{ExecutionPolicyCore, OrderRole, OrderSide, OrderStatus, OrderType, TimeInForce};
+use chrono::{FixedOffset, TimeZone, Utc};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3_stub_gen::derive::*;
@@ -48,6 +49,20 @@ fn validate_order_inputs(
         ensure_positive(v, "trail_reference_price")?;
     }
     Ok(())
+}
+
+fn format_timestamp_str(timestamp: i64) -> String {
+    let secs = timestamp.div_euclid(1_000_000_000);
+    let nanos = timestamp.rem_euclid(1_000_000_000) as u32;
+
+    if let Some(dt) = Utc.timestamp_opt(secs, nanos).single() {
+        let tz = FixedOffset::east_opt(8 * 3600).unwrap();
+        dt.with_timezone(&tz)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string()
+    } else {
+        timestamp.to_string()
+    }
 }
 
 #[gen_stub_pyclass]
@@ -226,6 +241,20 @@ impl Order {
     /// :return: 手续费
     fn get_commission(&self) -> f64 {
         self.commission.to_f64().unwrap_or_default()
+    }
+
+    #[getter]
+    /// 获取创建时间字符串 (Asia/Shanghai).
+    /// :return: 格式化时间字符串 YYYY-MM-DD HH:MM:SS
+    fn created_at_str(&self) -> String {
+        format_timestamp_str(self.created_at)
+    }
+
+    #[getter]
+    /// 获取更新时间字符串 (Asia/Shanghai).
+    /// :return: 格式化时间字符串 YYYY-MM-DD HH:MM:SS
+    fn updated_at_str(&self) -> String {
+        format_timestamp_str(self.updated_at)
     }
 
     #[getter]
@@ -485,6 +514,13 @@ impl Trade {
         self.commission.to_f64().unwrap_or_default()
     }
 
+    #[getter]
+    /// 获取格式化的成交时间字符串 (Asia/Shanghai).
+    /// :return: 格式化时间字符串 YYYY-MM-DD HH:MM:SS
+    fn timestamp_str(&self) -> String {
+        format_timestamp_str(self.timestamp)
+    }
+
     pub fn __repr__(&self) -> String {
         format!(
             "Trade(id={}, order_id={}, symbol={}, side={:?}, qty={}, price={}, time={}, bar={})",
@@ -597,5 +633,46 @@ mod tests {
     fn test_order_new_rejects_non_positive_price() {
         let result = validate_order_inputs(Decimal::from(1), Some(Decimal::ZERO), None, None, None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_format_timestamp_str_uses_asia_shanghai() {
+        let timestamp = 1_735_802_000_000_000_000_i64; // 2025-01-02 15:00:00+08:00
+        assert_eq!(format_timestamp_str(timestamp), "2025-01-02 15:00:00");
+    }
+
+    #[test]
+    fn test_order_time_string_getters() {
+        let mut order = Order::test_new(
+            "o1",
+            "AAPL",
+            OrderSide::Buy,
+            OrderType::Limit,
+            Decimal::from(10),
+        );
+        let timestamp = 1_735_802_000_000_000_000_i64;
+        order.created_at = timestamp;
+        order.updated_at = timestamp;
+
+        assert_eq!(order.created_at_str(), "2025-01-02 15:00:00");
+        assert_eq!(order.updated_at_str(), "2025-01-02 15:00:00");
+    }
+
+    #[test]
+    fn test_trade_timestamp_string_getter() {
+        let trade = Trade {
+            id: "t1".to_string(),
+            order_id: "o1".to_string(),
+            symbol: "AAPL".to_string(),
+            side: OrderSide::Buy,
+            quantity: Decimal::from(10),
+            price: Decimal::from(100),
+            commission: Decimal::ZERO,
+            timestamp: 1_735_802_000_000_000_000_i64,
+            bar_index: 0,
+            owner_strategy_id: None,
+        };
+
+        assert_eq!(trade.timestamp_str(), "2025-01-02 15:00:00");
     }
 }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -5115,6 +5115,36 @@ def test_order_rejects_non_positive_quantity() -> None:
         )
 
 
+def test_order_and_trade_time_string_properties() -> None:
+    """Order/Trade should expose readable Asia/Shanghai timestamp strings."""
+    ts = pd.Timestamp("2025-01-02 15:00:00", tz="Asia/Shanghai").value
+    order = akquant.Order(
+        "o-time-str",
+        "AAPL",
+        akquant.OrderSide.Buy,
+        akquant.OrderType.Limit,
+        10.0,
+        100.0,
+        created_at=ts,
+    )
+    trade = akquant.Trade(
+        "t-time-str",
+        "o-time-str",
+        "AAPL",
+        akquant.OrderSide.Buy,
+        10.0,
+        100.0,
+        1.0,
+        ts,
+        0,
+        None,
+    )
+
+    assert order.created_at_str == "2025-01-02 15:00:00"
+    assert order.updated_at_str == "2025-01-02 15:00:00"
+    assert trade.timestamp_str == "2025-01-02 15:00:00"
+
+
 def test_instrument_rejects_non_positive_tick_size() -> None:
     """Instrument should reject non-positive tick size."""
     with pytest.raises(


### PR DESCRIPTION
添加 `Order.created_at_str`、`Order.updated_at_str` 和 `Trade.timestamp_str` 属性， 将纳秒时间戳格式化为 Asia/Shanghai 时区的 "YYYY-MM-DD HH:MM:SS" 字符串， 便于在日志和调试中直接查看可读时间。