### PR TITLE
fix: 修复已取消订单在open_orders中可见的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.21"
+version = "0.2.22"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.21"
+version = "0.2.22"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from .akquant import OrderSide, OrderStatus, OrderType, TimeInForce
 
@@ -60,9 +60,25 @@ def get_open_orders(strategy: Any, symbol: Optional[str] = None) -> List[Any]:
     if strategy.ctx is None:
         return []
 
+    canceled_order_ids = {
+        str(order_id)
+        for order_id in getattr(strategy.ctx, "canceled_order_ids", [])
+        if order_id
+    }
+    pending_canceled_ids: Set[str] = getattr(
+        strategy, "_pending_canceled_order_ids", set()
+    )
+    if not isinstance(pending_canceled_ids, set):
+        pending_canceled_ids = set()
+        setattr(strategy, "_pending_canceled_order_ids", pending_canceled_ids)
+    canceled_order_ids.update(
+        str(order_id) for order_id in pending_canceled_ids if order_id
+    )
+
     orders = [
         o
         for o in strategy.ctx.active_orders
+        if getattr(o, "id", "") not in canceled_order_ids
         if o.status
         in (OrderStatus.New, OrderStatus.Submitted, OrderStatus.PartiallyFilled)
     ]
@@ -73,14 +89,37 @@ def get_open_orders(strategy: Any, symbol: Optional[str] = None) -> List[Any]:
 
 def get_order(strategy: Any, order_id: str) -> Optional[Any]:
     """获取指定订单详情."""
+    canceled_order_ids = {
+        str(oid)
+        for oid in getattr(getattr(strategy, "ctx", None), "canceled_order_ids", [])
+        if oid
+    }
+    pending_canceled_ids: Set[str] = getattr(
+        strategy, "_pending_canceled_order_ids", set()
+    )
+    if not isinstance(pending_canceled_ids, set):
+        pending_canceled_ids = set()
+        setattr(strategy, "_pending_canceled_order_ids", pending_canceled_ids)
+    canceled_order_ids.update(str(oid) for oid in pending_canceled_ids if oid)
+
     if order_id in strategy._known_orders:
         order = strategy._known_orders[order_id]
+        if order_id in canceled_order_ids:
+            try:
+                order.status = OrderStatus.Cancelled
+            except Exception:
+                pass
         _attach_broker_options(strategy, order_id, order)
         return order
 
     if strategy.ctx:
         for o in strategy.ctx.active_orders:
             if o.id == order_id:
+                if order_id in canceled_order_ids:
+                    try:
+                        o.status = OrderStatus.Cancelled
+                    except Exception:
+                        pass
                 _attach_broker_options(strategy, order_id, o)
                 return o
     return None
@@ -120,7 +159,28 @@ def _attach_broker_options(strategy: Any, order_id: str, order: Any) -> None:
 def cancel_order(strategy: Any, order_id: str) -> None:
     """取消指定订单."""
     if strategy.ctx:
+        pending_canceled_ids: Set[str] = getattr(
+            strategy, "_pending_canceled_order_ids", set()
+        )
+        if not isinstance(pending_canceled_ids, set):
+            pending_canceled_ids = set()
+            setattr(strategy, "_pending_canceled_order_ids", pending_canceled_ids)
+        pending_canceled_ids.add(order_id)
         strategy.ctx.cancel_order(order_id)
+        for order in strategy.ctx.active_orders:
+            if getattr(order, "id", "") != order_id:
+                continue
+            if getattr(order, "status", None) not in (
+                OrderStatus.New,
+                OrderStatus.Submitted,
+                OrderStatus.PartiallyFilled,
+            ):
+                continue
+            try:
+                order.status = OrderStatus.Cancelled
+            except Exception:
+                pass
+            break
 
 
 def cancel_all_orders(strategy: Any, symbol: Optional[str] = None) -> None:

