### PR TITLE
feat: 增强滑点配置支持并改进期货示例

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- 新增显式滑点策略写法，`run_backtest`、`StrategyConfig`、策略级 `strategy_slippage` 与订单级下单接口现支持 `{"type": "percent"|"fixed"|"ticks"|"zero", "value": ...}`。
+- `short()` / `cover()` 现支持 `tag`、`fill_policy`、`slippage` 与 `commission`，与 `buy()` / `sell()` 的下单覆盖能力保持一致。
+
+### Changed
+- 期货教材示例与相关中文文档已切换为显式滑点 policy 写法，优先推荐 `percent` / `fixed` / `ticks`，并补充了成交时点与滑点语义的防踩坑说明。
+- 内置 `broker_profile` 的滑点模板已迁移到显式 policy 表示，避免继续依赖裸数值语义。
+
+### Deprecated
+- 裸 `float` / `int` 形式的 `slippage` 仍保持兼容，但已进入弃用路径；当前会触发 `DeprecationWarning`，且对可疑的大滑点值给出明确提示。
+
+### Fixed
+- 为 `ticks` 滑点补充了 `tick_size` 解析与校验逻辑，避免多标的或缺少合约最小变动价位时静默使用错误滑点。
+
 ## [0.2.11] - 2026-04-16
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/textbook/07_futures.md
+++ b/docs/zh/textbook/07_futures.md
@@ -193,14 +193,21 @@ rb_config = InstrumentConfig(
 
 下面的代码展示了一个经典的期货趋势跟踪策略。注意期货特有的**做空 (Short Selling)** 操作。
 
+防踩坑提醒：
+
+*   期货策略请显式配置 `InstrumentConfig(asset_type="FUTURES", multiplier=..., margin_ratio=...)`，不要依赖默认资产类型。
+*   如果你的人工记录按“当根收盘信号、当根收盘附近成交”统计，请显式设置 `fill_policy={"price_basis":"close","bar_offset":0,"temporal":"same_cycle"}`。默认语义通常是“当根算信号、下一根开盘成交”。
+*   `run_backtest(..., slippage=...)` 建议显式写成 policy，例如 `{"type":"percent","value":0.0002}`、`{"type":"fixed","value":0.2}` 或 `{"type":"ticks","value":1}`。其中百分比语义下，`0.0002 = 2 bps`，如果写成 `0.2`，表示 `20%` 滑点，而不是 `0.2` 个点。
+*   需要表达固定点差时，优先使用订单级滑点配置，例如 `slippage={"type":"fixed","value":0.2}`。
+
 ```python
 --8<-- "examples/textbook/ch07_futures.py"
 ```
 
 **关键逻辑解析**：
 
-*   **做空开仓**：`self.sell(symbol, quantity)`。若当前无持仓，则持仓变为负数（如 -1）。
-*   **平空仓**：`self.buy(symbol, quantity)`。若当前持仓为 -1，买入 1 手后持仓归零。
+*   **做空开仓**：优先使用 `self.short(symbol, quantity)`，语义更清晰，也更适合向用户解释成交明细。
+*   **平空仓**：优先使用 `self.cover(symbol, quantity)`；若当前持仓为 -1，回补 1 手后持仓归零。
 *   **杠杆管理**：由于期货自带杠杆，策略在分配资金时需谨慎。建议按**名义本金 (Notional Value)** 而非保证金占用进行风控。
 
 ## 7.5 商品期限结构深入 (Deep Dive into Term Structure)

--- a/examples/textbook/ch07_futures.py
+++ b/examples/textbook/ch07_futures.py
@@ -4,7 +4,7 @@
 本示例展示了期货交易的核心特性：
 1. **保证金 (Margin)**：只需缴纳少量资金即可控制大额合约。
 2. **杠杆 (Leverage)**：放大收益与风险。
-3. **做空 (Short Selling)**：可以直接卖出开仓，在下跌行情中获利。
+3. **做空 (Short Selling)**：使用 `short()` / `cover()` 显式表达开空与平空。
 4. **合约乘数 (Multiplier)**：一手合约代表的价值。
 
 示例场景：
@@ -104,7 +104,7 @@ class FuturesTrendStrategy(Strategy):
                 self.buy(symbol, 1)
             elif signal == -1:
                 self.log("开空单 1 手")
-                self.sell(symbol, 1)
+                self.short(symbol, 1)
 
             self.last_signal = signal
 
@@ -165,6 +165,12 @@ if __name__ == "__main__":
         strategy=FuturesTrendStrategy,
         data=df,
         config=config,
+        # 对很多“按当根收盘价记交易”的期货策略，显式指定 fill_policy
+        # 会比默认的“下一根开盘成交”更贴近人工记录口径。
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+        # 注意：推荐显式声明滑点类型。
+        # 0.0002 = 2 bps；如果写成 0.2，表示 20% 滑点，不是 0.2 个点。
+        slippage={"type": "percent", "value": 0.0002},
     )
 
     print("\n" + "=" * 40)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.11"
+version = "0.2.12"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -69,8 +69,8 @@ class ExperimentalFillPolicy(TypedDict):
 
 FillPolicyInput = Union[FillPolicy, Dict[str, Any]]
 
-class SlippagePolicy(TypedDict):
-    type: Literal["percent", "fixed"]
+class SlippagePolicy(TypedDict, total=False):
+    type: Literal["percent", "fixed", "ticks", "zero"]
     value: float
 
 SlippagePolicyInput = Union[SlippagePolicy, Dict[str, Any]]
