### PR TITLE
fix(backtest): 修复多品种回测中相同时间戳顺序导致指标不稳定的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11] - 2026-04-16
+
+### Fixed
+- Fixed non-deterministic backtest metrics in multi-symbol runs when bars share the same timestamp.
+- Ensured terminal equity/cash/margin snapshots are overwritten with the fully updated portfolio state before final metric calculation.
+
 ## [0.2.10] - 2026-04-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.10"
+version = "0.2.11"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.10"
+version = "0.2.11"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -32,6 +32,16 @@ impl Default for StatisticsManager {
 }
 
 impl StatisticsManager {
+    fn upsert_timestamped_value<T>(series: &mut Vec<(i64, T)>, timestamp: i64, value: T) {
+        if let Some((last_ts, last_value)) = series.last_mut()
+            && *last_ts == timestamp
+        {
+            *last_value = value;
+            return;
+        }
+        series.push((timestamp, value));
+    }
+
     /// 创建新的统计管理器
     pub fn new() -> Self {
         Self {
@@ -45,9 +55,9 @@ impl StatisticsManager {
 
     /// 更新权益和现金曲线
     pub fn update(&mut self, timestamp: i64, equity: Decimal, cash: Decimal, margin: Decimal) {
-        self.equity_curve.push((timestamp, equity));
-        self.cash_curve.push((timestamp, cash));
-        self.margin_curve.push((timestamp, margin));
+        Self::upsert_timestamped_value(&mut self.equity_curve, timestamp, equity);
+        Self::upsert_timestamped_value(&mut self.cash_curve, timestamp, cash);
+        Self::upsert_timestamped_value(&mut self.margin_curve, timestamp, margin);
     }
 
     /// 记录持仓快照
@@ -60,7 +70,7 @@ impl StatisticsManager {
         trade_tracker: &crate::analysis::TradeTracker,
     ) {
         let snapshots = Self::create_snapshot(portfolio, instruments, last_prices, trade_tracker);
-        self.snapshots.push((timestamp, snapshots));
+        Self::upsert_timestamped_value(&mut self.snapshots, timestamp, snapshots);
     }
 
     pub fn record_liquidation_audit(&mut self, audit: LiquidationAudit) {
@@ -150,32 +160,20 @@ impl StatisticsManager {
         // Add final snapshot if needed
         if let Some(ts) = now_ns {
             let equity = portfolio.calculate_equity(last_prices, instruments);
+            let margin = portfolio.calculate_used_margin(last_prices, instruments);
+            let snap = Self::create_snapshot(
+                portfolio,
+                instruments,
+                last_prices,
+                &order_manager.trade_tracker,
+            );
 
-            // Append final equity point if not present
-            if equity_curve.last().is_none_or(|(t, _)| *t != ts) {
-                equity_curve.push((ts, equity));
-            }
-
-            // Append final cash point if not present
-            if cash_curve.last().is_none_or(|(t, _)| *t != ts) {
-                cash_curve.push((ts, portfolio.cash));
-            }
-
-            if margin_curve.last().is_none_or(|(t, _)| *t != ts) {
-                let margin = portfolio.calculate_used_margin(last_prices, instruments);
-                margin_curve.push((ts, margin));
-            }
-
-            // Append final position snapshot if not present
-            if snapshots.last().is_none_or(|(t, _)| *t != ts) {
-                let snap = Self::create_snapshot(
-                    portfolio,
-                    instruments,
-                    last_prices,
-                    &order_manager.trade_tracker,
-                );
-                snapshots.push((ts, snap));
-            }
+            // Always overwrite the terminal point at the same timestamp so the
+            // final result reflects the fully updated portfolio state.
+            Self::upsert_timestamped_value(&mut equity_curve, ts, equity);
+            Self::upsert_timestamped_value(&mut cash_curve, ts, portfolio.cash);
+            Self::upsert_timestamped_value(&mut margin_curve, ts, margin);
+            Self::upsert_timestamped_value(&mut snapshots, ts, snap);
         }
 
         BacktestResult::calculate(crate::analysis::CalculatorInput {

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1329,6 +1329,81 @@ def test_run_backtest_dataframe_multisymbol_preserves_bar_symbol() -> None:
     assert strategy.seen_symbols.count("IF2402.CFX") == 2
 
 
+def test_run_backtest_dataframe_multisymbol_row_order_keeps_metrics_stable() -> None:
+    """Metrics should not drift when same-timestamp symbol row order changes."""
+
+    class BuyOncePerSymbolStrategy(akquant.Strategy):
+        """Buy each symbol once and hold so equity depends on multi-symbol marking."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.bought_symbols: set[str] = set()
+
+        def on_bar(self, bar: akquant.Bar) -> None:
+            symbol = str(bar.symbol)
+            if symbol in self.bought_symbols:
+                return
+            self.buy(symbol=symbol, quantity=1)
+            self.bought_symbols.add(symbol)
+
+    rows = [
+        ("2024-01-02", "AAA", 10.0),
+        ("2024-01-02", "BBB", 20.0),
+        ("2024-01-03", "AAA", 11.0),
+        ("2024-01-03", "BBB", 19.0),
+        ("2024-01-04", "AAA", 12.0),
+        ("2024-01-04", "BBB", 21.0),
+        ("2024-01-05", "AAA", 13.0),
+        ("2024-01-05", "BBB", 23.0),
+    ]
+    frame = pd.DataFrame(rows, columns=["timestamp", "symbol", "close"])
+    frame["timestamp"] = pd.to_datetime(frame["timestamp"])
+    frame["open"] = frame["close"]
+    frame["high"] = frame["close"]
+    frame["low"] = frame["close"]
+    frame["volume"] = 1000.0
+
+    ascending = frame.sort_values(["timestamp", "symbol"]).reset_index(drop=True)
+    descending = frame.sort_values(
+        ["timestamp", "symbol"], ascending=[True, False]
+    ).reset_index(drop=True)
+
+    common_args: dict[str, Any] = dict(
+        strategy=BuyOncePerSymbolStrategy,
+        symbols=["AAA", "BBB"],
+        start_time="2024-01-02",
+        end_time="2024-01-05",
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    result_ascending = akquant.run_backtest(data=ascending, **common_args)
+    result_descending = akquant.run_backtest(data=descending, **common_args)
+
+    assert len(result_ascending.orders_df) == len(result_descending.orders_df) == 2
+    assert result_ascending.metrics.end_market_value == pytest.approx(
+        result_descending.metrics.end_market_value, rel=1e-12
+    )
+    assert result_ascending.metrics.total_return == pytest.approx(
+        result_descending.metrics.total_return, rel=1e-12
+    )
+    assert result_ascending.metrics.sharpe_ratio == pytest.approx(
+        result_descending.metrics.sharpe_ratio, rel=1e-12
+    )
+    assert result_ascending.metrics.volatility == pytest.approx(
+        result_descending.metrics.volatility, rel=1e-12
+    )
+    assert float(result_ascending.equity_curve.iloc[-1]) == pytest.approx(
+        float(result_descending.equity_curve.iloc[-1]), rel=1e-12
+    )
+
+
 def test_engine_run_empty() -> None:
     """Test running engine with no data."""
     engine = akquant.Engine()


### PR DESCRIPTION
确保相同时间戳的权益/现金/保证金曲线和持仓快照被最终更新的投资组合状态覆盖，避免因多品种数据行顺序不同导致回测指标漂移。新增测试验证排序稳定性。