--- a/src/context.rs
+++ b/src/context.rs
@@ -563,8 +563,13 @@ impl StrategyContext {
     ///
     /// :param order_id: 订单 ID
     fn cancel_order(&mut self, order_id: String) {
+        if !self.canceled_order_ids.iter().any(|existing| existing == &order_id) {
+            self.canceled_order_ids.push(order_id.clone());
+        }
         if let Ok(mut canceled) = self.canceled_order_ids_arc.write() {
-            canceled.push(order_id);
+            if !canceled.iter().any(|existing| existing == &order_id) {
+                canceled.push(order_id);
+            }
         }
     }
 

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -932,6 +932,15 @@ impl Processor for StrategyProcessor {
 
                 for id in canceled_ids {
                     engine.execution_model.on_cancel(&id);
+                    if let Some(cancelled_order) = engine
+                        .state
+                        .order_manager
+                        .cancel_active_order(&id, engine.clock.timestamp().unwrap_or(0))
+                    {
+                        let _ = engine
+                            .event_manager
+                            .send(Event::ExecutionReport(cancelled_order, None));
+                    }
                 }
                 for order in new_orders {
                     let _ = engine.event_manager.send(Event::OrderRequest(order));

--- a/tests/test_partial_filled_status.py
+++ b/tests/test_partial_filled_status.py
@@ -67,3 +67,152 @@ def test_partial_filled_status_and_open_orders_visibility() -> None:
     order = orders_df.iloc[0]
     assert order["status"] == "partiallyfilled"
     assert 0.0 < order["filled_quantity"] < order["quantity"]
+
+
+class CancelOpenOrderStrategy(Strategy):
+    """Strategy for verifying cancelled orders disappear from open orders."""
+
+    def __init__(self) -> None:
+        """Initialize counters for open-order visibility checks."""
+        super().__init__()
+        self.bar_count = 0
+        self.open_order_counts: list[int] = []
+        self.open_order_statuses: list[list[OrderStatus]] = []
+        self.open_order_counts_after_cancel: list[int] = []
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit then cancel a resting limit order across consecutive bars."""
+        self.bar_count += 1
+        open_orders = self.get_open_orders(bar.symbol)
+        self.open_order_counts.append(len(open_orders))
+        self.open_order_statuses.append([o.status for o in open_orders])
+
+        if self.bar_count == 1:
+            self.buy(bar.symbol, 100, price=9.0)
+        elif self.bar_count == 2:
+            self.cancel_all_orders(bar.symbol)
+            self.open_order_counts_after_cancel.append(
+                len(self.get_open_orders(bar.symbol))
+            )
+
+
+def test_cancelled_order_is_removed_from_open_orders_and_results() -> None:
+    """Cancelled pending order should disappear and end as cancelled."""
+    data = []
+    for i in range(4):
+        data.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2023-01-0{i + 1} 10:00:00").value,
+                open=10.0,
+                high=10.0,
+                low=10.0,
+                close=10.0,
+                volume=100.0,
+                symbol="TEST",
+            )
+        )
+
+    result = run_backtest(
+        data=data,
+        strategy=CancelOpenOrderStrategy,
+        symbols="TEST",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        min_commission=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    strategy = result.strategy
+    assert strategy is not None
+    assert strategy.open_order_counts[:4] == [0, 1, 0, 0]
+    assert strategy.open_order_counts_after_cancel == [0]
+    assert strategy.open_order_statuses[1] == [OrderStatus.New]
+    assert strategy.open_order_statuses[2] == []
+
+    orders_df = result.orders_df
+    assert len(orders_df) == 1
+    order = orders_df.iloc[0]
+    assert order["status"] == "cancelled"
+    assert order["filled_quantity"] == 0.0
+
+
+class TimerCancelOpenOrderStrategy(Strategy):
+    """Strategy for verifying timer-driven cancel_all_orders behavior."""
+
+    def __init__(self) -> None:
+        """Initialize timer and bar-side open-order counters."""
+        super().__init__()
+        self.timer_open_before_cancel: list[int] = []
+        self.timer_open_after_cancel: list[int] = []
+        self.bar_open_counts: list[int] = []
+
+    def on_start(self) -> None:
+        """Schedule a prepare-next-day style timer between two bars."""
+        self.schedule(
+            pd.Timestamp("2023-01-02 10:00:01", tz="Asia/Shanghai"),
+            "prepare_next_day",
+        )
+
+    def on_bar(self, bar: Bar) -> None:
+        """Place a resting limit order and track bar-side open-order counts."""
+        self.bar_open_counts.append(len(self.get_open_orders(bar.symbol)))
+        if len(self.bar_open_counts) == 1:
+            self.buy(bar.symbol, 100, price=9.0)
+
+    def on_timer(self, payload: str) -> None:
+        """Cancel all open orders and verify immediate timer-side visibility."""
+        if payload != "prepare_next_day" or self.current_bar is None:
+            return
+        self.timer_open_before_cancel.append(
+            len(self.get_open_orders(self.current_bar.symbol))
+        )
+        self.cancel_all_orders(self.current_bar.symbol)
+        self.timer_open_after_cancel.append(
+            len(self.get_open_orders(self.current_bar.symbol))
+        )
+
+
+def test_timer_prepare_next_day_cancel_updates_open_orders_immediately() -> None:
+    """Timer-driven cancel should hide open orders immediately and persist."""
+    data = []
+    for i in range(4):
+        data.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2023-01-0{i + 1} 10:00:00").value,
+                open=10.0,
+                high=10.0,
+                low=10.0,
+                close=10.0,
+                volume=100.0,
+                symbol="TEST",
+            )
+        )
+
+    result = run_backtest(
+        data=data,
+        strategy=TimerCancelOpenOrderStrategy,
+        symbols="TEST",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        min_commission=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    strategy = result.strategy
+    assert strategy is not None
+    assert strategy.bar_open_counts[0] == 0
+    assert strategy.bar_open_counts[1:] == [0, 0, 0]
+    assert strategy.timer_open_before_cancel == [1]
+    assert strategy.timer_open_after_cancel == [0]
+
+    orders_df = result.orders_df
+    assert len(orders_df) == 1
+    order = orders_df.iloc[0]
+    assert order["status"] == "cancelled"
+    assert order["filled_quantity"] == 0.0


### PR DESCRIPTION
确保在策略上下文和Python API层中，已取消的订单立即从get_open_orders中移除。 在Rust端，当执行取消操作时，将订单状态更新为已取消并发送执行报告。
在Python端，维护待取消订单ID集合，并在查询时过滤掉这些订单。
添加测试以验证在普通bar驱动和timer驱动场景下，取消订单后open_orders列表的正确性。