### PR TITLE
feat(strategy): 统一交易日边界回调命名并补充框架钩子示例

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- 策略交易日边界回调已硬切改名：`before_trading(trading_date, timestamp)` 更名为 `on_before_trading(trading_date, timestamp)`，`after_trading(trading_date, timestamp)` 更名为 `on_after_trading(trading_date, timestamp)`。
+- 旧回调名不再保留兼容别名；升级到当前版本后，若策略仍实现 `before_trading` / `after_trading`，将不会再被框架触发，请同步迁移到新名称。
+- 中英文策略指南现已补齐 `on_xxx` 回调总览、类风格/函数式对照、触发时序图与示例入口，覆盖 `on_resume`、`on_reject`、`on_session_*`、`on_before_trading/on_after_trading`、`on_daily_rebalance`、`on_portfolio_update`、`on_error`、`on_timer`、`on_train_signal` 等回调。
+- 教材第 5 章与教材目录页现已同步补充完整 `on_xxx` 回调地图、学习路径与相关示例入口，便于用户从教材直接理解各类回调的职责边界。
+- 示例体系已补充 `examples/50_framework_hooks_demo.py` 与 `examples/51_class_tick_callbacks_demo.py`，分别覆盖框架边界钩子与类风格 `on_tick` 的最小可运行案例。
+
 ### Fixed
 - 修复 `on_timer` / `add_daily_timer` 场景下，订单级 `fill_policy={"price_basis":"close","bar_offset":0,"temporal":"same_cycle"}` 未在当日 timer 事件内生效的问题；相关卖单现在会按当日 timer 时间与当日 close 成交，不再延后到下一交易日。
 - 修复 framework 内部 `__framework_rebalance__` / `__framework_boundary__` timer 被误参与 same-cycle 撮合与终态统计的问题，避免出现 `+1ns` 的伪成交、partial fill 被过早补满，以及权益曲线尾部多出额外采样点。

