### PR TITLE
fix(engine): 修复订单级当前收盘价策略在定时器事件下的执行时间戳

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- 修复 `on_timer` / `add_daily_timer` 场景下，订单级 `fill_policy={"price_basis":"close","bar_offset":0,"temporal":"same_cycle"}` 未在当日 timer 事件内生效的问题；相关卖单现在会按当日 timer 时间与当日 close 成交，不再延后到下一交易日。
+- 修复 framework 内部 `__framework_rebalance__` / `__framework_boundary__` timer 被误参与 same-cycle 撮合与终态统计的问题，避免出现 `+1ns` 的伪成交、partial fill 被过早补满，以及权益曲线尾部多出额外采样点。
+
 ## [0.2.14] - 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.15"
+version = "0.2.16"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -146,19 +146,39 @@ impl Engine {
         }
     }
 
+    fn effective_terminal_timestamp_for_timer(timer: &Timer) -> Option<i64> {
+        if let Some(source_ts) = timer
+            .payload
+            .strip_prefix("__framework_rebalance__|")
+            .and_then(|payload| payload.rsplit('|').next())
+            .and_then(|value| value.parse::<i64>().ok())
+        {
+            return Some(source_ts);
+        }
+        if timer.payload.starts_with("__framework_boundary__|after|") {
+            return Some(timer.timestamp.saturating_sub(1));
+        }
+        if timer.payload.starts_with("__framework_boundary__|before|") {
+            return None;
+        }
+        Some(timer.timestamp)
+    }
+
+    pub(crate) fn terminal_result_timestamp(&self) -> Option<i64> {
+        match self.current_event.as_ref() {
+            Some(Event::Bar(bar)) => Some(bar.timestamp),
+            Some(Event::Tick(tick)) => Some(tick.timestamp),
+            Some(Event::Timer(timer)) => Self::effective_terminal_timestamp_for_timer(timer),
+            _ => self.clock.timestamp(),
+        }
+    }
+
     pub(crate) fn execution_policy_core(&self) -> ExecutionPolicyCore {
         self.execution_policy_core_state
     }
 
     pub(crate) fn set_execution_policy_core(&mut self, policy: ExecutionPolicyCore) {
         self.execution_policy_core_state = policy;
-    }
-
-    pub(crate) fn timer_same_cycle_enabled(&self) -> bool {
-        matches!(
-            self.execution_policy_core_state.temporal,
-            crate::model::TemporalPolicy::SameCycle
-        )
     }
 
     pub(crate) fn normalized_order_strategy_id(order: &Order) -> Option<String> {

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -1081,7 +1081,7 @@ impl Engine {
 
         // Record final snapshot if we have data
         if self.current_date.is_some()
-            && let Some(timestamp) = self.clock.timestamp()
+            && let Some(timestamp) = self.terminal_result_timestamp()
         {
             self.statistics_manager.record_snapshot(
                 timestamp,
@@ -1117,7 +1117,7 @@ impl Engine {
             &self.last_prices,
             &self.state.order_manager,
             self.initial_cash,
-            self.clock.timestamp(),
+            self.terminal_result_timestamp(),
         )
     }
 }

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -2,7 +2,9 @@ use crate::context::EngineContext;
 use crate::data::FeedAction;
 use crate::engine::Engine;
 use crate::event::Event;
-use crate::model::{Bar, Order, OrderStatus, PriceBasis, TradingSession};
+use crate::model::{
+    Bar, ExecutionPolicyCore, Order, OrderStatus, PriceBasis, TemporalPolicy, TradingSession,
+};
 use crate::pipeline::processor::{Processor, ProcessorResult};
 use pyo3::prelude::*;
 use rust_decimal::Decimal;
@@ -109,16 +111,56 @@ fn process_order_request(engine: &mut Engine, py: Python<'_>, mut order: Order) 
     }
 }
 
-fn should_run_post_strategy_match_now(engine: &Engine) -> bool {
-    let policy = engine.execution_policy_core();
-    if !(policy.price_basis == PriceBasis::Close && policy.bar_offset == 0) {
-        return false;
+fn effective_execution_policy_for_order(engine: &Engine, order: &Order) -> ExecutionPolicyCore {
+    order
+        .fill_policy_override
+        .unwrap_or(engine.execution_policy_core())
+}
+
+fn should_run_phase_for_engine_default(
+    phase: &ExecutionPhase,
+    engine: &Engine,
+    event: Option<&Event>,
+) -> bool {
+    should_run_phase_for_current_event(phase, engine.execution_policy_core(), event)
+}
+
+fn should_run_phase_for_current_event(
+    phase: &ExecutionPhase,
+    policy: ExecutionPolicyCore,
+    event: Option<&Event>,
+) -> bool {
+    match phase {
+        ExecutionPhase::PreStrategy => policy.bar_offset == 1,
+        ExecutionPhase::PostStrategy => {
+            if !(policy.price_basis == PriceBasis::Close && policy.bar_offset == 0) {
+                return false;
+            }
+            match event {
+                Some(Event::Bar(_) | Event::Tick(_)) => true,
+                Some(Event::Timer(timer)) => {
+                    matches!(policy.temporal, TemporalPolicy::SameCycle)
+                        && !timer.payload.starts_with("__framework_")
+                }
+                _ => false,
+            }
+        }
     }
-    match engine.current_event.as_ref() {
-        Some(Event::Bar(_) | Event::Tick(_)) => true,
-        Some(Event::Timer(_)) => engine.timer_same_cycle_enabled(),
-        _ => false,
-    }
+}
+
+fn has_orders_matching_phase(engine: &Engine, phase: &ExecutionPhase, orders: &[Order]) -> bool {
+    let event = engine.current_event.as_ref();
+    orders.iter().any(|order| {
+        should_run_phase_for_current_event(
+            phase,
+            effective_execution_policy_for_order(engine, order),
+            event,
+        )
+    })
+}
+
+fn should_run_post_strategy_match_now(engine: &Engine, orders: &[Order]) -> bool {
+    has_orders_matching_phase(engine, &ExecutionPhase::PostStrategy, orders)
 }
 
 fn emit_execution_reports_for_current_event(engine: &mut Engine) {
@@ -344,8 +386,9 @@ impl Processor for ChannelProcessor {
                 let has_sell = pending_order_requests
                     .iter()
                     .any(|order| order.side == crate::model::OrderSide::Sell);
-                let can_do_two_phase =
-                    has_buy && has_sell && should_run_post_strategy_match_now(engine);
+                let can_do_two_phase = has_buy
+                    && has_sell
+                    && should_run_post_strategy_match_now(engine, &pending_order_requests);
 
                 if can_do_two_phase {
                     let mut sell_orders = Vec::new();
@@ -900,13 +943,10 @@ impl Processor for ExecutionProcessor {
         _py: Python<'_>,
         _strategy: &Bound<'_, PyAny>,
     ) -> PyResult<ProcessorResult> {
-        let should_run = match self.phase {
-            ExecutionPhase::PreStrategy => engine.execution_policy_core().bar_offset == 1,
-            ExecutionPhase::PostStrategy => {
-                let policy = engine.execution_policy_core();
-                policy.price_basis == PriceBasis::Close && policy.bar_offset == 0
-            }
-        };
+        let active_orders = engine.state.order_manager.active_orders.clone();
+        let event = engine.current_event.as_ref();
+        let should_run = should_run_phase_for_engine_default(&self.phase, engine, event)
+            || has_orders_matching_phase(engine, &self.phase, &active_orders);
 
         if !should_run {
             return Ok(ProcessorResult::Next);
@@ -921,9 +961,6 @@ impl Processor for ExecutionProcessor {
         if let Some(event) = engine.current_event.clone() {
             match event {
                 Event::Bar(_) | Event::Tick(_) | Event::Timer(_) => {
-                    if matches!(event, Event::Timer(_)) && !engine.timer_same_cycle_enabled() {
-                        return Ok(ProcessorResult::Next);
-                    }
                     // Create Context
                     let ctx = EngineContext {
                         instruments: &engine.instruments,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -289,6 +289,47 @@ class DailyTimerBuyStrategy(akquant.Strategy):
         self.submitted = True
 
 
+class DailyTimerOrderLevelCurrentCloseStrategy(akquant.Strategy):
+    """Use order-level current-close fill policy on daily timers."""
+
+    def __init__(self, symbol: str) -> None:
+        """Initialize symbol and order-level fill policy."""
+        super().__init__()
+        self.symbol_ref = symbol
+        self.fill_policy = {
+            "price_basis": "close",
+            "bar_offset": 0,
+            "temporal": "same_cycle",
+        }
+
+    def on_start(self) -> None:
+        """Register opening and closing daily timers."""
+        self.add_daily_timer("09:25:00", "daily_buy")
+        self.add_daily_timer("14:56:00", "daily_sell")
+
+    def on_timer(self, payload: str) -> None:
+        """Buy at the first timer and sell available shares at the second."""
+        if payload == "daily_buy":
+            self.buy(
+                symbol=self.symbol_ref,
+                quantity=1,
+                tag="timer-buy",
+                fill_policy=self.fill_policy,
+            )
+            return
+        if payload != "daily_sell":
+            return
+        available = self.get_available_position(self.symbol_ref)
+        if available <= 0:
+            return
+        self.sell(
+            symbol=self.symbol_ref,
+            quantity=available,
+            tag="timer-sell",
+            fill_policy=self.fill_policy,
+        )
+
+
 def _ns(dt: datetime) -> int:
     """
     Convert a datetime to nanoseconds since epoch.
@@ -496,6 +537,61 @@ def test_daily_timer_trading_day_alignment_uses_local_calendar_day() -> None:
     )
     assert first_entry_time == pd.Timestamp("2025-01-24 15:00:00", tz="Asia/Shanghai")
     assert first_entry_time.weekday() < 5
+
+
+def test_order_level_current_close_daily_timer_sell_fills_same_day() -> None:
+    """Order-level current-close timer sell should fill on the same trading day."""
+    symbol = "DAILY_TIMER_OVERRIDE"
+    data = pd.DataFrame(
+        {
+            "open": [10.0, 11.0, 12.0],
+            "high": [10.0, 11.0, 12.0],
+            "low": [10.0, 11.0, 12.0],
+            "close": [10.0, 11.0, 12.0],
+            "volume": [1000.0, 1000.0, 1000.0],
+            "symbol": [symbol, symbol, symbol],
+        },
+        index=pd.to_datetime(["2026-04-01", "2026-04-02", "2026-04-03"]),
+    )
+    strategy = DailyTimerOrderLevelCurrentCloseStrategy(symbol=symbol)
+
+    result = akquant.run_backtest(
+        data=data,
+        strategy=strategy,
+        symbols=symbol,
+        t_plus_one=True,
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    filled_sell_orders = result.orders_df[
+        (result.orders_df["side"].astype(str).str.lower() == "sell")
+        & (result.orders_df["status"].astype(str).str.lower() == "filled")
+        & (result.orders_df["tag"].astype(str) == "timer-sell")
+    ]
+    assert not filled_sell_orders.empty
+
+    sell_order = filled_sell_orders.iloc[0]
+    sell_updated_at = pd.Timestamp(sell_order["updated_at"]).tz_convert("Asia/Shanghai")
+    assert sell_updated_at == pd.Timestamp("2026-04-02 14:56:00", tz="Asia/Shanghai")
+    assert float(sell_order["avg_price"]) == pytest.approx(11.0)
+
+    executions_df = result.executions_df
+    filled_sell_executions = executions_df[
+        executions_df["side"].astype(str).str.lower() == "sell"
+    ]
+    assert not filled_sell_executions.empty
+    sell_execution_time = pd.Timestamp(
+        filled_sell_executions.iloc[0]["timestamp"]
+    ).tz_convert("Asia/Shanghai")
+    assert sell_execution_time == pd.Timestamp(
+        "2026-04-02 14:56:00", tz="Asia/Shanghai"
+    )
 
 
 def test_current_close_timer_order_next_event_policy_fills_on_next_bar() -> None:


### PR DESCRIPTION
修复订单级填充策略（fill_policy）中 temporal: same_cycle 在定时器事件下无法正确获取执行时间戳的问题。引入 terminal_result_timestamp 方法统一处理不同事件类型（Bar、Tick、Timer）的有效时间戳，确保订单级当前收盘价策略的卖单能在同一交易日内正确成交。

修改执行阶段判断逻辑，现在会检查每个订单的独立填充策略，支持订单级覆盖全局策略。添加测试验证订单级 current-close 策略在每日定时器上的卖单能于当日正确填充。