### PR TITLE
feat: 支持增量指标的历史预热与多标的独立实例

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -748,6 +748,41 @@ class IncrementalIndicatorStrategy(Strategy):
             self.buy(bar.symbol, 100)
 ```
 
+Incremental mode now supports two recommended capabilities:
+
+* `indicator_factory`: creates an isolated indicator instance per `symbol`, which is the recommended pattern for multi-symbol strategies.
+* `warmup_bars`: bootstraps incremental indicators with bars before `start_time` before the live event stream begins.
+
+```python
+from akquant import Bar, SMA, Strategy
+
+class MultiSymbolIncrementalStrategy(Strategy):
+    def __init__(self):
+        self.indicator_mode = "incremental"
+
+    def on_start(self):
+        self.register_incremental_indicator(
+            "sma20",
+            indicator_factory=lambda: SMA(20),
+            source="close",
+            symbols=["AAPL", "MSFT"],
+            warmup_bars=20,
+        )
+
+    def on_bar(self, bar: Bar):
+        val = self.sma20.value
+        if val is None:
+            return
+        if bar.close > val:
+            self.buy(bar.symbol, 100)
+```
+
+Notes:
+
+* The legacy single-symbol form `register_incremental_indicator("sma20", self.sma20, ...)` remains supported.
+* If one shared instance is reused across multiple symbols, AKQuant raises an explicit error and points users to `indicator_factory`.
+* `warmup_bars` only consumes history before the active start boundary and does not double-consume the first active bar.
+
 ## 7. Strategy Cookbook
 
 ### 7.1 Trailing Stop

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -889,8 +889,44 @@ class IncrementalIndicatorStrategy(Strategy):
             return
         if bar.close > val:
             self.buy(bar.symbol, 100)
+```
 
