### PR TITLE
docs: 澄清 MiniQMT/PTrade 适配器状态与 A 股业务边界

### DIFF
--- a/docs/zh/advanced/broker_capability_matrix.md
+++ b/docs/zh/advanced/broker_capability_matrix.md
@@ -10,6 +10,13 @@
 - `tif`: 支持的 TimeInForce 集合
 - `notes`: 语义差异或限制
 
+## 重要说明
+
+- 本页的能力矩阵用于描述统一接口层的目标形态与当前适配状态，不等同于“对应 broker 已完成生产级实盘接入”。
+- 对于内置 `MiniQMT` / `PTrade`，当前仓库中的 trader gateway 仍以占位适配和联调骨架为主；若要用于真实 A 股交易，通常仍需补齐券商专有字段、订单回报映射和账户/持仓同步逻辑。
+- 文档中出现的“集合竞价/盘前”更多指框架侧的时序与成交语义钩子，不应直接理解为已支持交易所或券商柜台的“集合竞价专用委托类型”。
+- 新股/新债打新、ETF 申赎等券商专有业务，不在当前内置统一下单接口的默认承诺范围内。
+
 ## 能力矩阵（v0）
 
 | Broker | market_data | order_entry | cancel | execution_report | account | tif | notes |
@@ -17,9 +24,9 @@
 | IB | Tick/Bar | Market/Limit/Stop/StopLimit | Yes | Yes | Yes | DAY/GTC/IOC | 首批优先 |
 | Oanda | Tick/Bar | Market/Limit/Stop | Yes | Yes | Yes | GTC/GTD/FOK/IOC | FX/CFD 语义 |
 | CCXT | Tick/Bar(交易所相关) | Market/Limit(主) | Yes | Yes | Yes | 交易所相关 | 需按交易所分层 |
-| CTP | Tick/Bar | Market/Limit/Stop(经映射) | Yes | Yes | Yes | 交易所相关 | 已有本地适配 |
-| MiniQMT | Tick/Bar | Market/Limit | Yes | Yes | Yes | DAY/GTC | 已有本地适配 |
-| PTrade | Bar(占位) | Market/Limit(占位) | Yes | 部分 | 部分 | DAY | 需增强 |
+| CTP | Tick/Bar | Market/Limit/Stop(经映射) | Yes | Yes | Yes | 交易所相关 | 已有本地适配，当前更适合作为已落地的内置实盘链路参考 |
+| MiniQMT | Tick/Bar(占位) | Market/Limit(占位) | 占位 | 占位 | 占位 | DAY/GTC(目标形态) | 当前仓库以内存/联调骨架为主，不应视为已完成生产级 A 股实盘适配 |
+| PTrade | Bar(占位) | Market/Limit(占位) | 占位 | 占位 | 占位 | DAY(目标形态) | 当前仓库以内存/联调骨架为主，不应视为已完成生产级 A 股实盘适配 |
 
 ## 统一错误规范
 
@@ -35,6 +42,12 @@
 - 下单后能收到状态更新与成交回报。
 - 撤单可追踪到最终状态。
 - 账户与持仓查询返回非空结构。
+
+## A 股专有业务边界
+
+- 当前内置统一下单接口主要覆盖通用报单/撤单语义。
+- A 股“集合竞价专用价格类型/撤单时窗控制”是否可用，取决于具体券商柜台适配是否已实现，而不是仅由 `on_pre_open` 或 `submit_order(...)` 决定。
+- 新股/新债打新不属于当前内置 broker 的现成能力；如有需求，建议通过自定义 broker 注册机制补齐券商专有下单字段与业务路由。
 
 ## 关联代码入口
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -53,7 +53,7 @@
 | `on_session_start` | 会话切换开始时 | 日盘/夜盘切换、session 级状态重置 | `examples/50_framework_hooks_demo.py` |
 | `on_session_end` | 会话切换结束时 | 收盘后清理、session 结束打点 | `examples/50_framework_hooks_demo.py` |
 | `on_before_trading` | 本地交易日首次进入 `Normal` 会话 | 盘前检查、生成交易日级信号 | `examples/50_framework_hooks_demo.py` |
