### PR TITLE
feat(warm-start): 在快照中保存并恢复历史缓冲区以支持 get_history 连续性

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/warm_start.md
+++ b/docs/en/advanced/warm_start.md
@@ -108,9 +108,10 @@ Built-in indicators (`SMA`, `EMA`, etc.) support pickle serialization. For custo
 2. **MarketModel reset**: Fee settings and trading rules (for example T+1) are not persisted in snapshots. Re-pass them via explicit args or `config.strategy_config` on resume.
 3. **Initial cash display**: `result2.metrics.initial_cash` is adjusted to resumed-phase starting cash, so phase-2 return metrics remain interpretable.
 4. **Data continuity**: Keep phase-1 end and phase-2 start continuous to avoid indicator jumps.
-5. **Runtime config injection**: Use `strategy_runtime_config` in `run_warm_start` to override runtime behavior at resume.
-6. **Strategy-level risk state continuity**: Strategy limits, strategy cashflow, daily-loss baseline, drawdown peak, and reduce-only activation state are persisted and restored.
-7. **Default timezone**: If `timezone` is not explicitly provided to `run_warm_start`, default is `Asia/Shanghai`.
+5. **`get_history()` continuity**: New snapshots also persist the history buffer, so `get_history()` and `get_history_map()` resume with the phase-1 rolling window intact. In the normal warm-start path you no longer need to manually prepend extra lookback bars.
+6. **Runtime config injection**: Use `strategy_runtime_config` in `run_warm_start` to override runtime behavior at resume.
+7. **Strategy-level risk state continuity**: Strategy limits, strategy cashflow, daily-loss baseline, drawdown peak, and reduce-only activation state are persisted and restored.
+8. **Default timezone**: If `timezone` is not explicitly provided to `run_warm_start`, default is `Asia/Shanghai`.
 
 ## 5. Full Example
 

--- a/docs/zh/advanced/warm_start.md
+++ b/docs/zh/advanced/warm_start.md
@@ -116,9 +116,10 @@ AKQuant 内置的指标（如 `SMA`, `EMA`）已经支持 Pickle 序列化。如
 2.  **MarketModel 重置**：费用设置（佣金、印花税）和交易规则（T+1）不会保存在快照中。务必在 `run_warm_start` 参数中重新传入正确配置（可通过显式参数或 `config.strategy_config`），优先使用 `stamp_tax_rate`、`transfer_fee_rate`（`stamp_tax`、`transfer_fee` 仍兼容）。
 3.  **初始资金显示**：`result2.metrics.initial_cash` 会自动调整为恢复时的资金，确保收益率计算是基于第二阶段的实际起始资金，而不是账户的历史初始资金。
 4.  **数据连续性**：确保 Phase 1 的结束时间与 Phase 2 的开始时间是连续的。如果中间有长时间中断，指标计算可能会出现跳跃。
-5.  **运行时配置注入**：可通过 `strategy_runtime_config` 在恢复阶段覆盖错误处理和快照阈值等运行时行为。
-6.  **策略级风控状态可恢复**：策略限额、策略现金流、日损基线、回撤峰值、仅平仓激活态等会随快照保存并恢复，便于断点续跑后保持风控行为连续。
-7.  **默认时区**：`run_warm_start` 未显式传入 `timezone` 时，默认使用 `Asia/Shanghai`。
+5.  **`get_history()` 连续性**：新版本快照会一并保存并恢复历史缓冲，因此 `run_warm_start` 恢复后，`get_history()`、`get_history_map()` 等接口会延续 Phase 1 的历史窗口；正常续跑时不再需要额外手工拼接 lookback 数据。
+6.  **运行时配置注入**：可通过 `strategy_runtime_config` 在恢复阶段覆盖错误处理和快照阈值等运行时行为。
+7.  **策略级风控状态可恢复**：策略限额、策略现金流、日损基线、回撤峰值、仅平仓激活态等会随快照保存并恢复，便于断点续跑后保持风控行为连续。
+8.  **默认时区**：`run_warm_start` 未显式传入 `timezone` 时，默认使用 `Asia/Shanghai`。
 
 ## 5. 完整示例
 

--- a/examples/21_warm_start_demo.py
+++ b/examples/21_warm_start_demo.py
@@ -200,9 +200,8 @@ def main() -> None:
     print("=" * 50)
 
     # 获取后半段数据
