### PR TITLE
fix: 修复日内调仓时机与行情数据跨符号排序问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.12"
+version = "0.2.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.12"
+version = "0.2.13"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.12"
+version = "0.2.13"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/data.py
+++ b/python/akquant/data.py
@@ -56,10 +56,17 @@ class ParquetDataCatalog:
                 df = df.set_index("date")
                 df.index = pd.to_datetime(df.index)
 
-        # Ensure symbol column exists for Polars compatibility
+        # Normalize common numeric columns so parquet schemas stay stable
+        # across symbols even when some series happen to contain integer-only values.
         if "symbol" not in df.columns:
             df = df.copy()
             df["symbol"] = symbol
+        else:
+            df = df.copy()
+
+        for col in ("open", "high", "low", "close", "volume"):
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors="coerce").astype("float64")
 
         df.to_parquet(file_path, compression="snappy")
         return file_path

--- a/python/akquant/factor/engine.py
+++ b/python/akquant/factor/engine.py
@@ -31,8 +31,10 @@ class FactorEngine:
         pattern = str(self.catalog.root / "**" / "*.parquet")
 
         try:
-            # use_pyarrow=True often helps with nested paths compatibility
-            lf = pl.scan_parquet(pattern)
+            lf = pl.scan_parquet(
+                pattern,
+                cast_options=pl.ScanCastOptions(integer_cast="allow-float"),
+            )
             return lf
         except Exception as e:
             logger.warning(f"Failed to scan parquet files: {e}")

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -998,11 +998,89 @@ def _select_plot_symbol(
         keys = [str(k) for k in market_data.keys()]
         if keys:
             return keys[0]
-    if isinstance(market_data, pd.DataFrame) and "symbol" in market_data.columns:
-        symbols = market_data["symbol"].dropna().astype(str)
-        if not symbols.empty:
-            return str(symbols.iloc[0])
+    if isinstance(market_data, pd.DataFrame):
+        symbol_col = _resolve_market_data_column(
+            market_data, ["symbol", "code", "ticker", "ts_code", "股票代码"]
+        )
+        if symbol_col is not None:
+            symbols = market_data[symbol_col].dropna().astype(str).str.strip()
+            if not symbols.empty:
+                return str(symbols.iloc[0])
     return None
+
+
+def _resolve_market_data_column(
+    data: pd.DataFrame, candidates: list[str]
+) -> Optional[str]:
+    """Resolve a market-data column name with case-insensitive matching."""
+    columns = list(data.columns)
+    lowered = {str(col).lower(): str(col) for col in columns}
+    for candidate in candidates:
+        if candidate in columns:
+            return candidate
+        resolved = lowered.get(candidate.lower())
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _normalize_market_data_frame(data: pd.DataFrame) -> pd.DataFrame:
+    """Normalize report market data into a canonical OHLCV schema."""
+    normalized = data.copy()
+    resolved_columns = {
+        "timestamp": _resolve_market_data_column(
+            normalized,
+            ["date", "timestamp", "datetime", "time", "trade_date", "日期", "时间"],
+        ),
+        "open": _resolve_market_data_column(normalized, ["open", "open_price", "开盘"]),
+        "high": _resolve_market_data_column(normalized, ["high", "high_price", "最高"]),
+        "low": _resolve_market_data_column(normalized, ["low", "low_price", "最低"]),
+        "close": _resolve_market_data_column(
+            normalized, ["close", "close_price", "收盘"]
+        ),
+        "volume": _resolve_market_data_column(normalized, ["volume", "vol", "成交量"]),
+        "symbol": _resolve_market_data_column(
+            normalized, ["symbol", "code", "ticker", "ts_code", "股票代码"]
+        ),
+    }
+    rename_map = {
+        source: target
+        for target, source in resolved_columns.items()
+        if source is not None and source != target
+    }
+    if rename_map:
+        normalized = normalized.rename(columns=rename_map)
+
+    if "symbol" in normalized.columns:
+        normalized["symbol"] = normalized["symbol"].astype(str).str.strip()
+
+    if not isinstance(normalized.index, pd.DatetimeIndex):
+        if "timestamp" in normalized.columns:
+            normalized = normalized.set_index("timestamp")
+        else:
+            normalized.index = pd.to_datetime(normalized.index, errors="coerce")
+
+    normalized.index = pd.to_datetime(normalized.index, errors="coerce")
+    valid_index_mask = ~normalized.index.to_series().isna()
+    normalized = normalized.loc[valid_index_mask].copy()
+    if normalized.empty:
+        return cast(pd.DataFrame, normalized)
+
+    numeric_columns = ["open", "high", "low", "close", "volume"]
+    for column in numeric_columns:
+        if column in normalized.columns:
+            normalized[column] = pd.to_numeric(normalized[column], errors="coerce")
+
+    required_cols = {"open", "high", "low", "close"}
+    if not required_cols.issubset(set(normalized.columns)):
+        return pd.DataFrame()
+
+    normalized = normalized.dropna(subset=list(required_cols), how="any")
+    if normalized.empty:
+        return cast(pd.DataFrame, normalized)
+
+    normalized = normalized.sort_index()
+    return cast(pd.DataFrame, normalized)
 
 
 def _extract_symbol_market_data(
@@ -1011,27 +1089,27 @@ def _extract_symbol_market_data(
     if market_data is None:
         return pd.DataFrame()
     if isinstance(market_data, dict):
-        data = market_data.get(symbol, pd.DataFrame()).copy()
+        matched_key = None
+        target_symbol = str(symbol).strip()
+        for key in market_data.keys():
+            if str(key).strip() == target_symbol:
+                matched_key = key
+                break
+        if matched_key is None:
+            return pd.DataFrame()
+        data = market_data.get(matched_key, pd.DataFrame()).copy()
     elif isinstance(market_data, pd.DataFrame):
         data = market_data.copy()
-        if "symbol" in data.columns:
-            data = data[data["symbol"].astype(str) == symbol].copy()
     else:
         return pd.DataFrame()
+
+    data = _normalize_market_data_frame(data)
     if data.empty:
         return cast(pd.DataFrame, data)
-    if not isinstance(data.index, pd.DatetimeIndex):
-        for col in ["date", "timestamp", "datetime", "Date", "Timestamp"]:
-            if col in data.columns:
-                data = data.set_index(col)
-                break
-        data.index = pd.to_datetime(data.index, errors="coerce")
-    valid_index_mask = ~data.index.to_series().isna()
-    data = data.loc[valid_index_mask].copy()
-    required_cols = {"open", "high", "low", "close"}
-    if not required_cols.issubset(set(data.columns)):
-        return pd.DataFrame()
-    data = data.sort_index()
+    if "symbol" in data.columns:
+        target_symbol = str(symbol).strip()
+        symbol_mask = data["symbol"].astype(str).str.strip() == target_symbol
+        data = data[symbol_mask].copy()
     return cast(pd.DataFrame, data)
 
 

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -897,7 +897,10 @@ class Strategy:
                 )
             return []
 
-        ranking = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        ranking = sorted(
+            scores.items(),
+            key=lambda item: (-float(item[1]), str(item[0])),
+        )
         threshold = min_score
         if threshold is None and long_only:
             threshold = 0.0

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -7,6 +7,7 @@ from .akquant import Bar, StrategyContext, Tick
 from .strategy_framework_hooks import (
     call_user_callback,
     dispatch_boundary_timer,
+    dispatch_daily_rebalance_timer,
     dispatch_portfolio_update,
     dispatch_time_hooks,
     ensure_framework_state,
@@ -164,6 +165,9 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
 
     dispatch_time_hooks(strategy)
     dispatch_portfolio_update(strategy)
+
+    if dispatch_daily_rebalance_timer(strategy, payload):
+        return
 
     if dispatch_boundary_timer(strategy, payload):
         return

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -56,6 +56,20 @@ def _dispatch_daily_rebalance_if_needed(
 ) -> None:
     if getattr(strategy, "_framework_daily_rebalance_done_date", None) == trading_date:
         return
+    event_type = getattr(strategy, "_last_event_type", None)
+    if event_type == "bar" and strategy.ctx is not None:
+        pending_date = getattr(
+            strategy,
+            "_framework_daily_rebalance_pending_date",
+            None,
+        )
+        if pending_date == trading_date:
+            return
+        schedule_ts = int(timestamp) + 1
+        payload = f"__framework_rebalance__|{trading_date}|{int(timestamp)}"
+        strategy.ctx.schedule(schedule_ts, payload)
+        strategy._framework_daily_rebalance_pending_date = trading_date
+        return
     call_user_callback(
         strategy,
         "on_daily_rebalance",
@@ -249,6 +263,40 @@ def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
     return True
 
 
+def dispatch_daily_rebalance_timer(strategy: Any, payload: str) -> bool:
+    """处理框架级日内调仓定时器，返回是否已消费该 payload."""
+    if not payload.startswith("__framework_rebalance__|"):
+        return False
+
+    parts = payload.split("|", 2)
+    if len(parts) != 3:
+        return True
+
+    trading_date_text = parts[1]
+    trading_date: Any = trading_date_text
+    try:
+        trading_date = pd.to_datetime(trading_date_text).date()
+    except Exception:
+        pass
+    try:
+        source_timestamp = int(parts[2])
+    except Exception:
+        source_timestamp = int(getattr(strategy.ctx, "current_time", 0))
+
+    done_date = getattr(strategy, "_framework_daily_rebalance_done_date", None)
+    if done_date != trading_date:
+        call_user_callback(
+            strategy,
+            "on_daily_rebalance",
+            trading_date,
+            source_timestamp,
+            payload={"trading_date": trading_date, "timestamp": source_timestamp},
+        )
+        strategy._framework_daily_rebalance_done_date = trading_date
+    strategy._framework_daily_rebalance_pending_date = None
+    return True
+
+
 def mark_portfolio_dirty(strategy: Any) -> None:
     """标记账户快照需要重新计算."""
     strategy._framework_portfolio_dirty = True
@@ -360,6 +408,8 @@ def ensure_framework_state(strategy: Any) -> None:
         strategy._framework_before_trading_done_date = None
     if not hasattr(strategy, "_framework_daily_rebalance_done_date"):
         strategy._framework_daily_rebalance_done_date = None
+    if not hasattr(strategy, "_framework_daily_rebalance_pending_date"):
+        strategy._framework_daily_rebalance_pending_date = None
     if not hasattr(strategy, "_framework_after_trading_done_date"):
         strategy._framework_after_trading_done_date = None
     if not hasattr(strategy, "_framework_last_portfolio_state"):

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1075,12 +1075,16 @@ def order_target_weights(
         and fill_temporal == "same_cycle"
     )
 
-    for symbol, target_value, _ in sorted(sell_legs, key=lambda item: item[2]):
+    for symbol, target_value, _ in sorted(
+        sell_legs,
+        key=lambda item: (float(item[2]), str(item[0])),
+    ):
         leg_price = price_map.get(symbol) if price_map else None
         order_target_value(strategy, target_value, symbol, leg_price, **kwargs)
 
     for symbol, target_value, _ in sorted(
-        buy_legs, key=lambda item: item[2], reverse=True
+        buy_legs,
+        key=lambda item: (-float(item[2]), str(item[0])),
     ):
         leg_price = price_map.get(symbol) if price_map else None
         if defer_buy_legs:

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -396,6 +396,7 @@ impl Processor for ChannelProcessor {
 
 pub struct DataProcessor {
     last_timestamp: i64,
+    finalized_timestamp: i64,
     seen_symbols: HashSet<String>,
 }
 
@@ -410,6 +411,7 @@ impl DataProcessor {
     pub fn new() -> Self {
         Self {
             last_timestamp: 0,
+            finalized_timestamp: 0,
             seen_symbols: HashSet::new(),
         }
     }
@@ -439,6 +441,14 @@ impl DataProcessor {
             }
         }
     }
+
+    fn finalize_current_timestamp(&mut self, engine: &Engine) {
+        if self.last_timestamp == 0 || self.finalized_timestamp == self.last_timestamp {
+            return;
+        }
+        self.fill_missing_bars(engine);
+        self.finalized_timestamp = self.last_timestamp;
+    }
 }
 
 impl Processor for DataProcessor {
@@ -454,11 +464,14 @@ impl Processor for DataProcessor {
         match action {
             FeedAction::Wait => Ok(ProcessorResult::Loop),
             FeedAction::End => {
-                self.fill_missing_bars(engine);
+                self.finalize_current_timestamp(engine);
                 Ok(ProcessorResult::Break)
             }
             FeedAction::Timer(_timestamp) => {
                 if let Some(timer) = engine.timers.pop() {
+                    if timer.payload.starts_with("__framework_rebalance__|") {
+                        self.finalize_current_timestamp(engine);
+                    }
                     let local_dt =
                         Engine::local_datetime_from_ns(timer.timestamp, engine.timezone_offset);
                     let session = engine.market_manager.get_session_status(local_dt.time());
@@ -483,7 +496,7 @@ impl Processor for DataProcessor {
                 }
 
                 if self.last_timestamp != 0 && timestamp > self.last_timestamp {
-                    self.fill_missing_bars(engine);
+                    self.finalize_current_timestamp(engine);
                     self.seen_symbols.clear();
 
                     if engine.is_active_timestamp(timestamp) {

--- a/tests/test_factor_engine.py
+++ b/tests/test_factor_engine.py
@@ -205,6 +205,49 @@ class TestFactorEngineNewOps(unittest.TestCase):
         res_d = df.filter(pl.col("symbol") == "D")
         self.assertEqual(len(res_d), 5)
 
+    def test_mixed_numeric_schema_catalog_scan(self) -> None:
+        """Allow integer/float parquet schema drift when scanning the whole catalog."""
+        if self.catalog_path.exists():
+            shutil.rmtree(self.catalog_path)
+        self.catalog = ParquetDataCatalog(root_path=str(self.catalog_path))
+        self.engine = FactorEngine(self.catalog)
+
+        dates = pd.date_range("2023-01-01", periods=3)
+
+        df_float = pd.DataFrame(
+            {
+                "date": dates,
+                "low": [1.1, 2.2, 3.3],
+                "close": [1.5, 2.5, 3.5],
+                "symbol": "FLOAT",
+            }
+        ).set_index("date")
+        df_int = pd.DataFrame(
+            {
+                "date": dates,
+                "low": [1, 2, 3],
+                "close": [4, 5, 6],
+                "symbol": "INT",
+            }
+        ).set_index("date")
+
+        self.catalog.write("FLOAT", df_float)
+        self.catalog.write("INT", df_int)
+
+        low_result = self.engine.run("Low").sort(["symbol", "date"])
+        self.assertEqual(low_result["factor_value"].dtype, pl.Float64)
+        self.assertEqual(low_result.height, 6)
+        self.assertEqual(
+            low_result.filter(pl.col("symbol") == "INT")["factor_value"].to_list(),
+            [1.0, 2.0, 3.0],
+        )
+
+        ts_result = self.engine.run("Ts_ArgMin(Low, 2)").sort(["symbol", "date"])
+        self.assertEqual(ts_result.height, 6)
+        self.assertIsNone(
+            ts_result.filter(pl.col("symbol") == "FLOAT")["factor_value"].to_list()[0]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -115,6 +115,40 @@ def _build_market_df(symbol: str = "TEST", n: int = 5) -> pd.DataFrame:
     return cast(pd.DataFrame, df)
 
 
+def _build_market_df_uppercase(symbol: str = "TEST", n: int = 5) -> pd.DataFrame:
+    rows = []
+    for bar in _build_data(symbol=symbol, n=n):
+        rows.append(
+            {
+                "Timestamp": pd.Timestamp(bar.timestamp),
+                "Open": bar.open,
+                "High": bar.high,
+                "Low": bar.low,
+                "Close": bar.close,
+                "Volume": bar.volume,
+                "Symbol": bar.symbol,
+            }
+        )
+    return cast(pd.DataFrame, pd.DataFrame(rows))
+
+
+def _build_market_df_aliases(symbol: str = "TEST", n: int = 5) -> pd.DataFrame:
+    rows = []
+    for bar in _build_data(symbol=symbol, n=n):
+        rows.append(
+            {
+                "trade_date": pd.Timestamp(bar.timestamp),
+                "open_price": bar.open,
+                "high_price": bar.high,
+                "low_price": bar.low,
+                "close_price": bar.close,
+                "vol": bar.volume,
+                "code": bar.symbol,
+            }
+        )
+    return cast(pd.DataFrame, pd.DataFrame(rows))
+
+
 def _skip_if_no_plotly() -> None:
     """Skip tests if plotly is unavailable."""
     if importlib.util.find_spec("plotly") is None:
@@ -178,6 +212,64 @@ def test_report_includes_trade_kline_with_market_data(tmp_path: Path) -> None:
     assert "Strategy Analysis: TEST" in html
     assert "entry" in html
     assert "exit" in html
+
+
+def test_report_accepts_uppercase_market_data_columns(tmp_path: Path) -> None:
+    """Report should accept DuckDB-like uppercase OHLCV column names."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=RoundTripStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    report_path = tmp_path / "report_with_uppercase_market_data.html"
+    result.report(
+        filename=str(report_path),
+        show=False,
+        market_data=_build_market_df_uppercase(symbol="TEST"),
+        plot_symbol="TEST",
+    )
+    html = report_path.read_text(encoding="utf-8")
+    assert "Strategy Analysis: TEST" in html
+    assert "行情数据不完整，无法绘制 K 线复盘图" not in html
+
+
+def test_report_accepts_market_data_alias_columns(tmp_path: Path) -> None:
+    """Report should accept alias columns such as trade_date/code/open_price."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=RoundTripStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    report_path = tmp_path / "report_with_alias_market_data.html"
+    result.report(
+        filename=str(report_path),
+        show=False,
+        market_data=_build_market_df_aliases(symbol="TEST"),
+        plot_symbol="TEST",
+    )
+    html = report_path.read_text(encoding="utf-8")
+    assert "Strategy Analysis: TEST" in html
+    assert "行情数据不完整，无法绘制 K 线复盘图" not in html
 
 
 def test_report_includes_benchmark_comparison_sections(tmp_path: Path) -> None:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -233,6 +233,19 @@ def test_rebalance_to_topn_supports_score_weight_mode() -> None:
     assert strategy.calls[0]["target_weights"]["AAA"] == pytest.approx(0.25)
 
 
+def test_rebalance_to_topn_breaks_score_ties_by_symbol() -> None:
+    """rebalance_to_topn should use symbol order as deterministic tie-breaker."""
+    strategy = TopNRebalanceStrategy()
+
+    selected = strategy.rebalance_to_topn(
+        scores={"BBB": 0.1, "AAA": 0.1, "CCC": 0.05},
+        top_n=2,
+    )
+
+    assert selected == ["AAA", "BBB"]
+    assert strategy.calls[0]["target_weights"] == {"AAA": 0.5, "BBB": 0.5}
+
+
 def test_rebalance_to_topn_rejects_invalid_weight_mode() -> None:
     """rebalance_to_topn should validate weight_mode."""
     strategy = TopNRebalanceStrategy()
@@ -898,6 +911,106 @@ class WarmStartRiskStateStrategy(Strategy):
         """Submit buy sequence across pre/post snapshot phases."""
         self.buy(symbol=bar.symbol, quantity=10)
         self.step += 1
+
+
+class DeferredDailyRebalanceStrategy(Strategy):
+    """Regression strategy for daily rebalance timing determinism."""
+
+    def __init__(
+        self,
+        all_symbols: list[str],
+        date2symbols: dict[Any, set[str]],
+        capture: dict[str, Any],
+    ) -> None:
+        """Initialize symbol universe, rebalance map, and capture sink."""
+        super().__init__()
+        self.all_symbols = list(all_symbols)
+        self.date2symbols = date2symbols
+        self.capture = capture
+        self.set_history_depth(2)
+
+    def on_start(self) -> None:
+        """Subscribe to all configured symbols."""
+        for symbol in self.all_symbols:
+            self.subscribe(symbol)
+
+    def on_daily_rebalance(self, trading_date: Any, timestamp: int) -> None:
+        """Select the strongest two-bar momentum symbol on the target day."""
+        if trading_date not in self.date2symbols:
+            return
+        symbols = self.date2symbols[trading_date]
+        history_map = self.get_history_map(count=2, symbols=symbols, field="close")
+        scores: dict[str, float] = {}
+        for symbol, closes in history_map.items():
+            if np.isnan(closes[0]) or closes[0] == 0:
+                continue
+            scores[symbol] = float((closes[-1] - closes[0]) / closes[0])
+        selected = self.rebalance_to_topn(scores=scores, top_n=1)
+        self.capture.setdefault("events", []).append(
+            (trading_date, timestamp, tuple(selected))
+        )
+
+
+def _make_order_sensitive_multisymbol_bars(day3_order: list[str]) -> list[Bar]:
+    """Create bars whose day-3 leader depends on when rebalance is evaluated."""
+    schedule = [
+        ("2023-01-01 15:00:00", {"AAA": 10.0, "BBB": 10.0}, ["AAA", "BBB"]),
+        ("2023-01-02 15:00:00", {"AAA": 10.0, "BBB": 10.0}, ["AAA", "BBB"]),
+        ("2023-01-03 15:00:00", {"AAA": 20.0, "BBB": 11.0}, day3_order),
+        ("2023-01-04 15:00:00", {"AAA": 10.0, "BBB": 30.0}, ["AAA", "BBB"]),
+    ]
+    bars: list[Bar] = []
+    for timestamp_text, closes, order in schedule:
+        ts = pd.Timestamp(timestamp_text, tz="Asia/Shanghai").value
+        for symbol in order:
+            close = closes[symbol]
+            bars.append(
+                Bar(
+                    timestamp=ts,
+                    open=close,
+                    high=close,
+                    low=close,
+                    close=close,
+                    volume=1000.0,
+                    symbol=symbol,
+                )
+            )
+    return bars
+
+
+def test_run_backtest_daily_rebalance_same_timestamp_order_insensitive() -> None:
+    """Daily rebalance should see a complete same-timestamp cross section."""
+    target_day = pd.Timestamp("2023-01-03", tz="Asia/Shanghai").date()
+    date2symbols = {target_day: {"AAA", "BBB"}}
+    first_capture: dict[str, Any] = {}
+    second_capture: dict[str, Any] = {}
+
+    first = run_backtest(
+        data=_make_order_sensitive_multisymbol_bars(["AAA", "BBB"]),
+        strategy=DeferredDailyRebalanceStrategy,
+        symbols=["AAA", "BBB"],
+        all_symbols=["AAA", "BBB"],
+        date2symbols=date2symbols,
+        capture=first_capture,
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    second = run_backtest(
+        data=_make_order_sensitive_multisymbol_bars(["BBB", "AAA"]),
+        strategy=DeferredDailyRebalanceStrategy,
+        symbols=["AAA", "BBB"],
+        all_symbols=["BBB", "AAA"],
+        date2symbols=date2symbols,
+        capture=second_capture,
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+
+    assert first_capture["events"][-1][0] == target_day
+    assert second_capture["events"][-1][0] == target_day
+    assert first_capture["events"][-1][2] == ("AAA",)
+    assert second_capture["events"][-1][2] == ("AAA",)
+    assert first.metrics.total_return == pytest.approx(second.metrics.total_return)
 
 
 def _make_bars(


### PR DESCRIPTION
- 修复 `on_daily_rebalance` 在 bar 事件后可能提前触发的问题，改为调度到下一纳秒执行，确保同一时间戳内所有品种数据已就绪
- 修复 `rebalance_to_topn` 和 `order_target_weights` 中分数相同时排序不确定的问题，增加符号作为次要排序键
- 修复因子引擎扫描 Parquet 目录时因整数/浮点数 schema 差异导致的读取失败，允许整数列自动转为浮点数
- 修复报告绘图模块对市场数据列名的兼容性，支持常见别名（如 trade_date/code/open_price）及大小写变体
- 修复数据处理流水线中定时器触发时未完成当前时间戳的缺失 bar 填充，确保调仓前数据完整性