--- a/docs/en/guide/examples.md
+++ b/docs/en/guide/examples.md
@@ -4,11 +4,16 @@
 
 *   [Examples Directory Index](https://github.com/akfamily/akquant/blob/main/examples/README.md): Quick entry to all scripts under `examples/`, including scenario-based shortest run paths.
 *   [Quick Start](../start/quickstart.md): Complete workflow covering manual data backtesting and AKShare data backtesting.
+*   [Unified Event Callback Example](https://github.com/akfamily/akquant/blob/main/examples/08_event_callbacks.py): A single entry covering `on_start/on_bar/on_order/on_trade/on_reject/on_timer/on_portfolio_update/on_stop`.
+*   [Class-Style Tick Callback Example](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py): Demonstrates `Strategy.on_tick(self, tick)` together with adjacent `on_order/on_trade/on_timer` callbacks.
 *   [Simple SMA Strategy](strategy.md#class-based): Demonstrates how to write a strategy in class style and perform simple trading logic in `on_bar`.
 *   [Expiry Callback Example](https://github.com/akfamily/akquant/blob/main/examples/49_on_expiry_demo.py): Demonstrates `on_expiry(event)` together with streamed `expiry` events for expiry-driven settlement workflows.
+*   [Framework Hooks Example](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py): Demonstrates `on_session_start/on_session_end/on_before_trading/on_after_trading/on_portfolio_update/on_reject` and their trigger order.
 *   [Shortest Path for Multi-Asset Target Weights](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): TopN dynamic rebalance example using momentum ranking and one-shot portfolio adjustment.
 
 > Data Source Convention: Unless otherwise specified (e.g. simulated data), examples on this page default to using AKShare to fetch real market data.
+>
+> Style hint: start with `08_event_callbacks.py`, `50_framework_hooks_demo.py`, and `51_class_tick_callbacks_demo.py` for class-based callbacks; use `23_functional_callbacks_demo.py` and `24_functional_tick_simulation_demo.py` when migrating script-style strategies.
 
 ### UI-Driven Strategy Parameterization (PARAM_MODEL)
 

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -29,7 +29,7 @@ A strategy goes through the following stages from start to finish:
 *   `on_trade`: Triggered when a trade execution report is received.
 *   `on_reject`: Triggered when an order enters `Rejected` status.
 *   `on_session_start` / `on_session_end`: Triggered on session transitions.
-*   `before_trading` / `after_trading`: Daily trading hooks.
+*   `on_before_trading` / `on_after_trading`: Daily trading hooks.
 *   `on_portfolio_update`: Triggered when portfolio snapshot changes.
 *   `on_error`: Triggered when user callback raises an exception, then exception is re-raised by default.
 *   `on_timer`: Called when a timer triggers (needs manual registration).
@@ -37,26 +37,98 @@ A strategy goes through the following stages from start to finish:
 *   `on_stop`: Called when the strategy stops, suitable for resource cleanup or result statistics (refer to Backtrader `stop` / Nautilus `on_stop`).
 *   `on_train_signal`: Triggered for rolling training signals (only in ML mode).
 
+### 2.0 Callback Cheat Sheet
+
+| Callback | Trigger timing | Typical usage | Example |
+| :--- | :--- | :--- | :--- |
+| `on_start` | After strategy instance is started | Subscribe symbols, register indicators, initialize runtime state | `examples/textbook/ch05_strategy.py` |
+| `on_resume` | On warm-start restore, before `on_start` | Restore connections, inspect restored state, continue from snapshot | `examples/21_warm_start_demo.py` |
+| `on_bar` | When each bar closes | Main trading logic, indicator updates, signal generation | `examples/01_quickstart.py` |
+| `on_tick` | When each tick arrives | High-frequency reactions, tick-level monitoring | `examples/51_class_tick_callbacks_demo.py` |
+| `on_order` | When order status changes | Track lifecycle, reset state, order-linked orchestration | `examples/08_event_callbacks.py` |
+| `on_trade` | When a trade report arrives | Execution logging, post-trade risk handling, aggregation | `examples/08_event_callbacks.py` |
+| `on_reject` | First time an order becomes `Rejected` | Log reject reasons, alerting, graceful degradation | `examples/50_framework_hooks_demo.py` |
+| `on_session_start` | When session transition begins | Reset day/night session state, session-aware bookkeeping | `examples/50_framework_hooks_demo.py` |
+| `on_session_end` | When session transition ends | End-of-session cleanup and logging | `examples/50_framework_hooks_demo.py` |
+| `on_before_trading` | First entry into `Normal` session each local trading day | Pre-market checks, trading-date level signal preparation | `examples/50_framework_hooks_demo.py` |
+| `on_daily_rebalance` | At most once per trading day, same phase as `on_before_trading` | Cross-sectional ranking and one-shot rebalance | `examples/strategies/05_stock_momentum_rotation_timer.py` |
+| `on_after_trading` | When leaving `Normal`, or replayed on the next event if needed | End-of-day summaries, post-close cleanup, archiving | `examples/50_framework_hooks_demo.py` |
+| `on_portfolio_update` | Incrementally when portfolio snapshot changes | Monitor cash/equity changes, push UI or alerts | `examples/50_framework_hooks_demo.py` |
+| `on_error` | When any user callback raises | Record callback source and choose continue vs fail-fast | `examples/22_strategy_runtime_config_demo.py` |
+| `on_timer` | When a registered timer fires | Scheduled rebalance, pre-market tasks, cadence checks | `examples/strategies/07_stock_momentum_rotation_on_timer.py` |
+| `on_stop` | When strategy stops | Final summary, resource cleanup, reporting | `examples/textbook/ch05_strategy.py` |
+| `on_expiry` | After expiry settlement/removal is actually executed | Roll contracts, record settlement, clear expired instruments | `examples/49_on_expiry_demo.py` |
+| `on_train_signal` | When ML rolling training window is triggered | Train models and swap pending model versions | `examples/10_ml_walk_forward.py` |
+
+For framework-level hooks such as `on_session_start`, `on_session_end`, `on_before_trading`, `on_after_trading`, `on_portfolio_update`, and `on_reject`, start with `examples/50_framework_hooks_demo.py` to observe trigger order and logs in one place.
+If you want a single "most common callbacks" script first, start with `examples/08_event_callbacks.py`; it bundles `on_start/on_bar/on_order/on_trade/on_reject/on_timer/on_portfolio_update/on_stop` in one place.
+For class-style Tick strategies, start with `examples/51_class_tick_callbacks_demo.py`; if you prefer function-style callbacks, then continue with `examples/24_functional_tick_simulation_demo.py`.
+
 ### 2.1 Callback Dispatch Contract
 
 For each `bar/tick/timer` event, AKQuant dispatches callbacks in this order:
 
 1. `on_order` / `on_trade` (plus `on_reject` when status is `Rejected`)
-2. Framework hooks (`on_session_*`, `before_trading`/`after_trading`, `on_portfolio_update`)
+2. Framework hooks (`on_session_*`, `on_before_trading`/`on_after_trading`, `on_portfolio_update`)
 3. User event callback (`on_bar` / `on_tick` / `on_timer`)
 
 Notes:
 
 * `on_reject` is emitted once per order id when the order first becomes `Rejected`.
-* `before_trading` is emitted once per local trading date when session enters `Normal`.
-* `after_trading` is emitted once per local trading date when leaving `Normal`, or on next event if day rollover occurs first.
+* `on_before_trading` is emitted once per local trading date when session enters `Normal`.
+* `on_after_trading` is emitted once per local trading date when leaving `Normal`, or on next event if day rollover occurs first.
 * Set `self.enable_precise_day_boundary_hooks = True` to enable boundary-timer based precise day hooks.
 * `on_portfolio_update` is incremental: emitted once at initialization, then only on order/trade or position-relevant price changes.
 * Use `self.portfolio_update_eps` to filter tiny equity/cash changes (default `0.0`).
-* During stop phase, pending `on_session_end` / `after_trading` are flushed before `on_stop`.
+* During stop phase, pending `on_session_end` / `on_after_trading` are flushed before `on_stop`.
 * `on_error` receives `(error, source, payload)`. Prefer `self.error_mode = "raise" | "continue"` (default `raise`). `self.re_raise_on_error` remains as fallback for compatibility.
 * Prefer `self.runtime_config = StrategyRuntimeConfig(...)` as a unified runtime switch entry.
 * Legacy alias fields and `runtime_config` stay synchronized automatically.
+
+#### 2.1.1 Regular Event Dispatch Sequence
+
+```mermaid
+sequenceDiagram
+    participant Feed as Market/Timer Event
+    participant FW as Framework Dispatcher
+    participant Strategy as User Strategy
+
+    Feed->>FW: bar / tick / timer arrives
+    FW->>Strategy: on_order(...)
+    FW->>Strategy: on_trade(...)
+    alt order first becomes Rejected
+        FW->>Strategy: on_reject(...)
+    end
+    FW->>Strategy: on_session_start / on_session_end
+    FW->>Strategy: on_before_trading / on_after_trading
+    FW->>Strategy: on_daily_rebalance
+    FW->>Strategy: on_portfolio_update
+    alt current event is Bar
+        FW->>Strategy: on_bar(bar)
+    else current event is Tick
+        FW->>Strategy: on_tick(tick)
+    else current event is Timer
+        FW->>Strategy: on_timer(payload)
+    end
+```
+
+#### 2.1.2 Stop-Phase Flush Sequence
+
+```mermaid
+sequenceDiagram
+    participant Engine as Engine Stop Phase
+    participant FW as Framework Dispatcher
+    participant Strategy as User Strategy
+
+    Engine->>FW: _on_stop_internal()
+    alt pending session-end event exists
+        FW->>Strategy: on_session_end(...)
+    end
+    alt pending trading-day end event exists
+        FW->>Strategy: on_after_trading(...)
+    end
+    FW->>Strategy: on_stop()
+```
 
 ## 3. Utilities
 
@@ -234,7 +306,35 @@ For style selection guidance, see [Strategy Style Decision Guide](../advanced/st
 | `on_trade(ctx, trade)` | Trade reports appear in `recent_trades` | Trade dedupe applies to avoid repeated callbacks |
 | `on_timer(ctx, payload)` | A timer is scheduled and fired | Includes both one-shot and daily timer payloads |
 
-### 4.2 Related Examples
+### 4.2 Class vs Function Callback Mapping
+
+| Class-based | Function-style | Notes | Recommended Example |
+| :--- | :--- | :--- | :--- |
+| `on_start(self)` | `on_start(ctx)` | Lifecycle entry point, supported by both styles | `examples/08_event_callbacks.py`, `examples/23_functional_callbacks_demo.py` |
+| `on_stop(self)` | `on_stop(ctx)` | Lifecycle exit point, supported by both styles | `examples/textbook/ch05_strategy.py` |
+| `on_bar(self, bar)` | `on_bar(ctx, bar)` | Primary strategy entry, supported by both styles | `examples/01_quickstart.py`, `examples/23_functional_callbacks_demo.py` |
+| `on_tick(self, tick)` | `on_tick(ctx, tick)` | Tick entry, supported by both styles | `examples/51_class_tick_callbacks_demo.py`, `examples/24_functional_tick_simulation_demo.py` |
+| `on_order(self, order)` | `on_order(ctx, order)` | Order state callback, supported by both styles | `examples/08_event_callbacks.py` |
+| `on_trade(self, trade)` | `on_trade(ctx, trade)` | Trade report callback, supported by both styles | `examples/08_event_callbacks.py` |
+| `on_expiry(self, event)` | `on_expiry(ctx, event)` | Expiry settlement callback, supported by both styles | `examples/49_on_expiry_demo.py` |
+| `on_timer(self, payload)` | `on_timer(ctx, payload)` | Timer callback, supported by both styles | `examples/08_event_callbacks.py`, `examples/23_functional_callbacks_demo.py` |
+| `on_resume(self)` | Not supported | Warm-start restore hook, currently class-style only | `examples/21_warm_start_demo.py` |
+| `on_reject(self, order)` | Not supported | Reject callback, currently class-style only | `examples/08_event_callbacks.py`, `examples/50_framework_hooks_demo.py` |
+| `on_session_start(self, session, timestamp)` | Not supported | Session boundary hook, currently class-style only | `examples/50_framework_hooks_demo.py` |
+| `on_session_end(self, session, timestamp)` | Not supported | Session boundary hook, currently class-style only | `examples/50_framework_hooks_demo.py` |
+| `on_before_trading(self, trading_date, timestamp)` | Not supported | Trading-day boundary hook, currently class-style only | `examples/50_framework_hooks_demo.py` |
+| `on_after_trading(self, trading_date, timestamp)` | Not supported | Trading-day boundary hook, currently class-style only | `examples/50_framework_hooks_demo.py` |
+| `on_daily_rebalance(self, trading_date, timestamp)` | Not supported | Daily rebalance hook, currently class-style only | `examples/strategies/05_stock_momentum_rotation_timer.py` |
+| `on_portfolio_update(self, snapshot)` | Not supported | Portfolio snapshot callback, currently class-style only | `examples/50_framework_hooks_demo.py` |
+| `on_error(self, error, source, payload)` | Not supported | User exception callback, currently class-style only | `examples/22_strategy_runtime_config_demo.py` |
+| `on_train_signal(self, context)` | Not supported | ML rolling-train hook, currently class-style only | `examples/10_ml_walk_forward.py` |
+
+Recommendations:
+
+*   Choose class-based style when you need framework hooks such as `on_session_*`, `on_before_trading`, `on_after_trading`, `on_portfolio_update`, or `on_error`.
+*   Choose function-style when you mainly need `on_bar/on_tick/on_order/on_trade/on_timer` for fast prototyping.
+
+### 4.3 Related Examples
 
 *   Function-style callback baseline: `examples/23_functional_callbacks_demo.py`
 *   Function-style tick callback simulation: `examples/24_functional_tick_simulation_demo.py`

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -638,8 +638,8 @@ Strategy base class. Users should inherit from this class and override callback 
 *   `on_expiry(event: Dict[str, Any])`: Triggered after an `expiry_date` driven settlement/removal is actually executed. Portfolio state is already updated when the callback runs. See `examples/49_on_expiry_demo.py` for a runnable example.
 *   `on_session_start(session, timestamp)`: Triggered on session transition start.
 *   `on_session_end(session, timestamp)`: Triggered on session transition end.
-*   `before_trading(trading_date, timestamp)`: Triggered once when entering Normal session each local day.
-*   `after_trading(trading_date, timestamp)`: Triggered when leaving Normal session, or replayed on next event after day rollover.
+*   `on_before_trading(trading_date, timestamp)`: Triggered once when entering Normal session each local day.
+*   `on_after_trading(trading_date, timestamp)`: Triggered when leaving Normal session, or replayed on next event after day rollover.
 *   `on_portfolio_update(snapshot)`: Triggered when cash/equity/position snapshot changes.
 *   `on_error(error, source, payload=None)`: Triggered when user callback raises, then exception is re-raised by default.
 *   `on_timer(payload: str)`: Triggered by timer.

--- a/docs/en/textbook/05_strategy.md
+++ b/docs/en/textbook/05_strategy.md
@@ -7,6 +7,8 @@ This chapter is currently maintained in Chinese first.
 - Practice links:
   - Primary example: [examples/textbook/ch05_strategy.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch05_strategy.py)
   - Extended example: [examples/23_functional_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/23_functional_callbacks_demo.py)
+  - Framework hooks example: [examples/50_framework_hooks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py)
+  - Class-style tick callback example: [examples/51_class_tick_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py)
   - Expiry callback example: [examples/49_on_expiry_demo.py](https://github.com/akfamily/akquant/blob/main/examples/49_on_expiry_demo.py)
   - Indicator playbook example: [examples/45_talib_indicator_playbook_demo.py](https://github.com/akfamily/akquant/blob/main/examples/45_talib_indicator_playbook_demo.py)
   - Real-data mode: `python examples/45_talib_indicator_playbook_demo.py --data-source akshare --symbol sh600000 --start-date 20240101 --end-date 20260301`
@@ -53,6 +55,6 @@ if ema_fast[-1] > ema_slow[-1] and adx[-1] >= 20:
     self.buy(symbol, 100)
 ```
 
-For complete Chinese content including warmup handling and migration tips:
+For complete Chinese content including the full `on_xxx` callback map, warmup handling, and migration tips:
 - [第 5 章：策略开发实战 (Strategy Implementation)](../../zh/textbook/05_strategy.md)
 - [指标组合实战手册](../../zh/guide/talib_indicator_playbook.md)

--- a/docs/en/textbook/index.md
+++ b/docs/en/textbook/index.md
@@ -29,4 +29,5 @@ Recent updates in the Chinese textbook:
 
 * Chapter 11 includes the `PARAM_MODEL + param_grid` workflow for UI-driven parameter optimization.
 * Chapter 15 has been aligned with current live-trading APIs, including warm-start and strategy-loader paths.
+* Chapter 5 now includes the full `on_xxx` callback map, framework hooks, and class-style Tick callback study path.
 * Textbook chapter structure and example chapter labels are now synchronized.

--- a/docs/zh/guide/examples.md
+++ b/docs/zh/guide/examples.md
@@ -4,12 +4,17 @@
 
 *   [Examples 目录索引](https://github.com/akfamily/akquant/blob/main/examples/README.md): 快速浏览 `examples/` 下所有脚本入口，并包含按场景整理的最短执行路径。
 *   [快速开始 (Quickstart)](../start/quickstart.md): 包含手动数据回测和 AKShare 数据回测的完整流程。
+*   [统一事件回调示例](https://github.com/akfamily/akquant/blob/main/examples/08_event_callbacks.py): 一次性演示 `on_start/on_bar/on_order/on_trade/on_reject/on_timer/on_portfolio_update/on_stop` 的最短路径。
+*   [类风格 Tick 回调示例](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py): 演示 `Strategy.on_tick(self, tick)` 与相邻 `on_order/on_trade/on_timer` 的触发顺序。
 *   [简单的均线策略 (SMA Strategy)](strategy.md#class-based): 展示了如何使用类风格编写策略，并在 `on_bar` 中进行简单的交易逻辑。
 *   [到期结算回调示例](https://github.com/akfamily/akquant/blob/main/examples/49_on_expiry_demo.py): 演示 `on_expiry(event)` 与流式 `expiry` 事件，适合验证期货/期权到期后的策略通知链路。
+*   [框架钩子示例](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py): 演示 `on_session_start/on_session_end/on_before_trading/on_after_trading/on_portfolio_update/on_reject` 的触发顺序与典型用途。
 *   [多标的目标权重调仓最短路径](https://github.com/akfamily/akquant/blob/main/examples/43_target_weights_rebalance.py): TopN 动态调仓示例，展示同时间切片收齐后基于动量的组合再平衡。
 *   [指标组合 Playbook 示例](https://github.com/akfamily/akquant/blob/main/examples/45_talib_indicator_playbook_demo.py): 演示 `EMA/ADX/NATR` 与 `BBANDS/RSI/MOM` 组合在同一策略中的落地方式，并支持 `--data-source akshare` 真实数据模式。
 
 > 数据源约定：除特别标注需要模拟数据外，本页示例默认使用 AKShare 获取真实市场数据。
+>
+> 风格建议：想先学类风格事件回调，优先从 `08_event_callbacks.py`、`50_framework_hooks_demo.py`、`51_class_tick_callbacks_demo.py` 开始；想迁移脚本式策略，再看 `23_functional_callbacks_demo.py`、`24_functional_tick_simulation_demo.py`。
 
 ### 页面化参数配置（PARAM_MODEL）
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -30,7 +30,7 @@
 * `on_trade`: 收到成交回报时触发。
 * `on_reject`: 订单进入 `Rejected` 状态时触发。
 * `on_session_start` / `on_session_end`: 会话切换时触发。
-* `before_trading` / `after_trading`: 交易日级钩子。
+* `on_before_trading` / `on_after_trading`: 交易日级钩子。
 * `on_daily_rebalance`: 交易日调仓钩子（每天最多一次，适合横截面轮动）。
 * `on_portfolio_update`: 账户快照变化时触发。
 * `on_error`: 用户回调抛异常时触发，默认触发后继续抛出异常。
@@ -38,28 +38,100 @@
 *   `on_stop`: 策略停止时调用，适合进行资源清理或结果统计。
 *   `on_train_signal`: 滚动训练触发信号 (仅在 ML 模式下触发)。
 
+### 2.0 回调速查表
+
+| 回调 | 何时触发 | 典型用途 | 示例入口 |
+| :--- | :--- | :--- | :--- |
+| `on_start` | 策略实例启动后 | 订阅标的、注册指标、初始化运行态资源 | `examples/textbook/ch05_strategy.py` |
+| `on_resume` | 热启动恢复时，且早于 `on_start` | 恢复连接、打印恢复状态、处理快照续跑逻辑 | `examples/21_warm_start_demo.py` |
+| `on_bar` | 每根 Bar 闭合时 | 主交易逻辑、指标更新、信号计算 | `examples/01_quickstart.py` |
+| `on_tick` | 每个 Tick 到达时 | 高频/盘口响应、逐笔监控 | `examples/51_class_tick_callbacks_demo.py` |
+| `on_order` | 订单状态变化时 | 跟踪下单生命周期、联动撤单/重置状态 | `examples/08_event_callbacks.py` |
+| `on_trade` | 收到成交回报时 | 成交日志、成交后风控、累计统计 | `examples/08_event_callbacks.py` |
+| `on_reject` | 订单首次进入 `Rejected` 时 | 记录拒单原因、告警、降级处理 | `examples/50_framework_hooks_demo.py` |
+| `on_session_start` | 会话切换开始时 | 日盘/夜盘切换、session 级状态重置 | `examples/50_framework_hooks_demo.py` |
+| `on_session_end` | 会话切换结束时 | 收盘后清理、session 结束打点 | `examples/50_framework_hooks_demo.py` |
+| `on_before_trading` | 本地交易日首次进入 `Normal` 会话 | 盘前检查、生成交易日级信号 | `examples/50_framework_hooks_demo.py` |
+| `on_daily_rebalance` | 每个交易日最多一次，与 `on_before_trading` 同阶段 | 横截面选股、统一调仓 | `examples/strategies/05_stock_momentum_rotation_timer.py` |
+| `on_after_trading` | 离开 `Normal` 会话时，必要时下一事件补发 | 日终统计、收盘后清理与归档 | `examples/50_framework_hooks_demo.py` |
+| `on_portfolio_update` | 账户快照变化时增量触发 | 监控现金/权益变化、推送 UI 或告警 | `examples/50_framework_hooks_demo.py` |
+| `on_error` | 任一用户回调抛异常时 | 记录异常源、决定继续/中断策略 | `examples/22_strategy_runtime_config_demo.py` |
+| `on_timer` | 定时器到点时 | 定时调仓、盘前任务、节律性检查 | `examples/strategies/07_stock_momentum_rotation_on_timer.py` |
+| `on_stop` | 策略停止时 | 汇总统计、资源释放、打印总结 | `examples/textbook/ch05_strategy.py` |
+| `on_expiry` | 引擎实际执行到期结算/移除后 | 处理换月、记录结算、清理失效合约 | `examples/49_on_expiry_demo.py` |
+| `on_train_signal` | ML 滚动训练窗口触发时 | 训练模型、切换待激活模型 | `examples/10_ml_walk_forward.py` |
+
+其中，`on_session_start`、`on_session_end`、`on_before_trading`、`on_after_trading`、`on_portfolio_update`、`on_reject` 这类框架级钩子，推荐直接运行 `examples/50_framework_hooks_demo.py` 观察触发顺序与日志输出。
+如果你只想先看一份“最常用回调的一站式示例”，优先运行 `examples/08_event_callbacks.py`；它把 `on_start/on_bar/on_order/on_trade/on_reject/on_timer/on_portfolio_update/on_stop` 放到了同一个脚本里。
+如果你要写类风格的 Tick 策略，先看 `examples/51_class_tick_callbacks_demo.py`；如果你更偏好函数式入口，再看 `examples/24_functional_tick_simulation_demo.py`。
+
 ### 2.1 回调触发契约
 
 对于每个 `bar/tick/timer` 事件，框架按以下顺序分发回调：
 
 1. `on_order` / `on_trade`（若拒单则额外触发 `on_reject`）
-2. 框架钩子（`on_session_*`、`before_trading`/`after_trading`、`on_portfolio_update`）
+2. 框架钩子（`on_session_*`、`on_before_trading`/`on_after_trading`、`on_portfolio_update`）
 3. 用户事件回调（`on_bar` / `on_tick` / `on_timer`）
 
 说明：
 
 * `on_reject` 对同一订单 id 只触发一次。
 * 回测中已终态拒单会通过上下文快照 `recent_rejected_orders` 在下一次事件分发时补发，避免因清理活跃订单导致漏触发。
-* `before_trading` 在本地交易日首次进入 Normal 会话时触发一次。
-* `on_daily_rebalance` 与 `before_trading` 同一阶段触发，每个交易日最多触发一次。
-* `after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `after_trading`。
+* `on_before_trading` 在本地交易日首次进入 Normal 会话时触发一次。
+* `on_daily_rebalance` 与 `on_before_trading` 同一阶段触发，每个交易日最多触发一次。
+* `on_after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `on_after_trading`。
 * 若需要更精确的交易日边界触发，可在策略中设置 `self.enable_precise_day_boundary_hooks = True`。
 * `on_portfolio_update` 采用增量触发：初始化时触发一次，后续仅在订单/成交或持仓相关价格变化时触发。
 * 可通过 `self.portfolio_update_eps` 过滤微小资产波动（默认 `0.0`，即不过滤）。
-* 停止阶段会在 `on_stop` 之前补发待触发的 `on_session_end` / `after_trading`。
+* 停止阶段会在 `on_stop` 之前补发待触发的 `on_session_end` / `on_after_trading`。
 * `on_error` 参数为 `(error, source, payload)`，推荐通过 `self.error_mode = "raise" | "continue"` 控制行为（默认 `raise`）。`self.re_raise_on_error` 仍兼容，作为兜底开关。
 * 推荐使用 `self.runtime_config = StrategyRuntimeConfig(...)` 统一配置上述行为开关。
 * 旧别名字段与 `runtime_config` 会自动保持同步。
+
+#### 2.1.1 常规事件分发时序
+
+```mermaid
+sequenceDiagram
+    participant Feed as 行情/Timer 事件
+    participant FW as Framework Dispatcher
+    participant Strategy as 用户策略
+
+    Feed->>FW: bar / tick / timer 到达
+    FW->>Strategy: on_order(...)
+    FW->>Strategy: on_trade(...)
+    alt 订单首次变为 Rejected
+        FW->>Strategy: on_reject(...)
+    end
+    FW->>Strategy: on_session_start / on_session_end
+    FW->>Strategy: on_before_trading / on_after_trading
+    FW->>Strategy: on_daily_rebalance
+    FW->>Strategy: on_portfolio_update
+    alt 当前事件是 Bar
+        FW->>Strategy: on_bar(bar)
+    else 当前事件是 Tick
+        FW->>Strategy: on_tick(tick)
+    else 当前事件是 Timer
+        FW->>Strategy: on_timer(payload)
+    end
+```
+
+#### 2.1.2 停止阶段补发时序
+
+```mermaid
+sequenceDiagram
+    participant Engine as Engine Stop Phase
+    participant FW as Framework Dispatcher
+    participant Strategy as 用户策略
+
+    Engine->>FW: _on_stop_internal()
+    alt 仍有未补发的 session 结束事件
+        FW->>Strategy: on_session_end(...)
+    end
+    alt 仍有未补发的交易日结束事件
+        FW->>Strategy: on_after_trading(...)
+    end
+    FW->>Strategy: on_stop()
+```
 
 ## 3. 风险管理 (Risk Management)
 
@@ -365,7 +437,35 @@ AKQuant 提供了两种风格的策略开发接口：
 | `on_expiry(ctx, event)` | 引擎实际执行到期结算/移除 | 仅在 `expiry_date` 驱动的结算真正发生后触发，且触发时账户状态已更新 |
 | `on_timer(ctx, payload)` | 已注册的定时器到点触发 | 支持单次定时与每日定时 payload |
 
-### 5.2 相关示例
+### 5.2 类风格 vs 函数式回调对照
+
+| 类风格 | 函数式 | 说明 | 推荐示例 |
+| :--- | :--- | :--- | :--- |
+| `on_start(self)` | `on_start(ctx)` | 生命周期起点，两种风格都支持 | `examples/08_event_callbacks.py`、`examples/23_functional_callbacks_demo.py` |
+| `on_stop(self)` | `on_stop(ctx)` | 生命周期终点，两种风格都支持 | `examples/textbook/ch05_strategy.py` |
+| `on_bar(self, bar)` | `on_bar(ctx, bar)` | 主策略入口，两种风格都支持 | `examples/01_quickstart.py`、`examples/23_functional_callbacks_demo.py` |
+| `on_tick(self, tick)` | `on_tick(ctx, tick)` | Tick 事件入口，两种风格都支持 | `examples/51_class_tick_callbacks_demo.py`、`examples/24_functional_tick_simulation_demo.py` |
+| `on_order(self, order)` | `on_order(ctx, order)` | 订单状态回调，两种风格都支持 | `examples/08_event_callbacks.py` |
+| `on_trade(self, trade)` | `on_trade(ctx, trade)` | 成交回报回调，两种风格都支持 | `examples/08_event_callbacks.py` |
+| `on_expiry(self, event)` | `on_expiry(ctx, event)` | 到期结算回调，两种风格都支持 | `examples/49_on_expiry_demo.py` |
+| `on_timer(self, payload)` | `on_timer(ctx, payload)` | 定时器回调，两种风格都支持 | `examples/08_event_callbacks.py`、`examples/23_functional_callbacks_demo.py` |
+| `on_resume(self)` | 不支持 | 热启动恢复钩子，目前仅类风格支持 | `examples/21_warm_start_demo.py` |
+| `on_reject(self, order)` | 不支持 | 拒单回调，目前仅类风格支持 | `examples/08_event_callbacks.py`、`examples/50_framework_hooks_demo.py` |
+| `on_session_start(self, session, timestamp)` | 不支持 | 会话边界钩子，目前仅类风格支持 | `examples/50_framework_hooks_demo.py` |
+| `on_session_end(self, session, timestamp)` | 不支持 | 会话边界钩子，目前仅类风格支持 | `examples/50_framework_hooks_demo.py` |
+| `on_before_trading(self, trading_date, timestamp)` | 不支持 | 交易日前边界钩子，目前仅类风格支持 | `examples/50_framework_hooks_demo.py` |
+| `on_after_trading(self, trading_date, timestamp)` | 不支持 | 交易日后边界钩子，目前仅类风格支持 | `examples/50_framework_hooks_demo.py` |
+| `on_daily_rebalance(self, trading_date, timestamp)` | 不支持 | 交易日调仓钩子，目前仅类风格支持 | `examples/strategies/05_stock_momentum_rotation_timer.py` |
+| `on_portfolio_update(self, snapshot)` | 不支持 | 账户快照回调，目前仅类风格支持 | `examples/50_framework_hooks_demo.py` |
+| `on_error(self, error, source, payload)` | 不支持 | 用户异常回调，目前仅类风格支持 | `examples/22_strategy_runtime_config_demo.py` |
+| `on_train_signal(self, context)` | 不支持 | ML 滚动训练钩子，目前仅类风格支持 | `examples/10_ml_walk_forward.py` |
+
+建议：
+
+*   如果你需要 `on_session_*`、`on_before_trading`、`on_after_trading`、`on_portfolio_update`、`on_error` 这类框架钩子，优先选择类风格。
+*   如果你只是做快速原型，且只依赖 `on_bar/on_tick/on_order/on_trade/on_timer`，函数式入口通常更轻量。
+
+### 5.3 相关示例
 
 *   函数式回调基础示例：`examples/23_functional_callbacks_demo.py`
 *   函数式 Tick 回调模拟示例：`examples/24_functional_tick_simulation_demo.py`

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -658,9 +658,9 @@ result = run_backtest(
 *   `on_expiry(event: Dict[str, Any])`: 到期结算回调。仅当引擎实际执行 `expiry_date` 驱动的到期结算/移除后触发；回调时账户状态已更新。示例见：`examples/49_on_expiry_demo.py`。
 *   `on_session_start(session, timestamp)`: 会话切换开始时触发。
 *   `on_session_end(session, timestamp)`: 会话切换结束时触发。
-*   `before_trading(trading_date, timestamp)`: 每个本地交易日首次进入 Normal 会话时触发一次。
+*   `on_before_trading(trading_date, timestamp)`: 每个本地交易日首次进入 Normal 会话时触发一次。
 *   `on_daily_rebalance(trading_date, timestamp)`: 交易日调仓钩子，每个交易日最多触发一次。
-*   `after_trading(trading_date, timestamp)`: 离开 Normal 会话时触发；若先跨日则在下一事件补发。
+*   `on_after_trading(trading_date, timestamp)`: 离开 Normal 会话时触发；若先跨日则在下一事件补发。
 *   `on_portfolio_update(snapshot)`: 账户快照变化时触发。
 *   `on_error(error, source, payload=None)`: 用户回调抛异常时触发，默认触发后继续抛出。
 *   `on_timer(payload: str)`: 定时器触发。

--- a/docs/zh/textbook/05_strategy.md
+++ b/docs/zh/textbook/05_strategy.md
@@ -6,7 +6,16 @@
 
 - 主示例：[examples/textbook/ch05_strategy.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch05_strategy.py)
 - 进阶示例：[examples/23_functional_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/23_functional_callbacks_demo.py)
+- 框架钩子示例：[examples/50_framework_hooks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py)
+- 类风格 Tick 示例：[examples/51_class_tick_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py)
 - 对应指南：[策略指南](../guide/strategy.md)
+
+建议学习路径：
+
+1. 先运行 `examples/textbook/ch05_strategy.py`，掌握 `on_start -> on_bar -> on_stop` 的主骨架。
+2. 再看 `examples/08_event_callbacks.py`，把订单、成交、拒单、定时器放到一张图里理解。
+3. 需要框架边界钩子时，运行 `examples/50_framework_hooks_demo.py`。
+4. 需要 Tick 级策略时，运行 `examples/51_class_tick_callbacks_demo.py`。
 
 ## 快速运行与验收
 
@@ -28,6 +37,8 @@ python examples/textbook/ch05_strategy.py
 2.  `on_start`: **初始化钩子**。回测开始前触发，常用于订阅数据、设置风控参数。
 3.  `on_bar`: **事件处理钩子**。每根 K 线走完时触发，这是策略逻辑的核心入口。
 4.  `on_stop`: **结束钩子**。回测结束时触发，常用于清理资源或统计结果。
+
+这 4 个回调构成了最常见的策略主骨架，但并不是全部。AKQuant 还提供了热启动、框架边界、定时器、账户快照、拒单、ML 训练信号等扩展回调。本章后续会给出一张完整的教材级速查表，帮助你知道“应该把逻辑写进哪个 `on_xxx`”。
 
 ### 5.1.1 示例代码：带止损的双均线策略
 
@@ -85,6 +96,46 @@ result = aq.run_backtest(
 ```
 
 当你需要 `on_start/on_stop/on_order/on_trade` 等完整生命周期并封装为可复用组件时，优先使用类风格；当你需要快速验证交易逻辑和参数时，函数式入口更轻量。
+
+### 5.2.4 全量 `on_xxx` 回调速查表
+
+如果把 `AKQuant` 的策略接口只理解为 `on_start -> on_bar -> on_stop`，很容易在盘前准备、日终归档、拒单处理、恢复续跑等场景里把逻辑塞错地方。更好的做法是按“事件来源”来理解回调族：
+
+1.  **生命周期回调**：控制策略启动、恢复、停止。
+2.  **主数据事件回调**：处理 Bar、Tick、Timer 这三类用户最常见的决策入口。
+3.  **订单与成交回调**：跟踪订单流转、拒单与实际成交。
+4.  **框架边界回调**：处理交易日、session 和账户快照这类“不是行情、但很关键”的事件。
+5.  **专项回调**：处理到期结算、ML 训练信号、异常治理等高级场景。
+
+下表给出教材中建议掌握的完整接口：
+
+| 回调 | 类型 | 典型用途 | 推荐示例 |
+| :--- | :--- | :--- | :--- |
+| `on_start` | 生命周期 | 订阅标的、注册指标、初始化运行态资源 | `examples/textbook/ch05_strategy.py` |
+| `on_resume` | 生命周期 | 热启动恢复、打印快照续跑状态、恢复外部连接 | `examples/21_warm_start_demo.py` |
+| `on_stop` | 生命周期 | 汇总统计、资源释放、输出最终摘要 | `examples/textbook/ch05_strategy.py` |
+| `on_bar` | 主数据事件 | K 线策略、指标更新、主交易逻辑 | `examples/textbook/ch05_strategy.py` |
+| `on_tick` | 主数据事件 | Tick 级监控、盘口驱动、高频响应 | `examples/51_class_tick_callbacks_demo.py` |
+| `on_timer` | 主数据事件 | 定时任务、盘前检查、固定时点调仓 | `examples/strategies/07_stock_momentum_rotation_on_timer.py` |
+| `on_order` | 订单事件 | 跟踪订单状态流转、联动撤单或重置状态 | `examples/08_event_callbacks.py` |
+| `on_trade` | 订单事件 | 记录成交、成交后风控、累计成交统计 | `examples/08_event_callbacks.py` |
+| `on_reject` | 订单事件 | 记录拒单原因、发告警、触发降级策略 | `examples/50_framework_hooks_demo.py` |
+| `on_session_start` | 框架边界 | 日盘/夜盘切换、session 级状态重置 | `examples/50_framework_hooks_demo.py` |
+| `on_session_end` | 框架边界 | 收盘后清理、session 结束打点与归档 | `examples/50_framework_hooks_demo.py` |
+| `on_before_trading` | 框架边界 | 盘前检查、生成交易日级信号、盘前风控 | `examples/50_framework_hooks_demo.py` |
+| `on_daily_rebalance` | 框架边界 | 横截面选股、每天最多一次的统一调仓 | `examples/strategies/05_stock_momentum_rotation_timer.py` |
+| `on_after_trading` | 框架边界 | 日终统计、收盘后归档、落盘或报表输出 | `examples/50_framework_hooks_demo.py` |
+| `on_portfolio_update` | 框架边界 | 账户权益变化监控、推送 UI 或风控告警 | `examples/50_framework_hooks_demo.py` |
+| `on_expiry` | 专项回调 | 期货/期权到期结算、换月、移除失效合约 | `examples/49_on_expiry_demo.py` |
+| `on_error` | 专项回调 | 统一处理用户回调异常、选择继续或中断 | `examples/22_strategy_runtime_config_demo.py` |
+| `on_train_signal` | 专项回调 | ML 滚动训练窗口触发时更新模型 | `examples/10_ml_walk_forward.py` |
+
+有两个实践判断非常重要：
+
+*   当逻辑依赖**价格数据本身**时，优先考虑 `on_bar` / `on_tick` / `on_timer`。
+*   当逻辑依赖**交易阶段边界**时，优先考虑 `on_before_trading` / `on_after_trading` / `on_session_*`，不要强行塞进 `on_bar`。
+
+如果你想系统理解这些回调的触发顺序、类风格与函数式的能力差异，以及每个回调是否有公开示例，请继续参考：[策略指南](../guide/strategy.md)。
 
 ## 5.3 交易接口详解 (Trading API)
 
@@ -464,7 +515,27 @@ def on_expiry(self, event):
 
 回调触发时，账户和持仓状态已经更新，因此你可以直接读取最新持仓。最小可运行示例见：`examples/49_on_expiry_demo.py`。
 
-### 5.7.4 `on_event`：策略外的统一事件流
+### 5.7.4 框架边界回调：把逻辑放在“正确阶段”
+
+很多初学者会把盘前准备、日终归档、交易日调仓都写进 `on_bar`。这在简单脚本里能跑，但一旦进入多标的、多 session、live/backtest 复用的场景，就容易变得难维护。更稳妥的做法是把逻辑写在对应的框架边界回调里：
+
+*   `on_before_trading(trading_date, timestamp)`: 本地交易日首次进入 `Normal` 会话时触发，适合做盘前检查、生成交易日级候选池。
+*   `on_daily_rebalance(trading_date, timestamp)`: 与 `on_before_trading` 同阶段，但每个交易日最多一次，适合横截面统一调仓。
+*   `on_after_trading(trading_date, timestamp)`: 离开 `Normal` 会话时触发，适合做日终归档、统计与报告。
+*   `on_session_start(session, timestamp)` / `on_session_end(session, timestamp)`: 适合夜盘/日盘切换、session 级状态管理。
+*   `on_portfolio_update(snapshot)`: 当账户权益、现金或持仓相关估值发生变化时增量触发，适合驱动监控面板。
+*   `on_reject(order)`: 当订单首次进入 `Rejected` 时触发，适合做拒单分类、重试和人工告警。
+*   `on_error(error, source, payload)`: 当用户回调抛异常时触发，可统一记录来源并决定是否继续。
+
+最小可运行示例见：`examples/50_framework_hooks_demo.py`。如果你只需要理解“哪个阶段该做什么”，可以先记住这条经验：
+
+1.  **盘前信号、当日候选池、统一调仓**：放 `on_before_trading` / `on_daily_rebalance`。
+2.  **日终汇总、落盘、报表**：放 `on_after_trading`。
+3.  **日盘夜盘切换、session 内状态重置**：放 `on_session_start` / `on_session_end`。
+4.  **账户权益变化通知**：放 `on_portfolio_update`。
+5.  **拒单与异常治理**：分别放 `on_reject` 和 `on_error`。
+
+### 5.7.5 `on_event`：策略外的统一事件流
 
 如果你需要把回测事件推送到日志系统、监控看板或告警服务，可在 `run_backtest` 入口直接传入 `on_event`，统一消费事件流。
 

--- a/docs/zh/textbook/index.md
+++ b/docs/zh/textbook/index.md
@@ -33,9 +33,10 @@
     *   向量化 vs 事件驱动 ([examples/textbook/ch04_comparison.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch04_comparison.py))
     *   核心组件解析：Engine, Strategy, DataFeed
 *   **[第 5 章：策略开发实战 (Strategy Implementation)](05_strategy.md)**
-    *   策略生命周期与下单接口
+    *   策略生命周期、完整 `on_xxx` 回调地图与下单接口
     *   历史数据获取与防未来函数
     *   案例：双均线策略实现 ([examples/textbook/ch05_strategy.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch05_strategy.py))
+    *   进阶：框架级钩子与 Tick 回调（[examples/50_framework_hooks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py), [examples/51_class_tick_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py)）
 
 ### 第三部分：多资产策略开发 (Strategies)
 
@@ -97,7 +98,7 @@
 | 第 2 章 | [ch02_programming.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch02_programming.py) | [17_readme_demo.py](https://github.com/akfamily/akquant/blob/main/examples/17_readme_demo.py) | [Python 基础](../guide/python_basics.md) |
 | 第 3 章 | [ch03_data.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch03_data.py) | [37_feed_replay_alignment_demo.py](https://github.com/akfamily/akquant/blob/main/examples/37_feed_replay_alignment_demo.py) | [数据指南](../guide/data.md) |
 | 第 4 章 | [ch04_comparison.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch04_comparison.py) | [25_streaming_backtest_demo.py](https://github.com/akfamily/akquant/blob/main/examples/25_streaming_backtest_demo.py) | [数据指南](../guide/data.md) |
-| 第 5 章 | [ch05_strategy.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch05_strategy.py) | [23_functional_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/23_functional_callbacks_demo.py) | [策略指南](../guide/strategy.md) |
+| 第 5 章 | [ch05_strategy.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch05_strategy.py) | [23_functional_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/23_functional_callbacks_demo.py), [50_framework_hooks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/50_framework_hooks_demo.py), [51_class_tick_callbacks_demo.py](https://github.com/akfamily/akquant/blob/main/examples/51_class_tick_callbacks_demo.py) | [策略指南](../guide/strategy.md) |
 | 第 6 章 | [ch06_stock_a.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch06_stock_a.py) | [20_risk_management_demo.py](https://github.com/akfamily/akquant/blob/main/examples/20_risk_management_demo.py) | [量化基础](../guide/quant_basics.md) |
 | 第 7 章 | [ch07_futures.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch07_futures.py) | [04_mixed_assets.py](https://github.com/akfamily/akquant/blob/main/examples/04_mixed_assets.py) | [策略指南](../guide/strategy.md) |
 | 第 8 章 | [ch08_options.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch08_options.py) | [07_option_test.py](https://github.com/akfamily/akquant/blob/main/examples/07_option_test.py) | [量化基础](../guide/quant_basics.md) |

--- a/examples/08_event_callbacks.py
+++ b/examples/08_event_callbacks.py
@@ -1,139 +1,153 @@
-"""
-AKQuant Event Callbacks Demo.
-
-===========================
-
-这个示例演示了如何使用 AKQuant 的事件回调功能：
-1. `on_order`: 监听订单状态变化（New, Submitted, Filled, Cancelled 等）。
-2. `on_trade`: 监听成交回报。
-
-Author: AKQuant Team
-"""
+"""Comprehensive event callback demo for class-style strategies."""
 
 from typing import Any
 
 import akquant as aq
-import numpy as np
 import pandas as pd
 from akquant import Bar, OrderStatus, Strategy
 
 
-# 1. 创建模拟数据
-def generate_mock_data(days: int = 100) -> pd.DataFrame:
-    """生成简单的模拟行情数据."""
-    dates = pd.date_range(start="2024-01-01", periods=days, freq="D")
+def build_intraday_data() -> list[Bar]:
+    """Build deterministic intraday bars so timer callbacks can also fire."""
+    rows = [
+        ("2024-01-02 09:30:00", 10.00),
+        ("2024-01-02 14:55:00", 10.10),
+        ("2024-01-02 15:00:00", 10.05),
+        ("2024-01-03 09:30:00", 10.20),
+        ("2024-01-03 14:55:00", 10.35),
+        ("2024-01-03 15:00:00", 10.30),
+    ]
+    bars: list[Bar] = []
+    for dt_str, close in rows:
+        ts = pd.Timestamp(dt_str, tz="Asia/Shanghai").value
+        bars.append(
+            Bar(
+                timestamp=ts,
+                open=close,
+                high=close + 0.10,
+                low=close - 0.10,
+                close=close,
+                volume=1000.0,
+                symbol="MOCK_STOCK",
+            )
+        )
+    return bars
 
-    # 简单的正弦波趋势 + 随机噪声
-    x = np.linspace(0, 4 * np.pi, days)
-    prices = 100 + 10 * np.sin(x) + np.random.normal(0, 1, days)
 
-    df = pd.DataFrame(
-        {
-            "date": dates,
-            "symbol": "MOCK_STOCK",
-            "open": prices,
-            "high": prices + 2,
-            "low": prices - 2,
-            "close": prices,
-            "volume": 100000,
-        }
-    )
-    return df
-
-
-# 2. 定义策略
 class EventCallbacksStrategy(Strategy):
-    """示例策略，演示事件回调功能."""
+    """Single example covering the most common event callbacks."""
+
+    def __init__(self) -> None:
+        """Initialize counters used by the demo output."""
+        self.submitted_reject_order = False
+        self.submitted_entry_order = False
+        self.submitted_exit_order = False
+        self.portfolio_updates = 0
+        self.timer_hits = 0
+        self.trade_hits = 0
+        self.reject_hits = 0
 
     def on_start(self) -> None:
-        """策略启动回调."""
+        """Register subscriptions and timers."""
         print("\n=== 策略启动 ===")
-        # 注意：on_start 阶段 self.ctx 尚未初始化，无法访问资金等信息
         self.subscribe("MOCK_STOCK")
-        self.order_count = 0
+        self.add_daily_timer("14:55:00", "close_check")
 
     def on_bar(self, bar: Bar) -> None:
-        """K线数据回调."""
-        # 简单的交易逻辑：
-        # - 没有持仓时买入
-        # - 有持仓且盈利超过 2% 时卖出
+        """Submit one rejected order and one valid order using bar events."""
+        dt_str = str(
+            pd.Timestamp(bar.timestamp, unit="ns", tz="UTC").tz_convert("Asia/Shanghai")
+        )
+        print(f"[Callback] on_bar | {dt_str} | close={bar.close:.2f}")
 
-        position = self.get_position(bar.symbol)
+        if not self.submitted_reject_order:
+            self.submitted_reject_order = True
+            print("[Strategy] 提交一笔超大买单，故意触发 on_reject")
+            self.buy(bar.symbol, 1000)
+            return
 
-        if position == 0:
-            # 每隔 10 天买入一次，避免频繁交易
-            if self.order_count % 10 == 0:
-                dt = pd.to_datetime(bar.timestamp, unit="ns")
-                print(f"\n[Strategy] 触发买入信号 @ {dt} 价格: {bar.close:.2f}")
-                # 使用限价单买入，价格比当前收盘价略高，保证成交
-                self.buy(bar.symbol, 100, price=bar.close * 1.01)
-            self.order_count += 1
+        if not self.submitted_entry_order and "2024-01-03 09:30:00" in dt_str:
+            self.submitted_entry_order = True
+            print("[Strategy] 提交一笔有效买单，观察 on_order / on_trade")
+            self.buy(bar.symbol, 10)
 
-        elif position > 0:
-            # 持仓检查
-            if self.ctx:
-                # 简化逻辑，实际应从 Trade 记录获取
-                _ = self.ctx.positions.get(bar.symbol, 0)
-
-            # 这里简单演示，直接在持有 5 天后卖出
-            if self.order_count % 10 == 5:
-                dt = pd.to_datetime(bar.timestamp, unit="ns")
-                print(f"\n[Strategy] 触发卖出信号 @ {dt} 价格: {bar.close:.2f}")
-                self.sell(bar.symbol, 100)  # 市价卖出
-            self.order_count += 1
+    def on_timer(self, payload: str) -> None:
+        """Use timer as a second event source."""
+        self.timer_hits += 1
+        position = self.get_position("MOCK_STOCK")
+        print(f"[Callback] on_timer | payload={payload} | position={position}")
+        if payload == "close_check" and position > 0 and not self.submitted_exit_order:
+            self.submitted_exit_order = True
+            print("[Strategy] timer 触发卖出，观察同一示例中的定时调仓路径")
+            self.sell("MOCK_STOCK", position)
 
     def on_order(self, order: Any) -> None:
-        """订单状态变化回调."""
-        emoji = "❓"
-        if order.status == OrderStatus.New:
-            emoji = "🆕"
-        elif order.status == OrderStatus.Submitted:
-            emoji = "📨"
-        elif order.status == OrderStatus.Filled:
-            emoji = "✅"
-        elif order.status == OrderStatus.Cancelled:
-            emoji = "❌"
-        elif order.status == OrderStatus.Rejected:
-            emoji = "🚫"
-        elif order.status == OrderStatus.Expired:
-            emoji = "⏰"
-
-        # order.status.name 可能不可用，直接打印 order.status
+        """Print all order state transitions."""
+        status_to_icon = {
+            getattr(OrderStatus, "New", None): "[NEW]",
+            getattr(OrderStatus, "Submitted", None): "[SUBMIT]",
+            getattr(OrderStatus, "Accepted", None): "[ACCEPT]",
+            getattr(OrderStatus, "PartiallyFilled", None): "[PART]",
+            getattr(OrderStatus, "Filled", None): "[FILLED]",
+            getattr(OrderStatus, "Cancelled", None): "[CANCEL]",
+            getattr(OrderStatus, "Rejected", None): "[REJECT]",
+            getattr(OrderStatus, "Expired", None): "[EXPIRE]",
+        }
+        icon = status_to_icon.get(order.status, "[ORDER]")
         print(
-            f"[Callback] on_order {emoji} | "
-            f"ID: {order.id[:8]}... | "
-            f"Symbol: {order.symbol} | "
-            f"Side: {order.side} | "
-            f"Status: {order.status} | "
-            f"Qty: {order.filled_quantity}/{order.quantity}"
+            f"[Callback] on_order {icon} | "
+            f"id={order.id[:8]} | symbol={order.symbol} | side={order.side} | "
+            f"status={order.status} | filled={order.filled_quantity}/{order.quantity}"
         )
 
     def on_trade(self, trade: Any) -> None:
-        """成交回报回调."""
+        """Print trade reports."""
+        self.trade_hits += 1
         print(
-            f"[Callback] on_trade 💰 | "
-            f"Time: {trade.timestamp} | "
-            f"Symbol: {trade.symbol} | "
-            f"Side: {trade.side} | "
-            f"Price: {trade.price:.2f} | "
-            f"Qty: {trade.quantity} | "
-            f"Comm: {trade.commission:.2f}"
+            f"[Callback] on_trade | symbol={trade.symbol} | side={trade.side} | "
+            f"price={trade.price:.2f} | qty={trade.quantity} | "
+            f"comm={trade.commission:.4f}"
         )
 
+    def on_reject(self, order: Any) -> None:
+        """Observe rejected orders separately from generic order updates."""
+        self.reject_hits += 1
+        print(
+            f"[Callback] on_reject | id={order.id[:8]} | "
+            f"status={order.status} | qty={order.quantity}"
+        )
 
-# 3. 运行回测
+    def on_portfolio_update(self, snapshot: dict[str, Any]) -> None:
+        """Observe cash/equity updates."""
+        self.portfolio_updates += 1
+        print(
+            "[Callback] on_portfolio_update | "
+            f"cash={snapshot['cash']:.2f} | equity={snapshot['equity']:.2f}"
+        )
+
+    def on_stop(self) -> None:
+        """Print a small summary so users know what was triggered."""
+        print("\n=== 回调汇总 ===")
+        print(f"portfolio_updates={self.portfolio_updates}")
+        print(f"timer_hits={self.timer_hits}")
+        print(f"trade_hits={self.trade_hits}")
+        print(f"reject_hits={self.reject_hits}")
+
+
 def main() -> None:
-    """运行回测主函数."""
-    print("生成数据...")
-    df = generate_mock_data()
+    """Run the callback demo."""
+    print("准备确定性日内数据...")
+    bars = build_intraday_data()
 
     print("开始回测...")
     results = aq.run_backtest(
         strategy=EventCallbacksStrategy,
-        data=df,
+        data=bars,
         symbols="MOCK_STOCK",
-        initial_cash=100_000,
-        commission_rate=0.0003,  # 万三佣金
+        initial_cash=1000.0,
+        commission_rate=0.0003,
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+        show_progress=False,
     )
 
     print("\n=== 回测结束 ===")

--- a/examples/21_warm_start_demo.py
+++ b/examples/21_warm_start_demo.py
@@ -55,6 +55,13 @@ class MovingAverageStrategy(Strategy):
         self.register_indicator("sma_slow", self.sma_slow)
         print(f"[Strategy] Started. Fast={self.fast_window}, Slow={self.slow_window}")
 
+    def on_resume(self) -> None:
+        """Call only when strategy state is restored from snapshot."""
+        print(
+            "[Strategy] on_resume called. "
+            f"Existing counts: buy={self.buy_count}, sell={self.sell_count}"
+        )
+
     def on_bar(self, bar: Bar) -> None:
         """Call on every bar."""
         # 累加状态变量

--- a/examples/50_framework_hooks_demo.py
+++ b/examples/50_framework_hooks_demo.py
@@ -1,0 +1,128 @@
+import pandas as pd
+from akquant import Bar, Strategy, run_backtest
+
+
+class FrameworkHooksDemoStrategy(Strategy):
+    """Demonstrate framework-level hooks that wrap bar/timer callbacks."""
+
+    def __init__(self) -> None:
+        """Initialize demo state and enable precise day-boundary hooks."""
+        self.submitted_reject_order = False
+        self.event_log: list[str] = []
+
+        # Enable boundary timers so day hooks are fired at the exact session edges.
+        self.enable_precise_day_boundary_hooks = True
+
+    def on_start(self) -> None:
+        """Register the demo symbol and announce strategy startup."""
+        self.subscribe("HOOKS_DEMO")
+        self.log("strategy started")
+
+    def on_session_start(self, session: object, timestamp: int) -> None:
+        """Record when a trading session begins."""
+        self.event_log.append(f"session_start:{session}")
+        self.log(f"on_session_start session={session} time={pd.Timestamp(timestamp)}")
+
+    def on_session_end(self, session: object, timestamp: int) -> None:
+        """Record when a trading session ends."""
+        self.event_log.append(f"session_end:{session}")
+        self.log(f"on_session_end session={session} time={pd.Timestamp(timestamp)}")
+
+    def on_before_trading(self, trading_date: object, timestamp: int) -> None:
+        """Observe the trading-day boundary before the normal session opens."""
+        self.event_log.append(f"before:{trading_date}")
+        self.log(
+            f"on_before_trading date={trading_date} time={pd.Timestamp(timestamp)}"
+        )
+
+    def on_daily_rebalance(self, trading_date: object, timestamp: int) -> None:
+        """Show the once-per-day rebalance hook."""
+        self.event_log.append(f"rebalance:{trading_date}")
+        self.log(
+            f"on_daily_rebalance date={trading_date} time={pd.Timestamp(timestamp)}"
+        )
+
+    def on_after_trading(self, trading_date: object, timestamp: int) -> None:
+        """Observe the trading-day boundary after the normal session closes."""
+        self.event_log.append(f"after:{trading_date}")
+        self.log(f"on_after_trading date={trading_date} time={pd.Timestamp(timestamp)}")
+
+    def on_portfolio_update(self, snapshot: dict[str, object]) -> None:
+        """Print incremental portfolio snapshot updates."""
+        self.event_log.append("portfolio")
+        self.log(
+            f"on_portfolio_update cash={snapshot['cash']} equity={snapshot['equity']}"
+        )
+
+    def on_reject(self, order: object) -> None:
+        """Record rejected orders separately from generic order updates."""
+        order_id = getattr(order, "id", "<unknown>")
+        self.event_log.append(f"reject:{order_id}")
+        self.log(f"on_reject order_id={order_id}")
+
+    def on_order(self, order: object) -> None:
+        """Log every order-state transition observed by the strategy."""
+        order_id = getattr(order, "id", "<unknown>")
+        status = getattr(order, "status", "<unknown>")
+        self.event_log.append(f"order:{order_id}:{status}")
+        self.log(f"on_order order_id={order_id} status={status}")
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit one oversize order so the framework hooks become visible."""
+        self.event_log.append(f"bar:{bar.symbol}")
+        self.log(f"on_bar symbol={bar.symbol} close={bar.close}")
+
+        # Intentionally oversize one order so risk checks reject it and on_reject fires.
+        if not self.submitted_reject_order:
+            self.submitted_reject_order = True
+            self.buy(bar.symbol, quantity=1000)
+
+    def on_stop(self) -> None:
+        """Print the final framework-hook event sequence."""
+        print("\n=== framework hooks summary ===")
+        for event in self.event_log:
+            print(event)
+
+
+def build_data() -> list[Bar]:
+    """Build a tiny deterministic bar series for boundary-hook playback."""
+    rows = [
+        ("2023-01-03 09:30:00", 10.0),
+        ("2023-01-03 15:00:00", 10.5),
+        ("2023-01-04 09:30:00", 10.8),
+        ("2023-01-04 15:00:00", 10.6),
+    ]
+    bars: list[Bar] = []
+    for dt_str, close in rows:
+        ts = pd.Timestamp(dt_str, tz="Asia/Shanghai").value
+        bars.append(
+            Bar(
+                timestamp=ts,
+                open=close,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=1000.0,
+                symbol="HOOKS_DEMO",
+            )
+        )
+    return bars
+
+
+def main() -> None:
+    """Run the framework-hook callback demo."""
+    strategy = FrameworkHooksDemoStrategy()
+    run_backtest(
+        data=build_data(),
+        strategy=strategy,
+        symbols=["HOOKS_DEMO"],
+        initial_cash=1000.0,
+        lot_size=1,
+        show_progress=False,
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+        strategy_max_position_size={"_default": 10},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/51_class_tick_callbacks_demo.py
+++ b/examples/51_class_tick_callbacks_demo.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Class-style on_tick callback demo."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pandas as pd
+from akquant import Strategy, Tick
+from akquant.akquant import StrategyContext
+
+
+class DemoContext:
+    """Minimal context object for simulating class-style tick dispatch."""
+
+    def __init__(self) -> None:
+        """Initialize the minimal fields required by internal callbacks."""
+        self.canceled_order_ids: list[str] = []
+        self.active_orders: list[Any] = []
+        self.recent_trades: list[Any] = []
+        self.recent_rejected_orders: list[Any] = []
+        self.cash = 100000.0
+        self.positions: dict[str, float] = {}
+        self.available_positions: dict[str, float] = {}
+        self.session = "normal"
+        self.current_time = 0
+
+    def get_position(self, symbol: str) -> float:
+        """Return the simulated position size for one symbol."""
+        return float(self.positions.get(symbol, 0.0))
+
+
+class TickCallbacksStrategy(Strategy):
+    """Demonstrate class-style on_tick together with adjacent callbacks."""
+
+    def __init__(self) -> None:
+        """Store the callback sequence emitted by the demo."""
+        self.events: list[str] = []
+
+    def on_tick(self, tick: Tick) -> None:
+        """Record each simulated tick callback."""
+        self.events.append(f"tick:{tick.symbol}:{tick.price}")
+        print(f"[Callback] on_tick | symbol={tick.symbol} | price={tick.price}")
+
+    def on_order(self, order: Any) -> None:
+        """Record order callbacks adjacent to tick handling."""
+        self.events.append(f"order:{order.id}")
+        print(f"[Callback] on_order | id={order.id} | status={order.status}")
+
+    def on_trade(self, trade: Any) -> None:
+        """Record trade callbacks adjacent to tick handling."""
+        self.events.append(f"trade:{trade.order_id}")
+        print(f"[Callback] on_trade | order_id={trade.order_id}")
+
+    def on_timer(self, payload: str) -> None:
+        """Record timer callbacks in the same demo script."""
+        self.events.append(f"timer:{payload}")
+        print(f"[Callback] on_timer | payload={payload}")
+
+
+def main() -> None:
+    """Run a minimal class-style tick callback simulation."""
+    strategy = TickCallbacksStrategy()
+    ctx = cast(StrategyContext, DemoContext())
+
+    ts1 = int(pd.Timestamp("2024-01-02 09:30:01", tz="Asia/Shanghai").value)
+    ctx.current_time = ts1
+    ctx.active_orders = cast(
+        Any, [SimpleNamespace(id="o1", status="Submitted", filled_quantity=0.0)]
+    )
+    ctx.recent_trades = cast(Any, [SimpleNamespace(order_id="o1")])
+    tick1 = Tick(timestamp=ts1, price=101.0, volume=200.0, symbol="TEST")
+    strategy._on_tick_event(tick1, ctx)
+
+    ts2 = int(pd.Timestamp("2024-01-02 09:31:01", tz="Asia/Shanghai").value)
+    ctx.current_time = ts2
+    ctx.active_orders = cast(
+        Any, [SimpleNamespace(id="o2", status="Submitted", filled_quantity=0.0)]
+    )
+    ctx.recent_trades = cast(Any, [SimpleNamespace(order_id="o2")])
+    tick2 = Tick(timestamp=ts2, price=101.5, volume=220.0, symbol="TEST")
+    strategy._on_tick_event(tick2, ctx)
+
+    ctx.active_orders = []
+    ctx.recent_trades = []
+    strategy._on_timer_event("rebalance", ctx)
+
+    print("\n=== class tick summary ===")
+    print(f"events_total={len(strategy.events)}")
+    print(f"ticks={sum(1 for x in strategy.events if x.startswith('tick:'))}")
+    print(f"orders={sum(1 for x in strategy.events if x.startswith('order:'))}")
+    print(f"trades={sum(1 for x in strategy.events if x.startswith('trade:'))}")
+    print(f"timers={sum(1 for x in strategy.events if x.startswith('timer:'))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@
 - [05_live_trading_ctp.py](./05_live_trading_ctp.py): CTP 实盘接口示例。
 - [06_complex_orders.py](./06_complex_orders.py): 复杂订单助手示例（`place_bracket_order` + 自动 OCO 联动）。
 - [07_option_test.py](./07_option_test.py): 期权回测示例。
-- [08_event_callbacks.py](./08_event_callbacks.py): 回调事件使用示例。
+- [08_event_callbacks.py](./08_event_callbacks.py): 统一事件回调示例（`on_start/on_bar/on_order/on_trade/on_reject/on_timer/on_portfolio_update/on_stop`）。
 - [09_ml_framework.py](./09_ml_framework.py): 机器学习框架基础示例。
 - [10_ml_walk_forward.py](./10_ml_walk_forward.py): Walk-Forward 训练评估示例。
 - [11_plot_visualization.py](./11_plot_visualization.py): 可视化报告生成示例。
@@ -52,6 +52,8 @@
 - [47_margin_liquidation_audit_demo.py](./47_margin_liquidation_audit_demo.py): 信用账户强平审计示例（`margin` 模式 + `liquidation_audit_df` + 报告输出）。
 - [48_margin_liquidation_priority_compare.py](./48_margin_liquidation_priority_compare.py): 强平顺序对比示例（`short_first` vs `long_first`）。
 - [49_on_expiry_demo.py](./49_on_expiry_demo.py): `on_expiry` 回调与流式 `expiry` 事件最小示例（期货到期结算后通知）。
+- [50_framework_hooks_demo.py](./50_framework_hooks_demo.py): `on_session_start/on_session_end/on_before_trading/on_after_trading/on_portfolio_update/on_reject` 框架级钩子最小示例。
+- [51_class_tick_callbacks_demo.py](./51_class_tick_callbacks_demo.py): 类风格 `on_tick` 最小示例（含 `on_order/on_trade/on_timer` 相邻回调）。
 
 ## 流式回测与实时报告
 

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1143,7 +1143,7 @@ class Strategy:
         """会话结束回调."""
         pass
 
-    def before_trading(self, trading_date: dt.date, timestamp: int) -> None:
+    def on_before_trading(self, trading_date: dt.date, timestamp: int) -> None:
         """交易日开始前回调."""
         pass
 
@@ -1151,7 +1151,7 @@ class Strategy:
         """交易日调仓回调（每天最多一次）."""
         pass
 
-    def after_trading(self, trading_date: dt.date, timestamp: int) -> None:
+    def on_after_trading(self, trading_date: dt.date, timestamp: int) -> None:
         """交易日结束后回调."""
         pass
 

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -129,7 +129,7 @@ def dispatch_time_hooks(strategy: Any) -> None:
     ):
         call_user_callback(
             strategy,
-            "after_trading",
+            "on_after_trading",
             last_date,
             current_time,
             payload={"trading_date": last_date, "timestamp": current_time},
@@ -162,7 +162,7 @@ def dispatch_time_hooks(strategy: Any) -> None:
     ):
         call_user_callback(
             strategy,
-            "before_trading",
+            "on_before_trading",
             current_date,
             current_time,
             payload={"trading_date": current_date, "timestamp": current_time},
@@ -178,7 +178,7 @@ def dispatch_time_hooks(strategy: Any) -> None:
     ):
         call_user_callback(
             strategy,
-            "after_trading",
+            "on_after_trading",
             current_date,
             current_time,
             payload={"trading_date": current_date, "timestamp": current_time},
@@ -190,7 +190,7 @@ def dispatch_time_hooks(strategy: Any) -> None:
 
 
 def register_boundary_timers(strategy: Any) -> None:
-    """注册交易日边界定时器，用于精确触发 before/after_trading."""
+    """注册交易日边界定时器，用于精确触发 on_before/on_after_trading."""
     if strategy.ctx is None:
         return
     if not bool(_runtime_option(strategy, "enable_precise_day_boundary_hooks")):
@@ -240,7 +240,7 @@ def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
         if getattr(strategy, "_framework_before_trading_done_date", None) != day:
             call_user_callback(
                 strategy,
-                "before_trading",
+                "on_before_trading",
                 day,
                 current_time,
                 payload={"trading_date": day, "timestamp": current_time},
@@ -252,7 +252,7 @@ def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
         if getattr(strategy, "_framework_after_trading_done_date", None) != day:
             call_user_callback(
                 strategy,
-                "after_trading",
+                "on_after_trading",
                 day,
                 current_time,
                 payload={"trading_date": day, "timestamp": current_time},
@@ -388,7 +388,7 @@ def dispatch_shutdown_hooks(strategy: Any) -> None:
     if before_done_date is not None and after_done_date != before_done_date:
         call_user_callback(
             strategy,
-            "after_trading",
+            "on_after_trading",
             before_done_date,
             current_time,
             payload={"trading_date": before_done_date, "timestamp": current_time},

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -2735,7 +2735,7 @@ class FrameworkHooksStrategy(Strategy):
         """Record session end."""
         self.events.append(f"session_end:{session}:{timestamp}")
 
-    def before_trading(self, trading_date: Any, timestamp: int) -> None:
+    def on_before_trading(self, trading_date: Any, timestamp: int) -> None:
         """Record before trading hook."""
         self.events.append(f"before:{trading_date}:{timestamp}")
 
@@ -2743,7 +2743,7 @@ class FrameworkHooksStrategy(Strategy):
         """Record daily rebalance hook."""
         self.events.append(f"rebalance:{trading_date}:{timestamp}")
 
-    def after_trading(self, trading_date: Any, timestamp: int) -> None:
+    def on_after_trading(self, trading_date: Any, timestamp: int) -> None:
         """Record after trading hook."""
         self.events.append(f"after:{trading_date}:{timestamp}")
 
@@ -3342,8 +3342,8 @@ def test_run_backtest_runtime_config_override_false_keeps_strategy_config(
     assert "runtime_config_override=False" in caplog.text
 
 
-def test_stop_internal_flushes_session_and_after_trading_hooks() -> None:
-    """Stop phase should flush session_end and after_trading when pending."""
+def test_stop_internal_flushes_session_and_on_after_trading_hooks() -> None:
+    """Stop phase should flush session_end and on_after_trading when pending."""
     strategy = FrameworkHooksStrategy()
     ctx = MagicMock(spec=StrategyContext)
     ctx.get_position.return_value = 0.0


### PR DESCRIPTION
重命名 before_trading/after_trading 为 on_before_trading/on_after_trading，移除旧名兼容别名，确保命名一致性。

新增 examples/50_framework_hooks_demo.py 和 examples/51_class_tick_callbacks_demo.py，分别演示框架边界钩子和类风格 Tick 回调的完整触发顺序。更新策略指南、教材章节和示例目录，提供完整的 on_xxx 回调地图和学习路径，帮助用户理解各类回调的职责边界。