@@ -99,7 +99,7 @@ def run_backtest(
     stamp_tax_rate: Optional[float] = ...,
     transfer_fee_rate: Optional[float] = ...,
     min_commission: Optional[float] = ...,
-    slippage: Optional[float] = ...,
+    slippage: Optional[Union[float, SlippagePolicyInput]] = ...,
     volume_limit_pct: Optional[float] = ...,
     timezone: Optional[str] = ...,
     t_plus_one: bool = ...,
@@ -138,7 +138,7 @@ def run_backtest(
     strategy_priority: Optional[Dict[str, int]] = ...,
     strategy_risk_budget: Optional[Dict[str, float]] = ...,
     strategy_fill_policy: Optional[Dict[str, FillPolicyInput]] = ...,
-    strategy_slippage: Optional[Dict[str, SlippagePolicyInput]] = ...,
+    strategy_slippage: Optional[Dict[str, Union[float, SlippagePolicyInput]]] = ...,
     strategy_commission: Optional[Dict[str, CommissionPolicyInput]] = ...,
     portfolio_risk_budget: Optional[float] = ...,
     risk_budget_mode: Literal["order_notional", "trade_notional"] = ...,

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -3,6 +3,7 @@ import inspect
 import logging
 import os
 import sys
+import warnings
 from dataclasses import dataclass, fields
 from typing import (
     Any,
@@ -97,6 +98,9 @@ class SlippagePolicy(TypedDict, total=False):
 
     type: str
     value: float
+
+
+SlippageInput = Union[float, int, SlippagePolicy, Dict[str, Any], None]
 
 
 class CommissionPolicy(TypedDict, total=False):
@@ -322,7 +326,7 @@ _BROKER_PROFILE_TEMPLATES: Dict[str, Dict[str, Any]] = {
         "stamp_tax_rate": 0.001,
         "transfer_fee_rate": 0.00001,
         "min_commission": 5.0,
-        "slippage": 0.0002,
+        "slippage": {"type": "percent", "value": 0.0002},
         "volume_limit_pct": 0.2,
         "lot_size": 100,
     },
@@ -331,7 +335,7 @@ _BROKER_PROFILE_TEMPLATES: Dict[str, Dict[str, Any]] = {
         "stamp_tax_rate": 0.001,
         "transfer_fee_rate": 0.000005,
         "min_commission": 3.0,
-        "slippage": 0.0001,
+        "slippage": {"type": "percent", "value": 0.0001},
         "volume_limit_pct": 0.25,
         "lot_size": 100,
     },
@@ -340,7 +344,7 @@ _BROKER_PROFILE_TEMPLATES: Dict[str, Dict[str, Any]] = {
         "stamp_tax_rate": 0.001,
         "transfer_fee_rate": 0.00001,
         "min_commission": 5.0,
-        "slippage": 0.001,
+        "slippage": {"type": "percent", "value": 0.001},
         "volume_limit_pct": 0.1,
         "lot_size": 100,
     },
@@ -691,7 +695,7 @@ def _apply_strategy_config_overrides(
     strategy_priority: Optional[Dict[str, int]],
     strategy_risk_budget: Optional[Dict[str, float]],
     strategy_fill_policy: Optional[Dict[str, FillPolicy]],
-    strategy_slippage: Optional[Dict[str, SlippagePolicy]],
+    strategy_slippage: Optional[Dict[str, SlippageInput]],
     strategy_commission: Optional[Dict[str, CommissionPolicy]],
     portfolio_risk_budget: Optional[float],
     strategy_runtime_config: Optional[Union[StrategyRuntimeConfig, Dict[str, Any]]],
@@ -711,7 +715,7 @@ def _apply_strategy_config_overrides(
     Optional[Dict[str, int]],
     Optional[Dict[str, float]],
     Optional[Dict[str, FillPolicy]],
-    Optional[Dict[str, SlippagePolicy]],
+    Optional[Dict[str, SlippageInput]],
     Optional[Dict[str, CommissionPolicy]],
     Optional[float],
     Optional[Union[StrategyRuntimeConfig, Dict[str, Any]]],
@@ -803,7 +807,7 @@ def _apply_strategy_config_overrides(
         )
     if strategy_slippage is None:
         strategy_slippage = cast(
-            Optional[Dict[str, SlippagePolicy]],
+            Optional[Dict[str, SlippageInput]],
             getattr(strategy_config, "strategy_slippage", None),
         )
     if strategy_commission is None:
@@ -961,8 +965,9 @@ def _normalize_strategy_fill_policy_map(
 
 
 def _normalize_strategy_slippage_map(
-    strategy_slippage: Optional[Dict[str, SlippagePolicy]],
+    strategy_slippage: Optional[Dict[str, SlippageInput]],
     configured_slot_ids: Sequence[str],
+    logger: logging.Logger,
 ) -> Optional[Dict[str, SlippagePolicy]]:
     if not strategy_slippage:
         return None
@@ -973,28 +978,12 @@ def _normalize_strategy_slippage_map(
         strategy_key_str = str(strategy_key).strip()
         if not strategy_key_str:
             raise ValueError("strategy_slippage contains empty strategy id")
-        if not isinstance(raw_slippage, dict):
-            raise TypeError(
-                f"strategy_slippage[{strategy_key_str}] must be a dict SlippagePolicy"
-            )
-        raw_type = str(raw_slippage.get("type", "percent")).strip().lower()
-        if raw_type not in {"percent", "fixed"}:
-            raise ValueError(
-                f"strategy_slippage[{strategy_key_str}].type must be one of: "
-                "percent, fixed"
-            )
-        raw_value = raw_slippage.get("value", 0.0)
-        try:
-            value = float(raw_value)
-        except (TypeError, ValueError):
-            raise ValueError(
-                f"strategy_slippage[{strategy_key_str}].value must be a number >= 0"
-            ) from None
-        if value < 0:
-            raise ValueError(
-                f"strategy_slippage[{strategy_key_str}].value must be >= 0"
-            )
-        normalized[strategy_key_str] = {"type": raw_type, "value": value}
+        normalized[strategy_key_str] = _normalize_slippage_policy(
+            raw_slippage,
+            logger=logger,
+            scope=f"strategy_slippage[{strategy_key_str}]",
+            resolve_ticks=False,
+        )
     unknown_keys = sorted(set(normalized.keys()).difference(set(configured_slot_ids)))
     if unknown_keys:
         raise ValueError(
@@ -1539,6 +1528,108 @@ def _coerce_analyzer_plugins(
     return normalized
 
 
+def _warn_if_suspicious_global_slippage(
+    slippage: float, logger: logging.Logger
+) -> None:
+    """Warn when a global slippage value looks like a fixed price delta."""
+    if slippage < 0.05:
+        return
+    logger.warning(
+        "Global slippage=%s uses percent semantics in AKQuant. "
+        "For example, 0.2 means 20%% slippage, not a fixed 0.2 price delta. "
+        "If you intended a fixed offset such as 0.2 index points, set "
+        "order-level slippage={'type': 'fixed', 'value': 0.2} instead.",
+        slippage,
+    )
+
+
+def _warn_deprecated_float_slippage(
+    slippage: Union[int, float], logger: logging.Logger, scope: str
+) -> None:
+    _ = slippage
+    warnings.warn(
+        f"{scope} slippage passed as a bare number is deprecated in AKQuant. "
+        "Use an explicit policy such as "
+        "slippage={'type': 'percent', 'value': 0.0002} or "
+        "slippage={'type': 'fixed', 'value': 0.2}.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    logger.warning(
+        "%s slippage passed as a bare number is deprecated in AKQuant. "
+        "Please use an explicit policy such as "
+        "slippage={'type': 'percent', 'value': 0.0002} or "
+        "slippage={'type': 'fixed', 'value': 0.2}.",
+        scope,
+    )
+
+
+def _normalize_slippage_policy(
+    slippage: SlippageInput,
+    *,
+    instrument_snapshots: Optional[Dict[str, InstrumentSnapshot]] = None,
+    logger: Optional[logging.Logger] = None,
+    scope: str = "Global",
+    allow_float: bool = True,
+    resolve_ticks: bool = True,
+) -> SlippagePolicy:
+    if slippage is None:
+        return {"type": "zero", "value": 0.0}
+    if isinstance(slippage, (int, float)):
+        if not allow_float:
+            raise TypeError(
+                f"{scope} slippage must be a dict policy when provided; "
+                "bare numeric slippage is no longer accepted here"
+            )
+        numeric_value = float(slippage)
+        if numeric_value < 0:
+            raise ValueError(f"{scope} slippage.value must be >= 0")
+        if logger is not None and numeric_value != 0.0:
+            _warn_deprecated_float_slippage(numeric_value, logger, scope)
+            _warn_if_suspicious_global_slippage(numeric_value, logger)
+        return {"type": "percent", "value": numeric_value}
+    if not isinstance(slippage, dict):
+        raise TypeError(f"{scope} slippage must be a dict when provided")
+    raw_type = str(slippage.get("type", "percent")).strip().lower()
+    raw_value = slippage.get("value", 0.0)
+    if raw_type == "zero":
+        return {"type": "zero", "value": 0.0}
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{scope} slippage.value must be a number >= 0") from None
+    if value < 0:
+        raise ValueError(f"{scope} slippage.value must be >= 0")
+    if raw_type in {"percent", "fixed"}:
+        return {"type": raw_type, "value": value}
+    if raw_type == "ticks":
+        if not resolve_ticks:
+            return {"type": "ticks", "value": value}
+        if not instrument_snapshots:
+            raise ValueError(
+                f"{scope} slippage.type='ticks' requires instrument configuration"
+            )
+        tick_sizes = {
+            float(snapshot.tick_size)
+            for snapshot in instrument_snapshots.values()
+            if snapshot.tick_size is not None
+        }
+        if not tick_sizes:
+            raise ValueError(
+                f"{scope} slippage.type='ticks' requires at least one tick_size"
+            )
+        if len(tick_sizes) != 1:
+            raise ValueError(
+                f"{scope} slippage.type='ticks' requires a single shared tick_size "
+                "across all effective instruments"
+            )
+        tick_size = next(iter(tick_sizes))
+        return {"type": "fixed", "value": value * tick_size}
+    raise ValueError(
+        f"{scope} slippage.type must be one of: percent, fixed, ticks, zero"
+    )
+
+
 def run_backtest(
     data: Optional[BacktestDataInput] = None,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = None,
@@ -1551,7 +1642,7 @@ def run_backtest(
     stamp_tax_rate: Optional[float] = None,
     transfer_fee_rate: Optional[float] = None,
     min_commission: Optional[float] = None,
-    slippage: Optional[float] = None,
+    slippage: SlippageInput = None,
     volume_limit_pct: Optional[float] = None,
     timezone: Optional[str] = None,
     t_plus_one: bool = False,
@@ -1591,7 +1682,7 @@ def run_backtest(
     strategy_priority: Optional[Dict[str, int]] = None,
     strategy_risk_budget: Optional[Dict[str, float]] = None,
     strategy_fill_policy: Optional[Dict[str, FillPolicy]] = None,
-    strategy_slippage: Optional[Dict[str, SlippagePolicy]] = None,
+    strategy_slippage: Optional[Dict[str, SlippageInput]] = None,
     strategy_commission: Optional[Dict[str, CommissionPolicy]] = None,
     portfolio_risk_budget: Optional[float] = None,
     risk_budget_mode: str = "order_notional",
@@ -1630,7 +1721,11 @@ def run_backtest(
     :param stamp_tax_rate: 印花税率 (仅卖出, 默认 0.0)
     :param transfer_fee_rate: 过户费率 (默认 0.0)
     :param min_commission: 最低佣金 (默认 0.0)
-    :param slippage: 滑点 (默认 0.0)
+    :param slippage: 滑点策略。推荐显式传 dict，如
+                     {"type": "percent", "value": 0.0002}、
+                     {"type": "fixed", "value": 0.2}、
+                     {"type": "ticks", "value": 1}。
+                     裸 float 仍兼容，但已不推荐，且按 percent 语义解析。
     :param volume_limit_pct: 成交量限制比例 (默认 0.25)
     :param fill_policy: 统一成交语义配置（可选），格式:
         {"price_basis": "open|close|ohlc4|hl2",
@@ -1786,7 +1881,7 @@ def run_backtest(
                 Optional[float], broker_profile_values.get("commission_rate")
             )
         if slippage is None:
-            slippage = cast(Optional[float], broker_profile_values.get("slippage"))
+            slippage = cast(SlippageInput, broker_profile_values.get("slippage"))
         if volume_limit_pct is None:
             volume_limit_pct = cast(
                 Optional[float], broker_profile_values.get("volume_limit_pct")
@@ -2034,6 +2129,7 @@ def run_backtest(
     normalized_strategy_slippage = _normalize_strategy_slippage_map(
         strategy_slippage,
         configured_slot_ids,
+        logger,
     )
     normalized_strategy_commission = _normalize_strategy_commission_map(
         strategy_commission,
@@ -2242,6 +2338,12 @@ def run_backtest(
         )
     for current_strategy in all_strategy_instances:
         current_strategy._set_instrument_snapshots(preliminary_snapshots)
+    normalized_global_slippage = _normalize_slippage_policy(
+        slippage,
+        instrument_snapshots=preliminary_snapshots,
+        logger=logger,
+        scope="Global",
+    )
 
     # 调用 on_start 获取订阅
     # 注意：现在调用 _on_start_internal 来触发自动发现
@@ -2962,12 +3064,20 @@ def run_backtest(
     )
 
     # Configure Execution parameters
-    if slippage > 0:
+    if (
+        normalized_global_slippage["type"] != "zero"
+        and normalized_global_slippage["value"] > 0
+    ):
         if hasattr(engine, "set_slippage"):
-            # Assume "percent" model for the simple float config
-            engine.set_slippage("percent", slippage)
+            engine.set_slippage(
+                normalized_global_slippage["type"],
+                normalized_global_slippage["value"],
+            )
         else:
-            logger.warning(f"Slippage {slippage} set but not supported by Engine.")
+            logger.warning(
+                "Slippage policy %s set but not supported by Engine.",
+                normalized_global_slippage,
+            )
 
     if volume_limit_pct != 0.25:
         if hasattr(engine, "set_volume_limit"):
@@ -3572,7 +3682,7 @@ def run_warm_start(
     strategy_priority: Optional[Dict[str, int]] = None,
     strategy_risk_budget: Optional[Dict[str, float]] = None,
     strategy_fill_policy: Optional[Dict[str, FillPolicy]] = None,
-    strategy_slippage: Optional[Dict[str, SlippagePolicy]] = None,
+    strategy_slippage: Optional[Dict[str, SlippageInput]] = None,
     strategy_commission: Optional[Dict[str, CommissionPolicy]] = None,
     portfolio_risk_budget: Optional[float] = None,
     risk_budget_mode: str = "order_notional",
@@ -3856,6 +3966,7 @@ def run_warm_start(
     normalized_strategy_slippage = _normalize_strategy_slippage_map(
         strategy_slippage,
         configured_slot_ids,
+        logger,
     )
     normalized_strategy_commission = _normalize_strategy_commission_map(
         strategy_commission,

--- a/python/akquant/config.py
+++ b/python/akquant/config.py
@@ -126,7 +126,10 @@ class InstrumentConfig:
     :param min_commission: Minimum commission per order.
     :param stamp_tax_rate: Stamp tax rate (sell side only).
     :param transfer_fee_rate: Transfer fee rate.
-    :param slippage: Asset-specific slippage (e.g., 0.0002).
+    :param slippage: Asset-specific slippage policy. 推荐显式写为
+                     {"type": "percent", "value": 0.0002}、
+                     {"type": "fixed", "value": 0.2} 或
+                     {"type": "ticks", "value": 1}。
 
     **Option Specific:**
     :param option_type: "CALL" or "PUT".
@@ -149,7 +152,7 @@ class InstrumentConfig:
     min_commission: Optional[float] = None
     stamp_tax_rate: Optional[float] = None
     transfer_fee_rate: Optional[float] = None
-    slippage: Optional[float] = None
+    slippage: Optional[Union[float, Dict[str, Any]]] = None
 
     # Option specific
     option_type: Optional[InstrumentOptionTypeInput] = None
@@ -485,8 +488,11 @@ class StrategyConfig:
     **Execution Behavior:**
     :param enable_fractional_shares: Allow fractional share trading. Default False.
     :param round_fill_price: Round execution price to tick size. Default True.
-    :param slippage: Global slippage model (Percentage). 0.0002 means 2 bps slippage.
-                     Applied to all trades unless overridden in `InstrumentConfig`.
+    :param slippage: Global slippage policy. 推荐显式写为
+                     {"type": "percent", "value": 0.0002}、
+                     {"type": "fixed", "value": 0.2} 或
+                     {"type": "ticks", "value": 1}。
+                     裸 float 仍兼容，但按 percent 语义解析。
     :param volume_limit_pct: Max participation rate. 0.25 means order size is
                              capped at 25% of the bar's volume. Default 0.25.
     :param exit_on_last_bar: Auto-close all positions at the end of backtest.
@@ -513,7 +519,7 @@ class StrategyConfig:
     # Execution
     enable_fractional_shares: bool = False
     round_fill_price: bool = True
-    slippage: float = 0.0  # Global slippage (e.g., 0.0002 for 2 bps)
+    slippage: Union[float, Dict[str, Any], None] = 0.0
     volume_limit_pct: float = 0.25  # Max participation rate (e.g., 25% of bar volume)
 
     # Position Sizing Constraints

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1596,7 +1596,7 @@ class Strategy:
         trigger_price: Optional[float] = None,
         tag: Optional[str] = None,
         fill_policy: Optional[Dict[str, Any]] = None,
-        slippage: Optional[Dict[str, Any]] = None,
+        slippage: Optional[Union[float, Dict[str, Any]]] = None,
         commission: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
@@ -1635,7 +1635,7 @@ class Strategy:
         trigger_price: Optional[float] = None,
         tag: Optional[str] = None,
         fill_policy: Optional[Dict[str, Any]] = None,
-        slippage: Optional[Dict[str, Any]] = None,
+        slippage: Optional[Union[float, Dict[str, Any]]] = None,
         commission: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
@@ -1681,7 +1681,7 @@ class Strategy:
         trail_offset: Optional[float] = None,
         trail_reference_price: Optional[float] = None,
         fill_policy: Optional[Dict[str, Any]] = None,
-        slippage: Optional[Dict[str, Any]] = None,
+        slippage: Optional[Union[float, Dict[str, Any]]] = None,
         commission: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
@@ -1945,6 +1945,10 @@ class Strategy:
         price: Optional[float] = None,
         time_in_force: Optional[TimeInForce] = None,
         trigger_price: Optional[float] = None,
+        tag: Optional[str] = None,
+        fill_policy: Optional[Dict[str, Any]] = None,
+        slippage: Optional[Union[float, Dict[str, Any]]] = None,
+        commission: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         卖出开空 (Short Sell).
@@ -1956,7 +1960,18 @@ class Strategy:
             time_in_force: 订单有效期
             trigger_price: 触发价 (止损/止盈)
         """
-        _short_impl(self, symbol, quantity, price, time_in_force, trigger_price)
+        _short_impl(
+            self,
+            symbol,
+            quantity,
+            price,
+            time_in_force,
+            trigger_price,
+            tag,
+            fill_policy,
+            slippage,
+            commission,
+        )
 
     def cover(
         self,
@@ -1965,6 +1980,10 @@ class Strategy:
         price: Optional[float] = None,
         time_in_force: Optional[TimeInForce] = None,
         trigger_price: Optional[float] = None,
+        tag: Optional[str] = None,
+        fill_policy: Optional[Dict[str, Any]] = None,
+        slippage: Optional[Union[float, Dict[str, Any]]] = None,
+        commission: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         买入平空 (Buy to Cover).
@@ -1976,7 +1995,18 @@ class Strategy:
             time_in_force: 订单有效期
             trigger_price: 触发价 (止损/止盈)
         """
-        _cover_impl(self, symbol, quantity, price, time_in_force, trigger_price)
+        _cover_impl(
+            self,
+            symbol,
+            quantity,
+            price,
+            time_in_force,
+            trigger_price,
+            tag,
+            fill_policy,
+            slippage,
+            commission,
+        )
 
     def get_cash(self) -> float:
         """获取现金."""

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, List, Optional, Tuple, cast
+import warnings
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 from .akquant import OrderSide, OrderStatus, OrderType, TimeInForce
 
@@ -140,7 +141,7 @@ def buy(
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
     fill_policy: Optional[OrderFillPolicy] = None,
-    slippage: Optional[OrderSlippage] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
     commission: Optional[OrderCommission] = None,
 ) -> str:
     """买入下单."""
@@ -194,7 +195,7 @@ def sell(
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
     fill_policy: Optional[OrderFillPolicy] = None,
-    slippage: Optional[OrderSlippage] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
     commission: Optional[OrderCommission] = None,
 ) -> str:
     """卖出下单."""
@@ -248,7 +249,7 @@ def _submit_buy_side(
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
     fill_policy: Optional[OrderFillPolicy] = None,
-    slippage: Optional[OrderSlippage] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
     commission: Optional[OrderCommission] = None,
 ) -> str:
     if strategy.ctx is None:
@@ -272,7 +273,9 @@ def _submit_buy_side(
     )
     effective_slippage = _resolve_effective_order_slippage(strategy, slippage)
     fill_slippage_type, fill_slippage_value = _normalize_order_slippage(
-        effective_slippage
+        strategy,
+        symbol,
+        effective_slippage,
     )
     effective_commission = _resolve_effective_order_commission(strategy, commission)
     fill_commission_type, fill_commission_value = _normalize_order_commission(
@@ -336,7 +339,7 @@ def _submit_sell_side(
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
     fill_policy: Optional[OrderFillPolicy] = None,
-    slippage: Optional[OrderSlippage] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
     commission: Optional[OrderCommission] = None,
 ) -> str:
     if strategy.ctx is None:
@@ -357,7 +360,9 @@ def _submit_sell_side(
     )
     effective_slippage = _resolve_effective_order_slippage(strategy, slippage)
     fill_slippage_type, fill_slippage_value = _normalize_order_slippage(
-        effective_slippage
+        strategy,
+        symbol,
+        effective_slippage,
     )
     effective_commission = _resolve_effective_order_commission(strategy, commission)
     fill_commission_type, fill_commission_value = _normalize_order_commission(
@@ -430,7 +435,7 @@ def submit_order(
     trail_offset: Optional[float] = None,
     trail_reference_price: Optional[float] = None,
     fill_policy: Optional[OrderFillPolicy] = None,
-    slippage: Optional[OrderSlippage] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
     commission: Optional[OrderCommission] = None,
 ) -> str:
     """统一下单接口."""
@@ -547,23 +552,45 @@ def _normalize_order_fill_policy(
 
 
 def _normalize_order_slippage(
-    slippage: Optional[OrderSlippage],
+    strategy: Any,
+    symbol: str,
+    slippage: Optional[Union[OrderSlippage, float, int]],
 ) -> Tuple[Optional[str], Optional[float]]:
     if slippage is None:
         return None, None
-    if not isinstance(slippage, dict):
-        raise TypeError("slippage must be a dict when provided")
-    raw_type = str(slippage.get("type", "percent")).strip().lower()
-    if raw_type not in {"percent", "fixed"}:
-        raise ValueError("slippage.type must be one of: percent, fixed")
-    raw_value = slippage.get("value", 0.0)
+    if isinstance(slippage, (int, float)):
+        raw_type = "percent"
+        raw_value = float(slippage)
+        if raw_value != 0.0:
+            warnings.warn(
+                "Passing order slippage as a bare number is deprecated in AKQuant. "
+                "Use an explicit policy such as "
+                "slippage={'type': 'percent', 'value': 0.0002} or "
+                "slippage={'type': 'fixed', 'value': 0.2}.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+    else:
+        if not isinstance(slippage, dict):
+            raise TypeError("slippage must be a dict when provided")
+        raw_type = str(slippage.get("type", "percent")).strip().lower()
+        raw_value = slippage.get("value", 0.0)
     try:
         value = float(raw_value)
     except (TypeError, ValueError):
         raise ValueError("slippage.value must be a number >= 0") from None
     if value < 0:
         raise ValueError("slippage.value must be >= 0")
-    return raw_type, value
+    if raw_type in {"percent", "fixed"}:
+        return raw_type, value
+    if raw_type == "zero":
+        return "fixed", 0.0
+    if raw_type == "ticks":
+        tick_size = float(strategy.get_instrument(symbol).tick_size)
+        if tick_size <= 0:
+            raise ValueError("slippage.type='ticks' requires tick_size > 0")
+        return "fixed", value * tick_size
+    raise ValueError("slippage.type must be one of: percent, fixed, ticks, zero")
 
 
 def _normalize_order_commission(
@@ -609,8 +636,8 @@ def _resolve_effective_order_fill_policy(
 
 
 def _resolve_effective_order_slippage(
-    strategy: Any, slippage: Optional[OrderSlippage]
-) -> Optional[OrderSlippage]:
+    strategy: Any, slippage: Optional[Union[OrderSlippage, float, int]]
+) -> Optional[Union[OrderSlippage, float, int]]:
     if slippage is not None:
         return slippage
     owner_strategy_id = str(getattr(strategy, "_owner_strategy_id", "") or "").strip()
@@ -1108,6 +1135,10 @@ def short(
     price: Optional[float] = None,
     time_in_force: Optional[TimeInForce] = None,
     trigger_price: Optional[float] = None,
+    tag: Optional[str] = None,
+    fill_policy: Optional[OrderFillPolicy] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
+    commission: Optional[OrderCommission] = None,
 ) -> None:
     """卖出开空 (Short Sell)."""
     if strategy.ctx is None:
@@ -1130,7 +1161,18 @@ def short(
         )
 
     if quantity > 0:
-        strategy.ctx.sell(symbol, quantity, price, time_in_force, trigger_price)
+        _submit_sell_side(
+            strategy=strategy,
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            time_in_force=time_in_force,
+            trigger_price=trigger_price,
+            tag=tag,
+            fill_policy=fill_policy,
+            slippage=slippage,
+            commission=commission,
+        )
 
 
 def cover(
@@ -1140,6 +1182,10 @@ def cover(
     price: Optional[float] = None,
     time_in_force: Optional[TimeInForce] = None,
     trigger_price: Optional[float] = None,
+    tag: Optional[str] = None,
+    fill_policy: Optional[OrderFillPolicy] = None,
+    slippage: Optional[Union[OrderSlippage, float, int]] = None,
+    commission: Optional[OrderCommission] = None,
 ) -> None:
     """买入平空 (Buy to Cover)."""
     if strategy.ctx is None:
@@ -1155,7 +1201,18 @@ def cover(
             return
 
     if quantity > 0:
-        strategy.ctx.buy(symbol, quantity, price, time_in_force, trigger_price)
+        _submit_buy_side(
+            strategy=strategy,
+            symbol=symbol,
+            quantity=quantity,
+            price=price,
+            time_in_force=time_in_force,
+            trigger_price=trigger_price,
+            tag=tag,
+            fill_policy=fill_policy,
+            slippage=slippage,
+            commission=commission,
+        )
 
 
 def get_cash(strategy: Any) -> float:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,4 @@
+import logging
 import time
 import warnings
 from datetime import date, datetime, timezone
@@ -4217,6 +4218,41 @@ def test_run_grid_search_parallel_warns_worker_log_visibility(
     )
     captured = capsys.readouterr()
     assert "self.log() output may not be visible" in captured.out
+
+
+def test_run_backtest_warns_on_suspicious_global_slippage(caplog: Any) -> None:
+    """Large float slippage should warn because AKQuant treats it as percent."""
+    data = _build_benchmark_data(n=5, symbol="SLIP_WARN")
+
+    with pytest.warns(DeprecationWarning):
+        with caplog.at_level(logging.WARNING, logger="akquant"):
+            _ = akquant.run_backtest(
+                strategy=NoopStrategy,
+                data=data,
+                symbols="SLIP_WARN",
+                slippage=0.2,
+                show_progress=False,
+            )
+
+    assert "Global slippage=0.2 uses percent semantics in AKQuant" in caplog.text
+    assert "slippage={'type': 'fixed', 'value': 0.2}" in caplog.text
+
+
+def test_run_backtest_does_not_warn_on_small_global_slippage(caplog: Any) -> None:
+    """Typical bps-scale slippage should not trigger the suspicious warning."""
+    data = _build_benchmark_data(n=5, symbol="SLIP_OK")
+
+    with pytest.warns(DeprecationWarning):
+        with caplog.at_level(logging.WARNING, logger="akquant"):
+            _ = akquant.run_backtest(
+                strategy=NoopStrategy,
+                data=data,
+                symbols="SLIP_OK",
+                slippage=0.0002,
+                show_progress=False,
+            )
+
+    assert "uses percent semantics in AKQuant" not in caplog.text
 
 
 def test_run_grid_search_parallel_forward_worker_logs_suppresses_visibility_warning(

--- a/tests/test_examples_regression.py
+++ b/tests/test_examples_regression.py
@@ -80,3 +80,59 @@ def test_option_example_main_uses_keyword_arguments(monkeypatch: Any) -> None:
     assert captured["commission_rate"] == 0.0
     assert captured["show_progress"] is False
     assert set(captured["data"]) == {"CALL_OPT", "UL"}
+
+
+def test_textbook_futures_strategy_uses_short_for_bearish_signal(
+    monkeypatch: Any,
+) -> None:
+    """Textbook futures strategy should open bearish positions via short()."""
+    module = _load_example_module(
+        "example_textbook_futures_strategy",
+        "examples/textbook/ch07_futures.py",
+    )
+    strategy = module.FuturesTrendStrategy()
+    captured: dict[str, Any] = {"short": None, "buy": None}
+
+    monkeypatch.setattr(
+        strategy,
+        "get_history",
+        lambda **_kwargs: pd.Series([100.0] * strategy.ma_window + [90.0]),
+    )
+    monkeypatch.setattr(strategy, "get_position", lambda _symbol: 0.0)
+    monkeypatch.setattr(strategy, "log", lambda _message: None)
+    monkeypatch.setattr(
+        strategy,
+        "short",
+        lambda symbol, quantity: captured.__setitem__("short", (symbol, quantity)),
+    )
+    monkeypatch.setattr(
+        strategy,
+        "buy",
+        lambda symbol, quantity: captured.__setitem__("buy", (symbol, quantity)),
+    )
+
+    bar = aq.Bar(
+        timestamp=pd.Timestamp("2023-01-01 09:30:00", tz="UTC").value,
+        open=90.0,
+        high=90.0,
+        low=90.0,
+        close=90.0,
+        volume=1000.0,
+        symbol="RB2310",
+    )
+    strategy.on_bar(bar)
+
+    assert captured["short"] == ("RB2310", 1)
+    assert captured["buy"] is None
+
+
+def test_textbook_futures_example_documents_fill_policy_and_bps_slippage() -> None:
+    """Textbook futures example should retain safer fill/slippage configuration."""
+    root = Path(__file__).resolve().parents[1]
+    source = (root / "examples" / "textbook" / "ch07_futures.py").read_text(
+        encoding="utf-8"
+    )
+    assert '"price_basis": "close"' in source
+    assert '"bar_offset": 0' in source
+    assert '"temporal": "same_cycle"' in source
+    assert 'slippage={"type": "percent", "value": 0.0002}' in source

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 from akquant import (
     BacktestConfig,
+    InstrumentConfig,
     StrategyConfig,
     register_logger,
     register_strategy_loader,
@@ -3362,7 +3363,7 @@ def test_strategy_buy_sell_delegate_to_submit_order() -> None:
             trail_offset: float | None = None,
             trail_reference_price: float | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             _ = price
@@ -3587,6 +3588,18 @@ class _OrderLevelSlippageStrategy(Strategy):
             },
             slippage={"type": "percent", "value": 0.1},
         )
+        self.submit_order(
+            symbol=bar.symbol,
+            side="Buy",
+            quantity=1.0,
+            tag="slippage-ticks",
+            fill_policy={
+                "price_basis": "open",
+                "bar_offset": 1,
+                "temporal": "same_cycle",
+            },
+            slippage={"type": "ticks", "value": 2},
+        )
 
 
 def test_order_level_slippage_overrides_engine_slippage() -> None:
@@ -3609,14 +3622,20 @@ def test_order_level_slippage_overrides_engine_slippage() -> None:
         symbols="AAPL",
         initial_cash=100000.0,
         show_progress=False,
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(),
+            instruments_config=[InstrumentConfig(symbol="AAPL", tick_size=0.25)],
+        ),
     )
     filled_orders = result.orders_df[
         result.orders_df["status"].astype(str).str.lower() == "filled"
     ]
     fixed_row = filled_orders[filled_orders["tag"] == "slippage-fixed"].iloc[0]
     percent_row = filled_orders[filled_orders["tag"] == "slippage-percent"].iloc[0]
+    ticks_row = filled_orders[filled_orders["tag"] == "slippage-ticks"].iloc[0]
     assert float(fixed_row["avg_price"]) == pytest.approx(20.5)
     assert float(percent_row["avg_price"]) == pytest.approx(22.0)
+    assert float(ticks_row["avg_price"]) == pytest.approx(20.5)
 
 
 class _StrategyLevelSlippageStrategy(Strategy):
@@ -3650,8 +3669,74 @@ def test_strategy_level_slippage_applies_when_order_slippage_missing() -> None:
         symbols="AAPL",
         initial_cash=100000.0,
         show_progress=False,
-        slippage=0.2,
+        slippage={"type": "percent", "value": 0.2},
         strategy_slippage={"_default": {"type": "fixed", "value": 0.5}},
+    )
+    filled_orders = result.orders_df[
+        result.orders_df["status"].astype(str).str.lower() == "filled"
+    ]
+    row = filled_orders[filled_orders["tag"] == "strategy-slippage"].iloc[0]
+    assert float(row["avg_price"]) == pytest.approx(20.5)
+
+
+def test_strategy_level_ticks_slippage_uses_symbol_tick_size() -> None:
+    """Strategy-level tick slippage should resolve via instrument tick_size."""
+    register_logger(console=False, level="INFO")
+    data = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-01-01", periods=3, freq="D", tz="UTC"),
+            "open": [10.0, 20.0, 30.0],
+            "high": [11.0, 21.0, 31.0],
+            "low": [9.0, 19.0, 29.0],
+            "close": [100.0, 200.0, 300.0],
+            "volume": [10000.0, 10000.0, 10000.0],
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+        }
+    )
+    result = run_backtest(
+        data=data,
+        strategy=_StrategyLevelSlippageStrategy,
+        symbols="AAPL",
+        initial_cash=100000.0,
+        show_progress=False,
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(),
+            instruments_config=[InstrumentConfig(symbol="AAPL", tick_size=0.25)],
+        ),
+        strategy_slippage={"_default": {"type": "ticks", "value": 2}},
+    )
+    filled_orders = result.orders_df[
+        result.orders_df["status"].astype(str).str.lower() == "filled"
+    ]
+    row = filled_orders[filled_orders["tag"] == "strategy-slippage"].iloc[0]
+    assert float(row["avg_price"]) == pytest.approx(20.5)
+
+
+def test_global_ticks_slippage_resolves_to_fixed_from_shared_tick_size() -> None:
+    """Global tick slippage should resolve from a shared instrument tick_size."""
+    register_logger(console=False, level="INFO")
+    data = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-01-01", periods=3, freq="D", tz="UTC"),
+            "open": [10.0, 20.0, 30.0],
+            "high": [11.0, 21.0, 31.0],
+            "low": [9.0, 19.0, 29.0],
+            "close": [100.0, 200.0, 300.0],
+            "volume": [10000.0, 10000.0, 10000.0],
+            "symbol": ["AAPL", "AAPL", "AAPL"],
+        }
+    )
+    result = run_backtest(
+        data=data,
+        strategy=_StrategyLevelSlippageStrategy,
+        symbols="AAPL",
+        initial_cash=100000.0,
+        show_progress=False,
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(),
+            instruments_config=[InstrumentConfig(symbol="AAPL", tick_size=0.25)],
+        ),
+        slippage={"type": "ticks", "value": 2},
     )
     filled_orders = result.orders_df[
         result.orders_df["status"].astype(str).str.lower() == "filled"
@@ -3787,7 +3872,7 @@ def test_strategy_trailing_helpers_delegate_to_submit_order() -> None:
             trail_offset: float | None = None,
             trail_reference_price: float | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             _ = time_in_force
@@ -4014,7 +4099,7 @@ def test_bracket_prefers_engine_registration_when_available() -> None:
             trigger_price: float | None = None,
             tag: str | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             self.buy_calls.append(
@@ -4086,7 +4171,7 @@ def test_bracket_falls_back_to_deferred_engine_queue_on_runtime_error() -> None:
             trigger_price: float | None = None,
             tag: str | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             _ = (
@@ -4142,7 +4227,7 @@ def test_bracket_places_exit_orders_and_builds_oco() -> None:
             trigger_price: float | None = None,
             tag: str | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             self.buy_calls.append(
@@ -4169,7 +4254,7 @@ def test_bracket_places_exit_orders_and_builds_oco() -> None:
             trigger_price: float | None = None,
             tag: str | None = None,
             fill_policy: dict[str, Any] | None = None,
-            slippage: dict[str, Any] | None = None,
+            slippage: float | dict[str, Any] | None = None,
             commission: dict[str, Any] | None = None,
         ) -> str:
             self._sell_counter += 1


### PR DESCRIPTION
- 扩展滑点策略支持 `ticks` 和 `zero` 类型，并提供更清晰的配置警告
- 为 `short()` 和 `cover()` 方法添加完整的订单参数支持
- 更新期货示例，使用显式 `fill_policy` 和 `slippage` 配置
- 改进文档，强调期货策略配置的最佳实践
- 添加测试验证滑点配置的语义和警告行为