-    # 注意：为了让指标（如 SMA-30）在 7 月 1 日开盘时能立即计算，
-    # 我们需要提供一段"Lookback"历史数据。
-    # 这里我们取阶段一的最后 30 天数据与阶段二数据拼接。
+    # 新版本快照会恢复 get_history() 所依赖的历史缓冲，
+    # 正常 warm start 不需要再手工拼接额外的 lookback 数据。
     # lookback_days = 30
     # data_lookback = data_phase1[-lookback_days:]
     data_new = get_real_data(symbol, "2022-01-01", "2023-12-31")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.19"
+version = "0.2.20"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -4462,6 +4462,25 @@ def run_warm_start(
         cast(Any, engine).set_strategy_risk_cooldown_bars(normalized_cooldown_bars)
 
     all_strategy_instances = [strategy_instance, *slot_strategy_instances.values()]
+    snapshot_features = getattr(strategy_instance, "_warm_start_snapshot_features", {})
+    if not isinstance(snapshot_features, dict):
+        snapshot_features = {}
+    history_buffer_snapshot_available = bool(
+        snapshot_features.get("history_buffer_snapshot", False)
+    )
+    history_tracking_enabled = any(
+        int(getattr(current_strategy, "_history_depth", 0)) > 0
+        for current_strategy in all_strategy_instances
+    )
+    if history_tracking_enabled and not history_buffer_snapshot_available:
+        warning_message = (
+            "The checkpoint was created by an older AKQuant version and does not "
+            "include the history buffer snapshot. Warm start can continue, but "
+            "`get_history()` / `get_history_map()` may differ from a full backtest "
+            "until the checkpoint is regenerated with a newer version."
+        )
+        warnings.warn(warning_message, RuntimeWarning, stacklevel=2)
+        logger.warning(warning_message)
     if data_map_for_indicators:
         all_dates: set[pd.Timestamp] = set()
         day_bounds: Dict[str, Tuple[int, int]] = {}

--- a/python/akquant/checkpoint.py
+++ b/python/akquant/checkpoint.py
@@ -87,6 +87,9 @@ def save_snapshot(engine: Engine, strategy: Any, filepath: str) -> None:
             "default_strategy_id": default_strategy_id,
             "slot_ids": slot_ids,
         },
+        "snapshot_features": {
+            "history_buffer_snapshot": True,
+        },
         "version": _VERSION,
     }
 