+增量模式新增了两项推荐能力：
+
+*   `indicator_factory`: 为每个 `symbol` 创建独立指标实例，适合多标的策略，避免状态串线。
+*   `warmup_bars`: 在进入正式事件流前，先用 `start_time` 之前的历史 Bar 预热增量指标。
+
+```python
+from akquant import Bar, SMA, Strategy
+
+class MultiSymbolIncrementalStrategy(Strategy):
+    def __init__(self):
+        self.indicator_mode = "incremental"
+
+    def on_start(self):
+        self.register_incremental_indicator(
+            "sma20",
+            indicator_factory=lambda: SMA(20),
+            source="close",
+            symbols=["AAPL", "MSFT"],
+            warmup_bars=20,
+        )
+
+    def on_bar(self, bar: Bar):
+        val = self.sma20.value
+        if val is None:
+            return
+        if bar.close > val:
+            self.buy(bar.symbol, 100)
+
+
+说明：
+
+*   单标的旧写法 `register_incremental_indicator("sma20", self.sma20, ...)` 仍然兼容。
+*   如果一个共享实例被多个 `symbol` 复用，框架会显式报错，提示改为 `indicator_factory`。
+*   `warmup_bars` 只会消费正式开始时间之前的历史数据，不会重复消费第一根有效 Bar。
 ## 8. 高级特性：热启动 (Warm Start)
+
 
 AKQuant 支持**热启动 (Warm Start)** 功能，允许你保存回测状态并在未来恢复。这对于长周期分段回测、滚动训练或模拟实盘环境非常有用。
 

--- a/examples/58_incremental_bootstrap_demo.py
+++ b/examples/58_incremental_bootstrap_demo.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+AKQuant incremental bootstrap demo.
+
+This example shows a hybrid workflow for incremental indicators:
+1. Load enough history before `start_time`.
+2. Bootstrap an incremental indicator with `warmup_bars`.
+3. Continue updating the same indicator from the live event stream.
+
+The recommended multi-symbol pattern is `indicator_factory`, which creates
+one isolated indicator instance per symbol.
+"""
+
+from typing import Any
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def make_demo_data() -> pd.DataFrame:
+    """Build two-symbol synthetic minute bars."""
+    timestamps = pd.date_range("2024-01-01 09:30:00", periods=8, freq="min", tz="UTC")
+    records: list[dict[str, object]] = []
+    base_prices = {"AAPL": 100.0, "MSFT": 200.0}
+
+    for symbol, base in base_prices.items():
+        for i, ts in enumerate(timestamps):
+            close = base + float(i)
+            records.append(
+                {
+                    "timestamp": ts,
+                    "symbol": symbol,
+                    "open": close - 0.2,
+                    "high": close + 0.3,
+                    "low": close - 0.4,
+                    "close": close,
+                    "volume": 1000.0 + i * 10.0,
+                }
+            )
+    return pd.DataFrame(records)
+
+
+class IncrementalBootstrapStrategy(Strategy):
+    """Show per-symbol incremental indicators with historical bootstrap."""
+
+    sma3: Any
+
+    def __init__(self) -> None:
+        """Initialize demo strategy state."""
+        super().__init__()
+        self.runtime_config = {"indicator_mode": "incremental"}
+        self.seen_active_bars: dict[str, int] = {}
+
+    def on_start(self) -> None:
+        """Register one SMA per symbol and request bootstrap history."""
+        self.register_incremental_indicator(
+            "sma3",
+            indicator_factory=lambda: aq.SMA(3),
+            source="close",
+            symbols=["AAPL", "MSFT"],
+            warmup_bars=3,
+        )
+
+    def on_bar(self, bar: Bar) -> None:
+        """Print the active-stream indicator value for each symbol."""
+        self.seen_active_bars[bar.symbol] = self.seen_active_bars.get(bar.symbol, 0) + 1
+        sma = self.sma3.value
+        local_ts = self.format_time(bar.timestamp)
+        print(
+            f"{local_ts} | {bar.symbol} | close={bar.close:.2f} | "
+            f"sma3={sma:.2f} | active_bar={self.seen_active_bars[bar.symbol]}"
+        )
+
+
+if __name__ == "__main__":
+    demo_data = make_demo_data()
+    start_time = pd.Timestamp("2024-01-01 09:34:00", tz="UTC")
+    end_time = pd.Timestamp("2024-01-01 09:37:00", tz="UTC")
+
+    print("Running AKQuant incremental bootstrap demo...")
+    print(
+        "Expected behavior: SMA is already warm on the first active bar because "
+        "bars before start_time are used for bootstrap."
+    )
+
+    result = aq.run_backtest(
+        strategy=IncrementalBootstrapStrategy,
+        data=demo_data,
+        symbols=["AAPL", "MSFT"],
+        start_time=start_time,
+        end_time=end_time,
+        initial_cash=100000.0,
+        show_progress=False,
+        timezone="UTC",
+    )
+
+    print("\n=== Backtest Summary ===")
+    print(result)

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,6 +59,7 @@
 - [55_functional_ml_walk_forward.py](./55_functional_ml_walk_forward.py): 函数式 `on_train_signal(ctx)` + Walk-Forward 训练评估示例。
 - [56_functional_warm_start_demo.py](./56_functional_warm_start_demo.py): 函数式 `on_resume(ctx)` 热启动续跑最小示例。
 - [57_functional_multi_slot_warm_start_demo.py](./57_functional_multi_slot_warm_start_demo.py): 函数式多 slot `on_resume(ctx)` 热启动续跑示例。
+- [58_incremental_bootstrap_demo.py](./58_incremental_bootstrap_demo.py): 增量指标“历史预热 + 实时更新”最小示例，演示 `indicator_factory` 与 `warmup_bars`。
 
 ## 流式回测与实时报告
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.18"
+version = "0.2.19"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}
@@ -105,7 +105,6 @@ module = [
     "polars",
     "polars.*",
     "pytest",
-    "pytest.*",
     "quantstats",
     "quantstats.*",
 ]

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -1571,6 +1571,23 @@ def _should_prepare_precomputed_indicators(strategy_instance: Strategy) -> bool:
     return str(strategy_instance.indicator_mode).strip().lower() == "precompute"
 
 
+def _resolve_incremental_indicator_warmup_depth(strategy_instance: Strategy) -> int:
+    """提取增量指标注册中声明的最大历史预热深度."""
+    if str(strategy_instance.indicator_mode).strip().lower() != "incremental":
+        return 0
+    registrations = getattr(strategy_instance, "_incremental_indicators", {}) or {}
+    max_warmup = 0
+    for item in registrations.values():
+        warmup_bars = 0
+        if hasattr(item, "warmup_bars"):
+            warmup_bars = int(getattr(item, "warmup_bars", 0) or 0)
+        elif isinstance(item, dict):
+            warmup_bars = int(item.get("warmup_bars", 0) or 0)
+        if warmup_bars > max_warmup:
+            max_warmup = warmup_bars
+    return max_warmup
+
+
 def _resolve_runtime_warmup_depth(
     strategy_instance: Strategy,
     history_depth: int,
@@ -2537,7 +2554,11 @@ def run_backtest(
         int(getattr(current_strategy, "_history_depth", 0))
         for current_strategy in all_strategy_instances
     )
-    effective_depth = max(effective_depth, manual_history_depth)
+    indicator_warmup_depth = max(
+        _resolve_incremental_indicator_warmup_depth(current_strategy)
+        for current_strategy in all_strategy_instances
+    )
+    effective_depth = max(effective_depth, manual_history_depth, indicator_warmup_depth)
     preserve_pre_start_history = bool(start_time) and effective_depth > 0
     load_start_time = None if preserve_pre_start_history else start_time
     active_start_time_ns = (
@@ -3760,6 +3781,10 @@ def run_backtest(
                 current_strategy, "_prepare_indicators"
             ):
                 current_strategy._prepare_indicators(data_map_for_indicators)
+            if hasattr(current_strategy, "_bootstrap_incremental_indicators"):
+                current_strategy._bootstrap_incremental_indicators(
+                    data_map_for_indicators
+                )
 
     engine_summary: str = ""
     try:
@@ -4624,6 +4649,16 @@ def run_warm_start(
                     current_strategy._prepare_indicators(data_map_for_indicators)
                 except Exception as e:
                     logger.error(f"Failed to update indicators for warm start: {e}")
+            if hasattr(current_strategy, "_bootstrap_incremental_indicators"):
+                try:
+                    current_strategy._bootstrap_incremental_indicators(
+                        data_map_for_indicators
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to bootstrap incremental indicators for warm start: "
+                        f"{e}"
+                    )
 
     # 4. 运行
     engine_summary: str = ""

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Deque,
     Dict,
     List,
@@ -200,6 +201,51 @@ InstrumentOptionTypeName = Literal["CALL", "PUT"]
 InstrumentSettlementMode = Literal["CASH", "SETTLEMENT_PRICE", "FORCE_CLOSE"]
 
 
+@dataclass
+class IncrementalIndicatorRegistration:
+    """增量指标注册定义."""
+
+    source: str
+    symbols: Optional[set[str]]
+    input_mode: str = "source"
+    warmup_bars: int = 0
+    factory: Optional[Callable[[], Any]] = None
+    base_indicator: Any = None
+    primary_symbol: Optional[str] = None
+    instances: Dict[str, Any] = field(default_factory=dict)
+
+
+class IncrementalIndicatorBinding:
+    """按当前 symbol 访问底层增量指标实例的轻量代理."""
+
+    def __init__(self, strategy: "Strategy", name: str) -> None:
+        """绑定策略实例与指标名，延迟解析当前 symbol 对应的真实指标."""
+        self._strategy = strategy
+        self._name = name
+
+    def get_instance(self, symbol: Optional[str] = None) -> Any:
+        """返回指定 symbol 对应的底层指标实例."""
+        return self._strategy._get_incremental_indicator_instance(self._name, symbol)
+
+    @property
+    def value(self) -> Any:
+        """获取当前 symbol 的最新指标值."""
+        return getattr(self.get_instance(), "value", None)
+
+    @property
+    def is_ready(self) -> bool:
+        """获取当前 symbol 的 ready 状态."""
+        return bool(getattr(self.get_instance(), "is_ready", False))
+
+    def update(self, *args: Any, **kwargs: Any) -> Any:
+        """兼容手动调用 update 的现有写法."""
+        return self.get_instance().update(*args, **kwargs)
+
+    def __getattr__(self, attr: str) -> Any:
+        """将未知属性代理到底层当前 symbol 的增量指标实例."""
+        return getattr(self.get_instance(), attr)
+
+
 @dataclass(frozen=True)
 class InstrumentSnapshot:
     """策略侧可访问的标的静态属性快照."""
@@ -236,7 +282,7 @@ class Strategy:
     # Python side accesses it via self.ctx.history() (efficient copy).
     # No duplicate storage in Python.
     _precomputed_indicators: List["Indicator"]
-    _incremental_indicators: Dict[str, Dict[str, Any]]
+    _incremental_indicators: Dict[str, IncrementalIndicatorRegistration]
     _subscriptions: List[str]
     _last_prices: Dict[str, float]
     _rolling_train_window: int
@@ -457,6 +503,11 @@ class Strategy:
             del state["_framework_stop_flushed"]
         if "_framework_boundary_timers_registered" in state:
             del state["_framework_boundary_timers_registered"]
+        incremental_indicators = state.get("_incremental_indicators")
+        if isinstance(incremental_indicators, dict):
+            for name in incremental_indicators.keys():
+                if state.get(name).__class__ is IncrementalIndicatorBinding:
+                    del state[name]
         return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
@@ -492,6 +543,8 @@ class Strategy:
         self._start_initialized = False
         if not hasattr(self, "_seen_trade_keys"):
             self._seen_trade_keys = set()
+        if not hasattr(self, "_incremental_indicators"):
+            self._incremental_indicators = {}
         if not hasattr(self, "_seen_trade_key_order"):
             self._seen_trade_key_order = deque()
         if not hasattr(self, "_oco_groups"):
@@ -538,6 +591,8 @@ class Strategy:
             self._ml_pending_window_start_bar = None
         if not hasattr(self, "_ml_pending_window_end_bar"):
             self._ml_pending_window_end_bar = None
+        for name in list(getattr(self, "_incremental_indicators", {}).keys()):
+            setattr(self, name, IncrementalIndicatorBinding(self, name))
         _ensure_framework_state_impl(self)
 
     @property
@@ -1049,25 +1104,41 @@ class Strategy:
     def register_incremental_indicator(
         self,
         name: str,
-        indicator: Any,
+        indicator: Any = None,
         source: str = "close",
         symbols: Optional[Union[str, List[str], Tuple[str, ...], set[str]]] = None,
+        *,
+        warmup_bars: int = 0,
+        indicator_factory: Optional[Callable[[], Any]] = None,
+        input_mode: str = "source",
     ) -> None:
         """注册增量指标."""
         if self.indicator_mode != "incremental":
             raise ValueError(
                 "register_incremental_indicator requires indicator_mode='incremental'"
             )
-        source_key = str(source).strip().lower()
-        if source_key not in {"open", "high", "low", "close", "volume"}:
-            raise ValueError("source must be one of: open, high, low, close, volume")
+        if self.is_restored and name in self._incremental_indicators:
+            setattr(self, name, IncrementalIndicatorBinding(self, name))
+            return
         symbol_filter = self._normalize_indicator_symbols(symbols)
-        self._incremental_indicators[name] = {
-            "indicator": indicator,
-            "source": source_key,
-            "symbols": symbol_filter,
-        }
-        setattr(self, name, indicator)
+        source_key = str(source).strip().lower()
+        input_mode_key = self._normalize_incremental_input_mode(source_key, input_mode)
+        if indicator is not None and indicator_factory is not None:
+            raise ValueError("indicator and indicator_factory cannot both be provided")
+        if indicator is None and indicator_factory is None:
+            raise ValueError("indicator or indicator_factory is required")
+        warmup_bars_value = int(warmup_bars)
+        if warmup_bars_value < 0:
+            raise ValueError("warmup_bars must be >= 0")
+        self._incremental_indicators[name] = IncrementalIndicatorRegistration(
+            source=source_key,
+            symbols=symbol_filter,
+            input_mode=input_mode_key,
+            warmup_bars=warmup_bars_value,
+            factory=indicator_factory,
+            base_indicator=indicator,
+        )
+        setattr(self, name, IncrementalIndicatorBinding(self, name))
 
     def subscribe(self, instrument_id: str) -> None:
         """
@@ -1095,14 +1166,73 @@ class Strategy:
             return
         if not self._incremental_indicators:
             return
-        for item in self._incremental_indicators.values():
-            symbol_filter = item["symbols"]
-            if symbol_filter is not None and bar.symbol not in symbol_filter:
+        bar_symbol = getattr(bar, "symbol", None)
+        active_start_time_ns = getattr(self, "_active_start_time_ns", None)
+        if (
+            getattr(self, "_incremental_bootstrap_applied", False)
+            and active_start_time_ns is not None
+            and int(getattr(bar, "timestamp", active_start_time_ns))
+            < int(active_start_time_ns)
+        ):
+            return
+        for name in list(self._incremental_indicators.keys()):
+            item = self._get_incremental_registration(name)
+            symbol_filter = item.symbols
+            if symbol_filter is not None and bar_symbol not in symbol_filter:
                 continue
-            ind = item["indicator"]
-            source = item["source"]
-            value = getattr(bar, source)
-            ind.update(value)
+            ind = self._get_incremental_indicator_instance(name, bar_symbol)
+            args = self._build_incremental_indicator_args(
+                payload=bar,
+                source=item.source,
+                input_mode=item.input_mode,
+            )
+            ind.update(*args)
+
+    def _bootstrap_incremental_indicators(self, data: Dict[str, pd.DataFrame]) -> None:
+        """在实时增量更新前，用历史数据预热增量指标."""
+        if self.indicator_mode != "incremental" or self.is_restored:
+            return
+        if not self._incremental_indicators:
+            return
+        available_symbols = set(data.keys())
+        active_start_time_ns = getattr(self, "_active_start_time_ns", None)
+        if active_start_time_ns is None:
+            return
+        bootstrap_applied = False
+        for name in list(self._incremental_indicators.keys()):
+            item = self._get_incremental_registration(name)
+            if item.warmup_bars <= 0:
+                continue
+            target_symbols = (
+                sorted(item.symbols)
+                if item.symbols is not None
+                else sorted(available_symbols)
+            )
+            for symbol in target_symbols:
+                df = data.get(symbol)
+                if df is None or df.empty:
+                    continue
+                if active_start_time_ns is not None and isinstance(
+                    df.index, pd.DatetimeIndex
+                ):
+                    boundary = pd.Timestamp(active_start_time_ns, unit="ns", tz="UTC")
+                    if df.index.tz is None:
+                        boundary = boundary.tz_localize(None)
+                    else:
+                        boundary = boundary.tz_convert(df.index.tz)
+                    df = df[df.index < boundary]
+                    if df.empty:
+                        continue
+                indicator = self._get_incremental_indicator_instance(name, symbol)
+                for _, row in df.tail(item.warmup_bars).iterrows():
+                    args = self._build_incremental_indicator_args(
+                        payload=row,
+                        source=item.source,
+                        input_mode=item.input_mode,
+                    )
+                    indicator.update(*args)
+                    bootstrap_applied = True
+        self._incremental_bootstrap_applied = bootstrap_applied
 
     def _normalize_indicator_symbols(
         self,
@@ -1126,6 +1256,98 @@ class Strategy:
                 raise ValueError("symbols cannot be empty")
             return normalized
         raise TypeError("symbols must be str, list[str], tuple[str, ...], set[str]")
+
+    def _normalize_incremental_input_mode(self, source: str, input_mode: str) -> str:
+        input_mode_key = str(input_mode).strip().lower()
+        valid_modes = {"source", "hl", "hlc", "ohlc", "close_volume"}
+        if input_mode_key not in valid_modes:
+            raise ValueError(
+                "input_mode must be one of: source, hl, hlc, ohlc, close_volume"
+            )
+        if input_mode_key == "source" and source not in {
+            "open",
+            "high",
+            "low",
+            "close",
+            "volume",
+        }:
+            raise ValueError("source must be one of: open, high, low, close, volume")
+        return input_mode_key
+
+    def _get_incremental_registration(
+        self, name: str
+    ) -> IncrementalIndicatorRegistration:
+        item = self._incremental_indicators[name]
+        if isinstance(item, IncrementalIndicatorRegistration):
+            return item
+        legacy_item = cast(Dict[str, Any], item)
+        registration = IncrementalIndicatorRegistration(
+            source=str(legacy_item.get("source", "close")).strip().lower(),
+            symbols=legacy_item.get("symbols"),
+            input_mode=str(legacy_item.get("input_mode", "source")).strip().lower(),
+            warmup_bars=int(legacy_item.get("warmup_bars", 0) or 0),
+            factory=legacy_item.get("indicator_factory"),
+            base_indicator=legacy_item.get("indicator"),
+        )
+        self._incremental_indicators[name] = registration
+        return registration
+
+    def _get_incremental_indicator_instance(
+        self, name: str, symbol: Optional[str] = None
+    ) -> Any:
+        registration = self._get_incremental_registration(name)
+        resolved_symbol = self._resolve_incremental_indicator_symbol(
+            registration, symbol
+        )
+        if resolved_symbol in registration.instances:
+            return registration.instances[resolved_symbol]
+        if registration.factory is not None:
+            indicator = registration.factory()
+        elif registration.primary_symbol is None:
+            indicator = registration.base_indicator
+            registration.primary_symbol = resolved_symbol
+        elif registration.primary_symbol == resolved_symbol:
+            indicator = registration.base_indicator
+        else:
+            raise ValueError(
+                f"Incremental indicator '{name}' was registered with a shared instance "
+                "and cannot be used across multiple symbols. Use indicator_factory "
+                "for multi-symbol incremental indicators."
+            )
+        registration.instances[resolved_symbol] = indicator
+        return indicator
+
+    def _resolve_incremental_indicator_symbol(
+        self, registration: IncrementalIndicatorRegistration, symbol: Optional[str]
+    ) -> str:
+        if symbol is not None:
+            return str(symbol)
+        if self.current_bar is not None:
+            return str(self.current_bar.symbol)
+        if self.current_tick is not None:
+            return str(self.current_tick.symbol)
+        if registration.primary_symbol is not None:
+            return registration.primary_symbol
+        if len(registration.instances) == 1:
+            return next(iter(registration.instances))
+        if registration.symbols is not None and len(registration.symbols) == 1:
+            return next(iter(registration.symbols))
+        return "__default__"
+
+    def _build_incremental_indicator_args(
+        self, payload: Any, source: str, input_mode: str
+    ) -> Tuple[Any, ...]:
+        if input_mode == "source":
+            return (getattr(payload, source),)
+        if input_mode == "hl":
+            return (payload.high, payload.low)
+        if input_mode == "hlc":
+            return (payload.high, payload.low, payload.close)
+        if input_mode == "ohlc":
+            return (payload.open, payload.high, payload.low, payload.close)
+        if input_mode == "close_volume":
+            return (payload.close, payload.volume)
+        raise ValueError(f"Unsupported input_mode: {input_mode}")
 
     def on_order(self, order: Any) -> None:
         """

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -760,6 +760,8 @@ mod tests {
             Decimal::from(1000),
             None,
         );
+        let mut order = order;
+        order.allow_quantity_auto_resize = true;
         sim.on_order(order);
 
         let bar = create_test_bar(

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn test_format_timestamp_str_uses_asia_shanghai() {
-        let timestamp = 1_735_802_000_000_000_000_i64; // 2025-01-02 15:00:00+08:00
+        let timestamp = 1_735_801_200_000_000_000_i64; // 2025-01-02 15:00:00+08:00
         assert_eq!(format_timestamp_str(timestamp), "2025-01-02 15:00:00");
     }
 
@@ -652,7 +652,7 @@ mod tests {
             OrderType::Limit,
             Decimal::from(10),
         );
-        let timestamp = 1_735_802_000_000_000_000_i64;
+        let timestamp = 1_735_801_200_000_000_000_i64;
         order.created_at = timestamp;
         order.updated_at = timestamp;
 
@@ -670,7 +670,7 @@ mod tests {
             quantity: Decimal::from(10),
             price: Decimal::from(100),
             commission: Decimal::ZERO,
-            timestamp: 1_735_802_000_000_000_000_i64,
+            timestamp: 1_735_801_200_000_000_000_i64,
             bar_index: 0,
             owner_strategy_id: None,
         };

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -485,11 +485,46 @@ impl DataProcessor {
         }
     }
 
-    fn finalize_current_timestamp(&mut self, engine: &Engine) {
+    fn reject_missing_symbol_orders(&self, engine: &mut Engine) {
+        if self.last_timestamp == 0 {
+            return;
+        }
+
+        let rejected_orders: Vec<Order> = engine
+            .state
+            .order_manager
+            .active_orders
+            .iter()
+            .filter(|order| {
+                matches!(order.status, OrderStatus::New | OrderStatus::Submitted)
+                    && order.created_at == self.last_timestamp
+                    && !self.seen_symbols.contains(&order.symbol)
+                    && effective_execution_policy_for_order(engine, order).bar_offset == 1
+            })
+            .cloned()
+            .map(|mut order| {
+                order.status = OrderStatus::Rejected;
+                order.updated_at = self.last_timestamp;
+                order.reject_reason = format!(
+                    "Missing market data for symbol {} at execution timestamp {}",
+                    order.symbol, self.last_timestamp
+                );
+                order
+            })
+            .collect();
+
+        for order in rejected_orders {
+            engine.execution_model.on_cancel(&order.id);
+            let _ = engine.event_manager.send(Event::ExecutionReport(order, None));
+        }
+    }
+
+    fn finalize_current_timestamp(&mut self, engine: &mut Engine) {
         if self.last_timestamp == 0 || self.finalized_timestamp == self.last_timestamp {
             return;
         }
         self.fill_missing_bars(engine);
+        self.reject_missing_symbol_orders(engine);
         self.finalized_timestamp = self.last_timestamp;
     }
 }
@@ -1039,7 +1074,10 @@ impl Processor for StatisticsProcessor {
 mod tests {
     use super::*;
     use crate::engine::Engine;
-    use crate::model::{AssetType, Bar, Instrument, InstrumentEnum, StockInstrument};
+    use crate::model::{
+        AssetType, Bar, Instrument, InstrumentEnum, Order, OrderSide, OrderType, StockInstrument,
+        TimeInForce,
+    };
     use rust_decimal_macros::dec;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -1143,6 +1181,96 @@ mod tests {
                 assert_eq!(hist_a.closes[1], 100.0);
                 assert_eq!(hist_a.volumes[1], 0.0);
             }
+        });
+    }
+
+    #[test]
+    fn test_missing_symbol_next_open_order_is_rejected_and_removed_from_active_orders() {
+        pyo3::Python::initialize();
+
+        let mut engine = Engine::new();
+        engine
+            .instruments
+            .insert("A".to_string(), create_instrument("A"));
+        engine
+            .instruments
+            .insert("B".to_string(), create_instrument("B"));
+        engine.state.portfolio.cash = dec!(50000);
+        engine.last_prices.insert("A".to_string(), dec!(100));
+        engine.last_prices.insert("B".to_string(), dec!(100));
+
+        let mut pending_order =
+            Order::test_new("order-b", "B", OrderSide::Buy, OrderType::Limit, dec!(300));
+        pending_order.price = Some(dec!(100));
+        pending_order.time_in_force = TimeInForce::GTC;
+        pending_order.created_at = 1000;
+        pending_order.updated_at = 1000;
+
+        engine.execution_model.on_order(pending_order.clone());
+        engine.state.order_manager.add_active_order(pending_order);
+
+        let mut data_processor = DataProcessor::new();
+        let mut channel_processor = ChannelProcessor;
+        let mut cleanup_processor = CleanupProcessor;
+
+        let bar_t1_a = Bar {
+            timestamp: 1000,
+            symbol: "A".to_string(),
+            open: dec!(100),
+            high: dec!(100),
+            low: dec!(100),
+            close: dec!(100),
+            volume: dec!(100),
+            extra: HashMap::new(),
+        };
+        let bar_t2_a = Bar {
+            timestamp: 2000,
+            symbol: "A".to_string(),
+            open: dec!(101),
+            high: dec!(101),
+            low: dec!(101),
+            close: dec!(101),
+            volume: dec!(100),
+            extra: HashMap::new(),
+        };
+
+        engine.state.feed.add_bar(bar_t1_a).unwrap();
+        engine.state.feed.add_bar(bar_t2_a).unwrap();
+
+        pyo3::Python::attach(|py| {
+            let locals = py.import("builtins").unwrap();
+            let strategy = locals.getattr("None").unwrap();
+
+            data_processor.process(&mut engine, py, &strategy).unwrap();
+            channel_processor.process(&mut engine, py, &strategy).unwrap();
+            data_processor.process(&mut engine, py, &strategy).unwrap();
+            channel_processor.process(&mut engine, py, &strategy).unwrap();
+            cleanup_processor
+                .process(&mut engine, py, &strategy)
+                .unwrap();
+
+
+            let rejected_order = engine
+                .state
+                .order_manager
+                .get_all_orders()
+                .into_iter()
+                .find(|order| order.id == "order-b")
+                .unwrap();
+            assert_eq!(rejected_order.status, OrderStatus::Rejected);
+            assert!(rejected_order.reject_reason.contains("Missing market data"));
+            assert_eq!(
+                engine.state.order_manager.current_step_rejected_orders.len(),
+                1
+            );
+            assert!(
+                !engine
+                    .state
+                    .order_manager
+                    .active_orders
+                    .iter()
+                    .any(|order| order.id == "order-b")
+            );
         });
     }
 

--- a/tests/test_strategy_timers_indicators.py
+++ b/tests/test_strategy_timers_indicators.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 from unittest.mock import MagicMock
 
+import akquant
 import pandas as pd
 import pytest
 from akquant.akquant import StrategyContext
@@ -20,6 +21,8 @@ class SMA(Indicator):
 
 class MyTimerStrategy(Strategy):
     """Mock strategy for timer testing."""
+
+    inc_sma: Any
 
     def __init__(self) -> None:
         """Initialize."""
@@ -203,3 +206,100 @@ def test_incremental_indicator_symbol_filter() -> None:
     )
 
     assert indicator.values == [13.0]
+
+
+def test_incremental_indicator_uses_symbol_scoped_instances() -> None:
+    """不同 symbol 的增量指标应维护独立状态."""
+
+    class IncrementalIndicator:
+        def __init__(self) -> None:
+            self.values: list[float] = []
+
+        def update(self, value: float) -> None:
+            self.values.append(value)
+
+    class FakeBar:
+        def __init__(self, symbol: str, close: float) -> None:
+            self.symbol = symbol
+            self.open = close
+            self.high = close
+            self.low = close
+            self.close = close
+            self.volume = 0.0
+
+    strategy = MyTimerStrategy()
+    strategy.indicator_mode = "incremental"
+    strategy.register_incremental_indicator(
+        "inc_sma",
+        indicator_factory=IncrementalIndicator,
+        source="close",
+    )
+
+    strategy._update_incremental_indicators(cast(Any, FakeBar("000001.SZ", 10.0)))
+    strategy._update_incremental_indicators(cast(Any, FakeBar("000002.SZ", 20.0)))
+    strategy.current_bar = cast(Any, FakeBar("000001.SZ", 10.0))
+    first_symbol_values = strategy.inc_sma.values
+    strategy.current_bar = cast(Any, FakeBar("000002.SZ", 20.0))
+    second_symbol_values = strategy.inc_sma.values
+
+    assert first_symbol_values == [10.0]
+    assert second_symbol_values == [20.0]
+
+
+def test_incremental_indicator_bootstrap_respects_active_start_boundary() -> None:
+    """历史预热只使用 start_time 之前的 bars，不提前消费首根有效 bar."""
+
+    class IncrementalIndicator:
+        def __init__(self) -> None:
+            self.values: list[float] = []
+
+        def update(self, value: float) -> None:
+            self.values.append(value)
+
+    class BootstrapStrategy(Strategy):
+        inc_sma: Any
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.runtime_config = {"indicator_mode": "incremental"}
+
+        def on_start(self) -> None:
+            self.register_incremental_indicator(
+                "inc_sma",
+                indicator_factory=IncrementalIndicator,
+                source="close",
+                warmup_bars=2,
+            )
+
+        def on_bar(self, bar: Any) -> None:
+            pass
+
+    symbol = "BOOTSTRAP_TEST"
+    timestamps = pd.date_range("2024-01-01 09:30:00", periods=4, freq="min", tz="UTC")
+    data = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "open": [10.0, 11.0, 12.0, 13.0],
+            "high": [10.0, 11.0, 12.0, 13.0],
+            "low": [10.0, 11.0, 12.0, 13.0],
+            "close": [10.0, 11.0, 12.0, 13.0],
+            "volume": [1.0, 1.0, 1.0, 1.0],
+            "symbol": [symbol, symbol, symbol, symbol],
+        }
+    )
+
+    result = akquant.run_backtest(
+        strategy=BootstrapStrategy,
+        data=data,
+        symbols=[symbol],
+        start_time=timestamps[2],
+        end_time=timestamps[-1],
+        initial_cash=100000.0,
+        show_progress=False,
+        timezone="UTC",
+    )
+
+    strategy = result.strategy
+    assert strategy is not None
+    indicator = strategy.inc_sma.get_instance(symbol)
+    assert indicator.values == [10.0, 11.0, 12.0, 13.0]


### PR DESCRIPTION
新增增量指标的历史预热能力，允许在策略正式事件流开始前使用历史数据预热指标。引入 `indicator_factory` 参数，为多标的策略创建独立的指标实例，避免状态串线。新增 `warmup_bars` 参数指定预热深度，框架会自动加载并消费 `start_time` 之前的历史数据。

同时修复缺失行情数据时下一根K线开盘执行订单的错误处理，自动拒绝此类订单并生成执行报告。更新相关文档和测试用例，并发布版本 0.2.19。