### PR TITLE
fix(backtest): 修复精确交易日边界钩子触发时序问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.23"
+version = "0.2.24"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -56,6 +56,9 @@ from ..strategy import (
     StrategyRuntimeConfig,
 )
 from ..strategy_framework_hooks import (
+    collect_boundary_timer_entries as _collect_boundary_timer_entries_impl,
+)
+from ..strategy_framework_hooks import (
     collect_pre_open_timer_entries as _collect_pre_open_timer_entries_impl,
 )
 from ..strategy_loader import resolve_strategy_input
@@ -141,6 +144,29 @@ def _prime_framework_pre_open_timers(
         entries = _collect_pre_open_timer_entries_impl(current_strategy)
         if entries:
             current_strategy._framework_pre_open_timers_registered = True
+        for timestamp_ns, payload in entries:
+            unique_timers[payload] = int(timestamp_ns)
+
+    for payload, timestamp_ns in sorted(
+        unique_timers.items(),
+        key=lambda item: (int(item[1]), item[0]),
+    ):
+        add_timer(timestamp_ns, payload)
+
+
+def _prime_framework_boundary_timers(
+    strategies: Sequence[Strategy], engine: Any
+) -> None:
+    """Prime global boundary timers before the event loop starts."""
+    add_timer = getattr(engine, "add_timer", None)
+    if not callable(add_timer):
+        return
+
+    unique_timers: dict[str, int] = {}
+    for current_strategy in strategies:
+        entries = _collect_boundary_timer_entries_impl(current_strategy)
+        if entries:
+            current_strategy._framework_boundary_timers_registered = True
         for timestamp_ns, payload in entries:
             unique_timers[payload] = int(timestamp_ns)
 
@@ -2924,6 +2950,7 @@ def run_backtest(
     cast(Any, engine).active_start_time_ns = active_start_time_ns
     for current_strategy in all_strategy_instances:
         setattr(current_strategy, "_engine", engine)
+    _prime_framework_boundary_timers(all_strategy_instances, engine)
     _prime_framework_pre_open_timers(all_strategy_instances, engine)
     if analyzer_manager.plugins:
         try:
@@ -4773,6 +4800,7 @@ def run_warm_start(
             stream_error_mode,
             stream_mode,
         )
+    _prime_framework_boundary_timers(all_strategy_instances, engine)
     _prime_framework_pre_open_timers(all_strategy_instances, engine)
 
     if hasattr(strategy_instance, "_on_start_internal"):

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -34,6 +34,14 @@ def _runtime_option(strategy: Any, name: str) -> Any:
     return value
 
 
+def _use_precise_day_boundary_hooks(strategy: Any) -> bool:
+    """Return whether precise boundary timers should own daily hook dispatch."""
+    if not bool(_runtime_option(strategy, "enable_precise_day_boundary_hooks")):
+        return False
+    bounds = getattr(strategy, "_trading_day_bounds", None)
+    return bool(bounds)
+
+
 def _is_normal_session(session: Any) -> bool:
     normal = getattr(TradingSession, "Normal", None)
     if normal is not None:
@@ -96,6 +104,28 @@ def collect_pre_open_timer_entries(strategy: Any) -> List[Tuple[int, str]]:
         if start_ns <= 0:
             continue
         entries.append((start_ns, f"__framework_pre_open__|{day_key}|{start_ns}"))
+    return entries
+
+
+def collect_boundary_timer_entries(strategy: Any) -> List[Tuple[int, str]]:
+    """Collect global framework boundary timers for all trading days."""
+    if not _use_precise_day_boundary_hooks(strategy):
+        return []
+
+    bounds = getattr(strategy, "_trading_day_bounds", None)
+    if not bounds:
+        return []
+
+    entries: List[Tuple[int, str]] = []
+    for day_key, day_bounds in bounds.items():
+        if not isinstance(day_bounds, (list, tuple)) or len(day_bounds) != 2:
+            continue
+        start_ns = int(day_bounds[0])
+        end_ns = int(day_bounds[1])
+        if start_ns > 0:
+            entries.append((start_ns, f"__framework_boundary__|before|{day_key}"))
+        if end_ns > 0:
+            entries.append((end_ns + 1, f"__framework_boundary__|after|{day_key}"))
     return entries
 
 
@@ -170,7 +200,12 @@ def dispatch_time_hooks(strategy: Any) -> None:
     ts = pd.to_datetime(current_time, unit="ns", utc=True).tz_convert(strategy.timezone)
     current_date = ts.date()
     current_session = getattr(strategy.ctx, "session", None)
-    if getattr(strategy, "_framework_daily_rebalance_done_date", None) != current_date:
+    use_precise_boundaries = _use_precise_day_boundary_hooks(strategy)
+    if (
+        not use_precise_boundaries
+        and getattr(strategy, "_framework_daily_rebalance_done_date", None)
+        != current_date
+    ):
         _dispatch_daily_rebalance_if_needed(strategy, current_date, current_time)
 
     last_date = getattr(strategy, "_framework_last_local_date", None)
@@ -178,7 +213,8 @@ def dispatch_time_hooks(strategy: Any) -> None:
     after_done_date = getattr(strategy, "_framework_after_trading_done_date", None)
 
     if (
-        last_date is not None
+        not use_precise_boundaries
+        and last_date is not None
         and current_date != last_date
         and before_done_date == last_date
         and after_done_date != last_date
@@ -212,7 +248,8 @@ def dispatch_time_hooks(strategy: Any) -> None:
             )
 
     if (
-        _is_normal_session(current_session)
+        not use_precise_boundaries
+        and _is_normal_session(current_session)
         and getattr(strategy, "_framework_before_trading_done_date", None)
         != current_date
     ):
@@ -226,7 +263,8 @@ def dispatch_time_hooks(strategy: Any) -> None:
         strategy._framework_before_trading_done_date = current_date
 
     if (
-        not _is_normal_session(current_session)
+        not use_precise_boundaries
+        and not _is_normal_session(current_session)
         and getattr(strategy, "_framework_before_trading_done_date", None)
         == current_date
         and getattr(strategy, "_framework_after_trading_done_date", None)
@@ -272,25 +310,13 @@ def register_boundary_timers(strategy: Any) -> None:
     """注册交易日边界定时器，用于精确触发 on_before/on_after_trading."""
     if strategy.ctx is None:
         return
-    if not bool(_runtime_option(strategy, "enable_precise_day_boundary_hooks")):
+    if not _use_precise_day_boundary_hooks(strategy):
         return
     if getattr(strategy, "_framework_boundary_timers_registered", False):
         return
 
-    bounds = getattr(strategy, "_trading_day_bounds", None)
-    if not bounds:
-        strategy._framework_boundary_timers_registered = True
-        return
-
-    for day_key, day_bounds in bounds.items():
-        if not isinstance(day_bounds, (list, tuple)) or len(day_bounds) != 2:
-            continue
-        start_ns = int(day_bounds[0])
-        end_ns = int(day_bounds[1])
-        if start_ns > 0:
-            strategy.ctx.schedule(start_ns, f"__framework_boundary__|before|{day_key}")
-        if end_ns > 0:
-            strategy.ctx.schedule(end_ns + 1, f"__framework_boundary__|after|{day_key}")
+    for trigger_ts, payload in collect_boundary_timer_entries(strategy):
+        strategy.ctx.schedule(trigger_ts, payload)
 
     strategy._framework_boundary_timers_registered = True
 
@@ -325,6 +351,16 @@ def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
                 payload={"trading_date": day, "timestamp": current_time},
             )
             strategy._framework_before_trading_done_date = day
+        if getattr(strategy, "_framework_daily_rebalance_done_date", None) != day:
+            call_user_callback(
+                strategy,
+                "on_daily_rebalance",
+                day,
+                current_time,
+                payload={"trading_date": day, "timestamp": current_time},
+            )
+            strategy._framework_daily_rebalance_done_date = day
+            strategy._framework_daily_rebalance_pending_date = None
         return True
 
     if phase == "after":

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -28,10 +28,14 @@ from akquant.akquant import (
     TimeInForce,
 )
 from akquant.backtest import FunctionalStrategy
-from akquant.backtest.engine import _prime_framework_pre_open_timers
+from akquant.backtest.engine import (
+    _prime_framework_boundary_timers,
+    _prime_framework_pre_open_timers,
+)
 from akquant.config import RiskConfig
 from akquant.strategy import Strategy, StrategyRuntimeConfig
 from akquant.strategy_framework_hooks import (
+    collect_boundary_timer_entries,
     collect_pre_open_timer_entries,
     dispatch_pre_open_timer,
 )
@@ -3677,6 +3681,113 @@ def test_boundary_timers_register_and_drive_day_hooks() -> None:
     ctx.current_time = end_ts + 1
     strategy._on_timer_event("__framework_boundary__|after|2023-01-03", ctx)
     assert any(e.startswith("after:2023-01-03") for e in strategy.events)
+
+
+def test_collect_boundary_timers_and_prime_globally_once() -> None:
+    """Boundary timers should be deduplicated before the event loop starts."""
+    start_ts = pd.Timestamp("2023-01-03 09:30:00", tz="Asia/Shanghai").value
+    end_ts = pd.Timestamp("2023-01-03 15:00:00", tz="Asia/Shanghai").value
+    strategy_a = FrameworkHooksStrategy()
+    strategy_b = FrameworkHooksStrategy()
+    strategy_a.enable_precise_day_boundary_hooks = True
+    strategy_b.enable_precise_day_boundary_hooks = True
+    strategy_a._trading_day_bounds = {"2023-01-03": (start_ts, end_ts)}
+    strategy_b._trading_day_bounds = {"2023-01-03": (start_ts, end_ts)}
+
+    entries = collect_boundary_timer_entries(strategy_a)
+    assert entries == [
+        (start_ts, "__framework_boundary__|before|2023-01-03"),
+        (end_ts + 1, "__framework_boundary__|after|2023-01-03"),
+    ]
+
+    fake_engine = SimpleNamespace(add_timer=MagicMock())
+    _prime_framework_boundary_timers([strategy_a, strategy_b], fake_engine)
+
+    scheduled = [call.args for call in fake_engine.add_timer.call_args_list]
+    assert scheduled == [
+        (start_ts, "__framework_boundary__|before|2023-01-03"),
+        (end_ts + 1, "__framework_boundary__|after|2023-01-03"),
+    ]
+
+
+def test_precise_boundary_hooks_delay_after_trading_until_day_end() -> None:
+    """Precise boundary hooks should not emit after_trading during same-day timers."""
+
+    class PreciseBoundaryRegressionStrategy(Strategy):
+        def __init__(self) -> None:
+            self.enable_precise_day_boundary_hooks = True
+            self.events: list[tuple[str, object, int]] = []
+
+        def on_start(self) -> None:
+            self.subscribe("HOOKS_DEMO")
+
+        def on_before_trading(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("before", trading_date, timestamp))
+
+        def on_daily_rebalance(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("rebalance", trading_date, timestamp))
+
+        def on_after_trading(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("after", trading_date, timestamp))
+
+        def on_bar(self, bar: Bar) -> None:
+            self.events.append(("bar", bar.symbol, int(bar.timestamp)))
+
+    day1_open = pd.Timestamp("2023-01-03 09:30:00", tz="Asia/Shanghai").value
+    day1_mid = pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai").value
+    day1_close = pd.Timestamp("2023-01-03 15:00:00", tz="Asia/Shanghai").value
+    day2_open = pd.Timestamp("2023-01-04 09:30:00", tz="Asia/Shanghai").value
+    day2_mid = pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai").value
+    day2_close = pd.Timestamp("2023-01-04 15:00:00", tz="Asia/Shanghai").value
+
+    rows = [
+        (day1_open, 10.0),
+        (day1_mid, 10.2),
+        (day1_close, 10.5),
+        (day2_open, 10.8),
+        (day2_mid, 10.0),
+        (day2_close, 10.6),
+    ]
+    bars = [
+        Bar(
+            timestamp=timestamp,
+            open=close,
+            high=close + 0.2,
+            low=close - 0.2,
+            close=close,
+            volume=1000.0,
+            symbol="HOOKS_DEMO",
+        )
+        for timestamp, close in rows
+    ]
+
+    strategy = PreciseBoundaryRegressionStrategy()
+    run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbols=["HOOKS_DEMO"],
+        initial_cash=1000.0,
+        show_progress=False,
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+    )
+
+    day1_before = ("before", pd.Timestamp("2023-01-03").date(), day1_open)
+    day1_rebalance = ("rebalance", pd.Timestamp("2023-01-03").date(), day1_open)
+    day1_last_bar = ("bar", "HOOKS_DEMO", day1_close)
+    day1_after = ("after", pd.Timestamp("2023-01-03").date(), day1_close + 1)
+
+    assert day1_before in strategy.events
+    assert day1_rebalance in strategy.events
+    assert day1_last_bar in strategy.events
+    assert day1_after in strategy.events
+    assert strategy.events.index(day1_before) < strategy.events.index(day1_last_bar)
+    assert strategy.events.index(day1_rebalance) < strategy.events.index(day1_after)
+    assert strategy.events.index(day1_last_bar) < strategy.events.index(day1_after)
+    assert (
+        "after",
+        pd.Timestamp("2023-01-03").date(),
+        day1_open + 1,
+    ) not in strategy.events
 
 
 def test_collect_pre_open_timers_and_prime_globally_once() -> None:


### PR DESCRIPTION
确保启用 enable_precise_day_boundary_hooks 时，on_daily_rebalance 在 on_before_trading 后立即触发，且 on_after_trading 仅在交易日结束后触发。重构边界定时器收集逻辑，避免重复注册，并更新版本号至 0.2.24。