-| `on_pre_open` | 每个交易日首个常规行情事件前，由框架定时器抢先触发 | 集合竞价/盘前信号，使用默认 next-open 语义下单 | `examples/52_pre_open_demo.py` |
+| `on_pre_open` | 每个交易日首个常规行情事件前，由框架定时器抢先触发 | 盘前信号与“本次 open 成交”语义钩子；可用于表达集合竞价前的最后决策点，但不等同于券商柜台已支持集合竞价专用委托 | `examples/52_pre_open_demo.py` |
 | `on_daily_rebalance` | 每个交易日最多一次，与 `on_before_trading` 同阶段 | 横截面选股、统一调仓 | `examples/strategies/05_stock_momentum_rotation_timer.py` |
 | `on_after_trading` | 离开 `Normal` 会话时，必要时下一事件补发 | 日终统计、收盘后清理与归档 | `examples/50_framework_hooks_demo.py` |
 | `on_portfolio_update` | 账户快照变化时增量触发 | 监控现金/权益变化、推送 UI 或告警 | `examples/50_framework_hooks_demo.py` |
@@ -85,6 +85,8 @@
 * `on_daily_rebalance` 与 `on_before_trading` 同一阶段触发，每个交易日最多触发一次。
 * `on_after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `on_after_trading`。
 * `on_pre_open` 内若直接调用 `buy/sell/order_target_*` 且未显式传 `fill_policy`，框架会自动解析为 `price_basis=open, bar_offset=1, temporal=same_cycle`。
+* 这里表达的是框架侧“盘前决策，本次 open 成交”的时序语义，不等同于交易所或券商柜台已经实现了集合竞价专用报单、撤单窗口控制或专有价格类型。
+* 新股/新债打新不属于 `on_pre_open` 或当前统一 `submit_order(...)` 的默认承诺范围；若要支持，通常需要补齐 broker 专有字段与业务路由。
 * 若需要更精确的交易日边界触发，可在策略中设置 `self.enable_precise_day_boundary_hooks = True`。
 * `on_portfolio_update` 采用增量触发：初始化时触发一次，后续仅在订单/成交或持仓相关价格变化时触发。
 * 可通过 `self.portfolio_update_eps` 过滤微小资产波动（默认 `0.0`，即不过滤）。

--- a/docs/zh/textbook/15_live_trading.md
+++ b/docs/zh/textbook/15_live_trading.md
@@ -37,10 +37,17 @@ python examples/textbook/ch15_strategy_loader.py
 `AKQuant` 通过适配器模式支持多种柜台接口：
 
 *   **CTP (China Trading Platform)**：期货市场标准接口，支持行情与交易链路。
-*   **MiniQMT**：面向本地 A 股交易生态的适配接口。
-*   **PTrade**：可接入券商量化终端的适配接口。
+*   **MiniQMT**：面向本地 A 股交易生态的适配接口入口；当前仓库内置实现更偏向占位骨架与联调层，不应直接理解为已完成生产级实盘适配。
+*   **PTrade**：可接入券商量化终端的适配接口入口；当前仓库内置实现更偏向占位骨架与联调层，不应直接理解为已完成生产级实盘适配。
 
 在实盘模式下，`DataFeed` 切换为实时行情源，交易执行由对应 broker gateway 负责。
+
+需要特别区分两层含义：
+
+1. `AKQuant` 提供的是统一交易框架与 adapter 接口；
+2. 某个 broker 是否真正支持 A 股集合竞价专用委托、新股/新债打新、券商特定价格类型与业务代码，取决于该 broker adapter 是否已经补齐对应柜台语义。
+
+因此，当前内置 `MiniQMT/PTrade` 不应被视为“开箱即用支持 A 股集合竞价与打新”的官方承诺；这类场景通常仍需通过自定义 broker 或增强现有 adapter 来落地。
 
 CTP 交易链路支持 `execution_semantics_mode`：
 


### PR DESCRIPTION
更新中文文档，明确当前内置 MiniQMT/PTrade 适配器主要为占位骨架与联调层，不应被视为已完成生产级实盘适配。澄清框架时序语义（如 on_pre_open）与券商柜台实际能力（如集合竞价、打新）的边界，避免用户误解。