@@ -129,6 +132,9 @@ def warm_start(
     topology = snapshot.get("strategy_topology", {})
     if not isinstance(topology, dict):
         topology = {}
+    snapshot_features = snapshot.get("snapshot_features", {})
+    if not isinstance(snapshot_features, dict):
+        snapshot_features = {}
 
     # 2. Initialize new Engine
     engine = Engine()
@@ -156,6 +162,7 @@ def warm_start(
         ]
         if normalized_slot_ids:
             setattr(strategy, "_strategy_slot_ids", normalized_slot_ids)
+    setattr(strategy, "_warm_start_snapshot_features", dict(snapshot_features))
     # print(f"Warm start loaded from {filepath}. Snapshot time: {engine.snapshot_time}")
 
     return engine, strategy

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -80,6 +80,7 @@ mod tests {
     #[test]
     fn test_engine_snapshot_serialization() {
         use crate::engine::state::EngineSnapshot;
+        use crate::history::HistoryBufferSnapshot;
         use crate::order_manager::OrderManager;
         use crate::portfolio::Portfolio;
         use std::collections::HashMap;
@@ -107,6 +108,10 @@ mod tests {
             current_time: 123456789,
             portfolio,
             order_manager,
+            history_state: Some(HistoryBufferSnapshot {
+                data: HashMap::new(),
+                default_capacity: 3,
+            }),
             strategy_risk_state: Default::default(),
         };
 
@@ -115,5 +120,12 @@ mod tests {
 
         assert_eq!(decoded.current_time, 123456789);
         assert_eq!(decoded.portfolio.cash, Decimal::from(50000));
+        assert_eq!(
+            decoded
+                .history_state
+                .as_ref()
+                .map(|snapshot| snapshot.default_capacity),
+            Some(3)
+        );
     }
 }

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -553,10 +553,14 @@ impl Engine {
 
     /// 导出当前状态为二进制数据
     fn get_state_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let history_state = Some(crate::history::HistoryBufferSnapshot::from(
+            &*self.history_buffer.read().unwrap(),
+        ));
         let snapshot = crate::engine::state::EngineSnapshot {
             current_time: self.clock.timestamp().unwrap_or(0),
             portfolio: self.state.portfolio.clone(),
             order_manager: self.state.order_manager.clone(),
+            history_state,
             strategy_risk_state: crate::engine::state::StrategyRiskStateSnapshot {
                 default_strategy_id: self.default_strategy_id.clone(),
                 strategy_slots: self
@@ -603,6 +607,10 @@ impl Engine {
 
         self.state.portfolio = snapshot.portfolio;
         self.state.order_manager = snapshot.order_manager;
+        let history_buffer = snapshot.history_state.map(crate::history::HistoryBuffer::from);
+        if let Some(buffer) = history_buffer {
+            self.history_buffer = Arc::new(RwLock::new(buffer));
+        }
         self.snapshot_time = snapshot.current_time;
         self.default_strategy_id = snapshot.strategy_risk_state.default_strategy_id;
         self.strategy_slots = snapshot
@@ -656,6 +664,13 @@ impl Engine {
     /// :param depth: 历史数据长度
     fn set_history_depth(&mut self, depth: usize) {
         self.history_buffer.write().unwrap().set_capacity(depth);
+    }
+
+    fn configure_history_depth(&mut self, depth: usize) {
+        self.history_buffer
+            .write()
+            .unwrap()
+            .set_capacity_preserve_existing(depth);
     }
 
     /// 设置时区偏移 (秒)
@@ -1018,7 +1033,7 @@ impl Engine {
             && let Ok(depth) = depth_attr.extract::<usize>()
             && depth > 0
         {
-            self.set_history_depth(depth);
+            self.configure_history_depth(depth);
         }
 
         if strategy.hasattr("_on_start_internal")? {

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::data::DataFeed;
+use crate::history::HistoryBufferSnapshot;
 use crate::order_manager::OrderManager;
 use crate::portfolio::Portfolio;
 
@@ -34,6 +35,8 @@ pub struct EngineSnapshot {
     pub current_time: i64,
     pub portfolio: Portfolio,
     pub order_manager: OrderManager,
+    #[serde(default)]
+    pub history_state: Option<HistoryBufferSnapshot>,
     #[serde(default)]
     pub strategy_risk_state: StrategyRiskStateSnapshot,
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,5 +1,6 @@
 use crate::model::Bar;
 use rust_decimal::prelude::ToPrimitive;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 
 #[derive(Debug, Clone)]
@@ -68,6 +69,48 @@ impl SymbolHistory {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SymbolHistorySnapshot {
+    pub timestamps: VecDeque<i64>,
+    pub opens: VecDeque<f64>,
+    pub highs: VecDeque<f64>,
+    pub lows: VecDeque<f64>,
+    pub closes: VecDeque<f64>,
+    pub volumes: VecDeque<f64>,
+    pub extras: HashMap<String, VecDeque<f64>>,
+    pub capacity: usize,
+}
+
+impl From<&SymbolHistory> for SymbolHistorySnapshot {
+    fn from(history: &SymbolHistory) -> Self {
+        Self {
+            timestamps: history.timestamps.clone(),
+            opens: history.opens.clone(),
+            highs: history.highs.clone(),
+            lows: history.lows.clone(),
+            closes: history.closes.clone(),
+            volumes: history.volumes.clone(),
+            extras: history.extras.clone(),
+            capacity: history.capacity,
+        }
+    }
+}
+
+impl From<SymbolHistorySnapshot> for SymbolHistory {
+    fn from(snapshot: SymbolHistorySnapshot) -> Self {
+        Self {
+            timestamps: snapshot.timestamps,
+            opens: snapshot.opens,
+            highs: snapshot.highs,
+            lows: snapshot.lows,
+            closes: snapshot.closes,
+            volumes: snapshot.volumes,
+            extras: snapshot.extras,
+            capacity: snapshot.capacity,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct HistoryBuffer {
     pub data: HashMap<String, SymbolHistory>,
@@ -87,6 +130,29 @@ impl HistoryBuffer {
         self.data.clear();
     }
 
+    pub fn set_capacity_preserve_existing(&mut self, capacity: usize) {
+        self.default_capacity = capacity;
+        if capacity == 0 {
+            self.data.clear();
+            return;
+        }
+
+        for history in self.data.values_mut() {
+            history.capacity = capacity;
+            while history.timestamps.len() > capacity {
+                history.timestamps.pop_front();
+                history.opens.pop_front();
+                history.highs.pop_front();
+                history.lows.pop_front();
+                history.closes.pop_front();
+                history.volumes.pop_front();
+                for values in history.extras.values_mut() {
+                    values.pop_front();
+                }
+            }
+        }
+    }
+
     pub fn update(&mut self, bar: &Bar) {
         if self.default_capacity == 0 {
             return;
@@ -102,5 +168,105 @@ impl HistoryBuffer {
 
     pub fn get_history(&self, symbol: &str) -> Option<&SymbolHistory> {
         self.data.get(symbol)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryBufferSnapshot {
+    pub data: HashMap<String, SymbolHistorySnapshot>,
+    pub default_capacity: usize,
+}
+
+impl From<&HistoryBuffer> for HistoryBufferSnapshot {
+    fn from(buffer: &HistoryBuffer) -> Self {
+        Self {
+            data: buffer
+                .data
+                .iter()
+                .map(|(symbol, history)| (symbol.clone(), SymbolHistorySnapshot::from(history)))
+                .collect(),
+            default_capacity: buffer.default_capacity,
+        }
+    }
+}
+
+impl From<HistoryBufferSnapshot> for HistoryBuffer {
+    fn from(snapshot: HistoryBufferSnapshot) -> Self {
+        Self {
+            data: snapshot
+                .data
+                .into_iter()
+                .map(|(symbol, history)| (symbol, SymbolHistory::from(history)))
+                .collect(),
+            default_capacity: snapshot.default_capacity,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{HistoryBuffer, HistoryBufferSnapshot};
+    use crate::model::Bar;
+    use rust_decimal::Decimal;
+    use std::collections::HashMap;
+
+    fn make_bar(timestamp: i64, close: i64, extra: Option<(&str, f64)>) -> Bar {
+        let mut extra_map = HashMap::new();
+        if let Some((key, value)) = extra {
+            extra_map.insert(key.to_string(), value);
+        }
+        Bar {
+            timestamp,
+            open: Decimal::from(close),
+            high: Decimal::from(close),
+            low: Decimal::from(close),
+            close: Decimal::from(close),
+            volume: Decimal::from(1000),
+            symbol: "TEST".to_string(),
+            extra: extra_map,
+        }
+    }
+
+    #[test]
+    fn test_history_buffer_snapshot_roundtrip_preserves_history() {
+        let mut buffer = HistoryBuffer::new(4);
+        buffer.update(&make_bar(1, 10, Some(("factor", 1.0))));
+        buffer.update(&make_bar(2, 11, None));
+        buffer.update(&make_bar(3, 12, Some(("factor", 3.0))));
+
+        let snapshot = HistoryBufferSnapshot::from(&buffer);
+        let encoded = rmp_serde::to_vec(&snapshot).expect("serialize history snapshot");
+        let decoded: HistoryBufferSnapshot =
+            rmp_serde::from_slice(&encoded).expect("deserialize history snapshot");
+        let restored = HistoryBuffer::from(decoded);
+
+        assert_eq!(restored.default_capacity, 4);
+        let history = restored.get_history("TEST").expect("history for TEST");
+        assert_eq!(history.capacity, 4);
+        assert_eq!(history.timestamps.iter().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(history.closes.iter().copied().collect::<Vec<_>>(), vec![10.0, 11.0, 12.0]);
+        let extras = history.extras.get("factor").expect("factor extra history");
+        assert_eq!(extras.len(), 3);
+        assert_eq!(extras[0], 1.0);
+        assert!(extras[1].is_nan());
+        assert_eq!(extras[2], 3.0);
+    }
+
+    #[test]
+    fn test_set_capacity_preserve_existing_keeps_tail_window() {
+        let mut buffer = HistoryBuffer::new(4);
+        for (timestamp, close) in [(1, 10), (2, 11), (3, 12), (4, 13)] {
+            buffer.update(&make_bar(timestamp, close, Some(("factor", close as f64))));
+        }
+
+        buffer.set_capacity_preserve_existing(2);
+
+        assert_eq!(buffer.default_capacity, 2);
+        let history = buffer.get_history("TEST").expect("history for TEST");
+        assert_eq!(history.capacity, 2);
+        assert_eq!(history.timestamps.iter().copied().collect::<Vec<_>>(), vec![3, 4]);
+        assert_eq!(history.closes.iter().copied().collect::<Vec<_>>(), vec![12.0, 13.0]);
+        let extras = history.extras.get("factor").expect("factor extra history");
+        assert_eq!(extras.iter().copied().collect::<Vec<_>>(), vec![12.0, 13.0]);
     }
 }

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import logging
+import pickle
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Iterator, cast
@@ -869,6 +870,21 @@ class WarmStartE2EStrategy(Strategy):
         self.events.append(f"on_bar:{self.bar_seen}")
 
 
+class WarmStartHistoryContinuityStrategy(Strategy):
+    """Strategy for warm-start history-buffer continuity tests."""
+
+    def __init__(self) -> None:
+        """Track close-history snapshots across bars."""
+        self.set_history_depth(3)
+        self.samples: list[tuple[int, np.ndarray]] = []
+
+    def on_bar(self, bar: Bar) -> None:
+        """Capture the rolling close window seen on each bar."""
+        self.samples.append(
+            (bar.timestamp, self.get_history(count=3, field="close").copy())
+        )
+
+
 class RuntimeConfigWarmStartStrategy(Strategy):
     """Strategy for warm start runtime config injection test."""
 
@@ -1535,6 +1551,83 @@ def test_run_warm_start_end_to_end_lifecycle(tmp_path: Path) -> None:
     assert strategy.events[resume_idx + 1] == "on_start"
     assert strategy.events[-1] == "on_bar:7"
     assert result2.metrics.initial_market_value == result1.metrics.end_market_value
+
+
+def test_run_warm_start_preserves_get_history_window(tmp_path: Path) -> None:
+    """Warm start should restore get_history windows without extra lookback input."""
+    checkpoint = tmp_path / "snapshot_history.pkl"
+    phase1 = _make_bars("2023-01-01", 4)
+    phase2 = _make_bars("2023-01-05", 3, start_price=104.0)
+
+    full_result = run_backtest(
+        data=phase1 + phase2,
+        strategy=WarmStartHistoryContinuityStrategy,
+        symbols="TEST",
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    result1 = run_backtest(
+        data=phase1,
+        strategy=WarmStartHistoryContinuityStrategy,
+        symbols="TEST",
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    save_snapshot(result1.engine, result1.strategy, str(checkpoint))  # type: ignore[arg-type]
+    warm_result = run_warm_start(
+        checkpoint_path=str(checkpoint),
+        data=phase2,
+        symbols="TEST",
+        show_progress=False,
+    )
+
+    full_strategy = full_result.strategy
+    warm_strategy = warm_result.strategy
+    assert full_strategy is not None
+    assert warm_strategy is not None
+
+    full_samples = {timestamp: history for timestamp, history in full_strategy.samples}
+    warm_samples = {timestamp: history for timestamp, history in warm_strategy.samples}
+    assert list(sorted(warm_samples)) == list(sorted(full_samples))
+    for timestamp, full_history in full_samples.items():
+        np.testing.assert_allclose(
+            warm_samples[timestamp],
+            full_history,
+            equal_nan=True,
+        )
+
+
+def test_run_warm_start_warns_for_legacy_checkpoint_without_history_feature_marker(
+    tmp_path: Path,
+) -> None:
+    """Warm start should warn when a checkpoint lacks the history-buffer marker."""
+    checkpoint = tmp_path / "snapshot_legacy_history.pkl"
+    phase1 = _make_bars("2023-01-01", 4)
+    phase2 = _make_bars("2023-01-05", 2, start_price=104.0)
+
+    result1 = run_backtest(
+        data=phase1,
+        strategy=WarmStartHistoryContinuityStrategy,
+        symbols="TEST",
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    save_snapshot(result1.engine, result1.strategy, str(checkpoint))  # type: ignore[arg-type]
+
+    with checkpoint.open("rb") as fh:
+        snapshot = pickle.load(fh)
+    snapshot.pop("snapshot_features", None)
+    with checkpoint.open("wb") as fh:
+        pickle.dump(snapshot, fh)
+
+    with pytest.warns(RuntimeWarning, match="history buffer snapshot"):
+        result2 = run_warm_start(
+            checkpoint_path=str(checkpoint),
+            data=phase2,
+            symbols="TEST",
+            show_progress=False,
+        )
+    assert result2.strategy is not None
 
 
 def test_run_warm_start_functional_lifecycle(tmp_path: Path) -> None:


### PR DESCRIPTION
- 将历史缓冲区（HistoryBuffer）状态纳入 EngineSnapshot 实现序列化
- 在 Python 层的 save_snapshot 中标记历史缓冲区快照特性
- 恢复时自动重建历史缓冲区，确保 get_history() 和 get_history_map() 窗口连续
- 为旧版本快照添加兼容性警告
- 更新文档说明，移除了手动拼接 lookback 数据的建议
- 增加单元测试验证历史窗口的完整性和向后兼容性