### PR TITLE
fix(execution,strategy): 修复同周期跨标的订单资金使用与执行顺序问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.27"
+version = "0.2.28"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -33,23 +33,6 @@ def _is_before_active_start(strategy: Any, timestamp: int) -> bool:
     return active_start_time is not None and timestamp < int(active_start_time)
 
 
-def _flush_deferred_target_value_orders(strategy: Any, event_symbol: str) -> None:
-    deferred_orders = getattr(strategy, "_deferred_target_value_orders", None)
-    if not deferred_orders:
-        return
-    remaining_orders = []
-    from .strategy_trading_api import order_target_value
-
-    for symbol, target_value, price, kwargs in deferred_orders:
-        if symbol == event_symbol:
-            order_target_value(strategy, target_value, symbol, price, **kwargs)
-        else:
-            remaining_orders.append((symbol, target_value, price, kwargs))
-    setattr(strategy, "_deferred_target_value_orders", remaining_orders)
-    strategy._check_order_events()
-    check_expiry_events(strategy)
-
-
 def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     """引擎调用的 Bar 回调 (Internal)."""
     ensure_framework_state(strategy)
@@ -97,7 +80,6 @@ def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
         mark_portfolio_dirty(strategy)
     dispatch_time_hooks(strategy)
     dispatch_portfolio_update(strategy)
-    _flush_deferred_target_value_orders(strategy, bar.symbol)
 
     if strategy._bar_count < strategy.warmup_period:
         return
@@ -155,7 +137,6 @@ def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
         mark_portfolio_dirty(strategy)
     dispatch_time_hooks(strategy)
     dispatch_portfolio_update(strategy)
-    _flush_deferred_target_value_orders(strategy, tick.symbol)
     call_user_callback(strategy, "on_tick", tick, payload=tick)
 
 

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -1527,26 +1527,6 @@ def order_target_weights(
 
     sell_legs = [item for item in planned if item[2] < 0]
     buy_legs = [item for item in planned if item[2] >= 0]
-    effective_fill_policy = _resolve_effective_order_fill_policy(
-        strategy,
-        cast(Optional[OrderFillPolicy], kwargs.get("fill_policy")),
-    )
-    if effective_fill_policy is None:
-        stored_fill_policy = cast(
-            Optional[OrderFillPolicy], getattr(strategy, "_default_fill_policy", None)
-        )
-        if stored_fill_policy is not None:
-            effective_fill_policy = dict(stored_fill_policy)
-    fill_price_basis, fill_bar_offset, fill_temporal = _normalize_order_fill_policy(
-        effective_fill_policy
-    )
-    defer_buy_legs = (
-        sell_legs
-        and buy_legs
-        and fill_price_basis == "close"
-        and fill_bar_offset == 0
-        and fill_temporal == "same_cycle"
-    )
 
     for symbol, target_value, _ in sorted(
         sell_legs,
@@ -1560,14 +1540,6 @@ def order_target_weights(
         key=lambda item: (-float(item[2]), str(item[0])),
     ):
         leg_price = price_map.get(symbol) if price_map else None
-        if defer_buy_legs:
-            deferred_orders = cast(
-                list[tuple[str, float, Optional[float], dict[str, Any]]],
-                getattr(strategy, "_deferred_target_value_orders", []),
-            )
-            deferred_orders.append((symbol, target_value, leg_price, dict(kwargs)))
-            setattr(strategy, "_deferred_target_value_orders", deferred_orders)
-            continue
         order_target_value(strategy, target_value, symbol, leg_price, **kwargs)
 
 

--- a/src/execution/mod.rs
+++ b/src/execution/mod.rs
@@ -32,6 +32,11 @@ pub trait ExecutionClient: Send + Sync {
     /// 处理市场事件并返回执行报告
     fn on_event(&mut self, event: &Event, ctx: &EngineContext) -> Vec<Event>;
 
+    /// 在一个时间片结束时补充处理延迟的 same-cycle 订单。
+    fn finalize_timestamp(&mut self, _events: &[Event], _ctx: &EngineContext) -> Vec<Event> {
+        Vec::new()
+    }
+
     /// 设置滑点模型 (仅回测有效)
     fn set_slippage_model(&mut self, _model: Box<dyn SlippageModel>) {}
 

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -6,10 +6,13 @@ use crate::event::Event;
 use crate::execution::matcher::{ExecutionMatcher, MatchContext};
 use crate::execution::slippage::{SlippageModel, ZeroSlippage};
 use crate::execution::{ExecutionClient, crypto, forex, futures, option, stock};
-use crate::model::{AssetType, Order, OrderStatus, TimeInForce, TradingSession};
+use crate::model::{
+    AssetType, ExecutionPolicyCore, Order, OrderStatus, PriceBasis, TemporalPolicy,
+    TimeInForce, TradingSession,
+};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// 模拟交易所执行器 (Simulated Execution Client)
 /// 负责在内存中撮合订单 (回测模式)
@@ -25,6 +28,9 @@ pub struct SimulatedExecutionClient {
     futures_enforce_tick_size: bool,
     futures_enforce_lot_size: bool,
     futures_validation_by_prefix: Vec<(String, Option<bool>, Option<bool>)>,
+    slice_tracking_timestamp: Option<i64>,
+    attempted_same_cycle_order_ids: HashSet<String>,
+    deferred_same_cycle_order_ids: HashSet<String>,
 }
 
 impl SimulatedExecutionClient {
@@ -64,7 +70,422 @@ impl SimulatedExecutionClient {
             futures_enforce_tick_size: true,
             futures_enforce_lot_size: true,
             futures_validation_by_prefix: Vec::new(),
+            slice_tracking_timestamp: None,
+            attempted_same_cycle_order_ids: HashSet::new(),
+            deferred_same_cycle_order_ids: HashSet::new(),
         }
+    }
+
+    fn prepare_slice_tracking(&mut self, timestamp: i64) {
+        if self.slice_tracking_timestamp == Some(timestamp) {
+            return;
+        }
+        self.slice_tracking_timestamp = Some(timestamp);
+        self.attempted_same_cycle_order_ids.clear();
+        self.deferred_same_cycle_order_ids.clear();
+    }
+
+    fn clear_slice_tracking(&mut self) {
+        self.attempted_same_cycle_order_ids.clear();
+        self.deferred_same_cycle_order_ids.clear();
+        self.slice_tracking_timestamp = None;
+    }
+
+    fn event_symbol(event: &Event) -> Option<&str> {
+        match event {
+            Event::Bar(bar) => Some(bar.symbol.as_str()),
+            Event::Tick(tick) => Some(tick.symbol.as_str()),
+            _ => None,
+        }
+    }
+
+    fn is_order_active(order: &Order) -> bool {
+        !matches!(
+            order.status,
+            OrderStatus::Cancelled
+                | OrderStatus::Filled
+                | OrderStatus::Rejected
+                | OrderStatus::Expired
+        )
+    }
+
+    fn effective_policy(order: &Order, ctx: &crate::context::EngineContext) -> ExecutionPolicyCore {
+        order.fill_policy_override.unwrap_or(ctx.execution_policy_core)
+    }
+
+    fn is_same_cycle_close_policy(policy: ExecutionPolicyCore) -> bool {
+        policy.price_basis == PriceBasis::Close
+            && policy.bar_offset == 0
+            && matches!(policy.temporal, TemporalPolicy::SameCycle)
+    }
+
+    fn is_same_cycle_close_order(&self, order: &Order, ctx: &crate::context::EngineContext) -> bool {
+        Self::is_same_cycle_close_policy(Self::effective_policy(order, ctx))
+    }
+
+    fn has_cross_symbol_reduce_pending(
+        &self,
+        event: &Event,
+        ctx: &crate::context::EngineContext,
+    ) -> bool {
+        let Some(event_symbol) = Self::event_symbol(event) else {
+            return false;
+        };
+        self.orders.values().any(|candidate| {
+            Self::is_order_active(candidate)
+                && candidate.created_at == ctx.current_time
+                && candidate.symbol != event_symbol
+                && self.is_same_cycle_close_order(candidate, ctx)
+                && crate::model::is_reduce_first_order(candidate.side, candidate.position_effect)
+        })
+    }
+
+    fn should_defer_order_on_current_event(
+        &self,
+        order: &Order,
+        event: &Event,
+        ctx: &crate::context::EngineContext,
+    ) -> bool {
+        if order.created_at != ctx.current_time || !self.is_same_cycle_close_order(order, ctx) {
+            return false;
+        }
+        if crate::model::is_reduce_first_order(order.side, order.position_effect) {
+            return false;
+        }
+        Self::event_symbol(event)
+            .map(|symbol| order.symbol == symbol)
+            .unwrap_or(false)
+            && self.has_cross_symbol_reduce_pending(event, ctx)
+    }
+
+    fn should_finalize_order(
+        &self,
+        order: &Order,
+        ctx: &crate::context::EngineContext,
+    ) -> bool {
+        order.created_at == ctx.current_time
+            && Self::is_order_active(order)
+            && self.is_same_cycle_close_order(order, ctx)
+            && (!self.attempted_same_cycle_order_ids.contains(&order.id)
+                || self.deferred_same_cycle_order_ids.contains(&order.id))
+    }
+
+    fn sorted_queue(&self) -> Vec<String> {
+        let mut queue: Vec<String> = self.order_queue.clone();
+        queue.sort_by_key(|order_id| {
+            self.orders
+                .get(order_id)
+                .map(|order| match order.side {
+                    crate::model::OrderSide::Sell => 0_u8,
+                    crate::model::OrderSide::Buy => 1_u8,
+                })
+                .unwrap_or(2_u8)
+        });
+        queue
+    }
+
+    fn sync_order_from_report(&mut self, report: &Event) {
+        if let Event::ExecutionReport(updated_order, _) = report
+            && let Some(existing) = self.orders.get_mut(&updated_order.id)
+        {
+            existing.status = updated_order.status;
+            existing.filled_quantity = updated_order.filled_quantity;
+            existing.average_filled_price = updated_order.average_filled_price;
+            existing.commission = updated_order.commission;
+            existing.updated_at = updated_order.updated_at;
+        }
+    }
+
+    fn cleanup_finished_orders(&mut self) {
+        let mut finished_ids = Vec::new();
+        for id in &self.order_queue {
+            if let Some(order) = self.orders.get(id) {
+                if !Self::is_order_active(order) {
+                    finished_ids.push(id.clone());
+                }
+            } else {
+                finished_ids.push(id.clone());
+            }
+        }
+        for id in finished_ids {
+            self.orders.remove(&id);
+        }
+        self.order_queue.retain(|id| self.orders.contains_key(id));
+    }
+
+    fn match_with_events<F>(
+        &mut self,
+        events: &[Event],
+        ctx: &crate::context::EngineContext,
+        mut order_filter: F,
+        defer_cross_symbol_increase: bool,
+    ) -> Vec<Event>
+    where
+        F: FnMut(&Order, &Event) -> bool,
+    {
+        let mut reports = Vec::new();
+        let mut projected_portfolio = ctx.portfolio.clone();
+        let stock_margin_ratio_override = stock_margin_ratio_override(ctx.risk_config);
+        let mut current_free_margin = calculate_free_margin(
+            &projected_portfolio,
+            ctx.last_prices,
+            ctx.instruments,
+            ctx.trade_tracker,
+            ctx.risk_config,
+        );
+
+        for event in events {
+            let queue = self.sorted_queue();
+            for order_id in &queue {
+                let mut synced_report: Option<Event> = None;
+                let Some(order_snapshot) = self.orders.get(order_id).cloned() else {
+                    continue;
+                };
+                if !Self::is_order_active(&order_snapshot) || !order_filter(&order_snapshot, event) {
+                    continue;
+                }
+
+                let defer_current = defer_cross_symbol_increase
+                    && self.should_defer_order_on_current_event(&order_snapshot, event, ctx);
+                let mark_attempted = order_snapshot.created_at == ctx.current_time
+                    && self.is_same_cycle_close_order(&order_snapshot, ctx)
+                    && Self::event_symbol(event)
+                        .map(|symbol| order_snapshot.symbol == symbol)
+                        .unwrap_or(false);
+
+                if defer_current {
+                    self.deferred_same_cycle_order_ids
+                        .insert(order_snapshot.id.clone());
+                    self.attempted_same_cycle_order_ids
+                        .insert(order_snapshot.id.clone());
+                    continue;
+                }
+
+                if mark_attempted {
+                    self.attempted_same_cycle_order_ids
+                        .insert(order_snapshot.id.clone());
+                }
+
+                if let Some(order) = self.orders.get_mut(order_id) {
+                    if let Some(instrument) = ctx.instruments.get(&order.symbol)
+                        && let Some(matcher) = self.matchers.get(&instrument.asset_type)
+                    {
+                        let match_ctx = MatchContext {
+                            event,
+                            instrument,
+                            execution_policy_core: Self::effective_policy(order, ctx),
+                            slippage: self.slippage_model.as_ref(),
+                            volume_limit_pct: self.volume_limit_pct,
+                            bar_index: ctx.bar_index,
+                            last_price: ctx.last_prices.get(&order.symbol).copied(),
+                        };
+                        let report_opt = matcher.match_order(order, &match_ctx);
+                        if let Some(mut report) = report_opt {
+                            let mut replacement_report: Option<Event> = None;
+                            if let Event::ExecutionReport(ref mut report_order, Some(ref mut trade)) =
+                                report
+                            {
+                                let mut prices_for_margin = ctx.last_prices.clone();
+                                prices_for_margin.insert(trade.symbol.clone(), trade.price);
+
+                                let commission = ctx.market_model.calculate_commission(
+                                    instrument,
+                                    trade.side,
+                                    trade.price,
+                                    trade.quantity,
+                                );
+
+                                let base_used_margin = projected_portfolio
+                                    .calculate_used_margin_with_stock_ratio(
+                                        &prices_for_margin,
+                                        ctx.instruments,
+                                        stock_margin_ratio_override,
+                                    );
+                                let mut margin_projection = projected_portfolio.clone();
+                                let current_pos = margin_projection
+                                    .positions
+                                    .get(&trade.symbol)
+                                    .copied()
+                                    .unwrap_or(Decimal::ZERO);
+                                let next_pos = crate::model::project_position_after(
+                                    trade.side,
+                                    trade.position_effect,
+                                    current_pos,
+                                    trade.quantity,
+                                );
+                                margin_projection.adjust_position(
+                                    &trade.symbol,
+                                    next_pos - current_pos,
+                                );
+                                let next_used_margin = margin_projection
+                                    .calculate_used_margin_with_stock_ratio(
+                                        &prices_for_margin,
+                                        ctx.instruments,
+                                        stock_margin_ratio_override,
+                                    );
+                                let margin_required =
+                                    (next_used_margin - base_used_margin).max(Decimal::ZERO);
+                                let total_required = margin_required + commission;
+
+                                if total_required > current_free_margin {
+                                    if report_order.allow_quantity_auto_resize {
+                                        let lot_size = instrument.lot_size();
+                                        let safety_factor = Decimal::from_f64(0.9999)
+                                            .unwrap_or(Decimal::ONE);
+                                        let mut new_qty = if total_required > Decimal::ZERO
+                                            && current_free_margin > Decimal::ZERO
+                                        {
+                                            (trade.quantity
+                                                * current_free_margin
+                                                * safety_factor
+                                                / total_required)
+                                                .floor()
+                                        } else {
+                                            Decimal::ZERO
+                                        };
+                                        if lot_size > Decimal::ZERO {
+                                            new_qty = new_qty - (new_qty % lot_size);
+                                        }
+                                        if new_qty >= trade.quantity && lot_size > Decimal::ZERO {
+                                            new_qty -= lot_size;
+                                        }
+
+                                        while new_qty > Decimal::ZERO {
+                                            let new_comm = ctx.market_model.calculate_commission(
+                                                instrument,
+                                                trade.side,
+                                                trade.price,
+                                                new_qty,
+                                            );
+                                            let mut resized_projection =
+                                                projected_portfolio.clone();
+                                            let current_pos = resized_projection
+                                                .positions
+                                                .get(&trade.symbol)
+                                                .copied()
+                                                .unwrap_or(Decimal::ZERO);
+                                            let next_pos = crate::model::project_position_after(
+                                                trade.side,
+                                                trade.position_effect,
+                                                current_pos,
+                                                new_qty,
+                                            );
+                                            resized_projection.adjust_position(
+                                                &trade.symbol,
+                                                next_pos - current_pos,
+                                            );
+                                            let resized_used_margin = resized_projection
+                                                .calculate_used_margin_with_stock_ratio(
+                                                    &prices_for_margin,
+                                                    ctx.instruments,
+                                                    stock_margin_ratio_override,
+                                                );
+                                            let resized_required = (resized_used_margin
+                                                - base_used_margin)
+                                                .max(Decimal::ZERO);
+                                            if resized_required + new_comm <= current_free_margin {
+                                                break;
+                                            }
+                                            if new_qty >= lot_size && lot_size > Decimal::ZERO {
+                                                new_qty -= lot_size;
+                                            } else {
+                                                new_qty = Decimal::ZERO;
+                                            }
+                                        }
+
+                                        trade.quantity = new_qty;
+                                    } else {
+                                        let mut rejected_order = report_order.clone();
+                                        rejected_order.status = crate::model::OrderStatus::Rejected;
+                                        rejected_order.filled_quantity = Decimal::ZERO;
+                                        rejected_order.average_filled_price = None;
+                                        rejected_order.updated_at = ctx.current_time;
+                                        rejected_order.reject_reason = format!(
+                                            "Risk: Insufficient margin at execution. Required: {total_required}, Available: {current_free_margin}"
+                                        );
+                                        replacement_report =
+                                            Some(Event::ExecutionReport(rejected_order, None));
+                                    }
+                                }
+                            }
+
+                            if let Some(new_report) = replacement_report {
+                                report = new_report;
+                            }
+
+                            if let Event::ExecutionReport(_, Some(ref trade)) = report
+                                && trade.quantity > Decimal::ZERO
+                            {
+                                let mut prices_for_margin = ctx.last_prices.clone();
+                                prices_for_margin.insert(trade.symbol.clone(), trade.price);
+                                let commission = ctx.market_model.calculate_commission(
+                                    instrument,
+                                    trade.side,
+                                    trade.price,
+                                    trade.quantity,
+                                );
+                                projected_portfolio.adjust_cash(-commission);
+                                if is_futures_margin_account(instrument, ctx.risk_config) {
+                                    let realized = estimate_futures_realized_pnl(
+                                        ctx.trade_tracker,
+                                        &trade.symbol,
+                                        trade.side,
+                                        trade.quantity,
+                                        trade.price,
+                                        instrument.multiplier(),
+                                    );
+                                    projected_portfolio.adjust_cash(realized);
+                                } else {
+                                    let cost =
+                                        trade.price * trade.quantity * instrument.multiplier();
+                                    if trade.side == crate::model::OrderSide::Buy {
+                                        projected_portfolio.adjust_cash(-cost);
+                                    } else {
+                                        projected_portfolio.adjust_cash(cost);
+                                    }
+                                }
+                                let current_pos = projected_portfolio
+                                    .positions
+                                    .get(&trade.symbol)
+                                    .copied()
+                                    .unwrap_or(Decimal::ZERO);
+                                let next_pos = crate::model::project_position_after(
+                                    trade.side,
+                                    trade.position_effect,
+                                    current_pos,
+                                    trade.quantity,
+                                );
+                                projected_portfolio
+                                    .adjust_position(&trade.symbol, next_pos - current_pos);
+                                current_free_margin = calculate_free_margin(
+                                    &projected_portfolio,
+                                    &prices_for_margin,
+                                    ctx.instruments,
+                                    ctx.trade_tracker,
+                                    ctx.risk_config,
+                                );
+                            }
+
+                            let keep_report = !matches!(
+                                &report,
+                                Event::ExecutionReport(_, Some(trade))
+                                    if trade.quantity <= Decimal::ZERO
+                            );
+                            if keep_report {
+                                synced_report = Some(report);
+                            }
+                        }
+                    }
+                }
+                if let Some(report) = synced_report {
+                    self.sync_order_from_report(&report);
+                    reports.push(report);
+                }
+            }
+        }
+
+        self.cleanup_finished_orders();
+        reports
     }
 }
 
@@ -147,15 +568,14 @@ impl ExecutionClient for SimulatedExecutionClient {
     }
 
     fn on_event(&mut self, event: &Event, ctx: &crate::context::EngineContext) -> Vec<Event> {
+        self.prepare_slice_tracking(ctx.current_time);
         let mut reports = Vec::new();
 
-        // Skip matching during non-trading sessions
         if ctx.session == TradingSession::Break
             || ctx.session == TradingSession::Closed
             || ctx.session == TradingSession::PreOpen
             || ctx.session == TradingSession::PostClose
         {
-            // Also check for Day orders expiry if Closed
             if ctx.session == TradingSession::Closed {
                 let timestamp = match event {
                     Event::Bar(b) => b.timestamp,
@@ -165,10 +585,7 @@ impl ExecutionClient for SimulatedExecutionClient {
 
                 for order_id in &self.order_queue {
                     if let Some(order) = self.orders.get_mut(order_id)
-                        && order.status != OrderStatus::Cancelled
-                        && order.status != OrderStatus::Filled
-                        && order.status != OrderStatus::Rejected
-                        && order.status != OrderStatus::Expired
+                        && Self::is_order_active(order)
                         && order.time_in_force == TimeInForce::Day
                     {
                         order.status = OrderStatus::Expired;
@@ -176,299 +593,61 @@ impl ExecutionClient for SimulatedExecutionClient {
                         reports.push(Event::ExecutionReport(order.clone(), None));
                     }
                 }
+                self.cleanup_finished_orders();
             }
             return reports;
         }
 
-        // Track available margin for this step (snapshot of portfolio + changes in this loop)
-        let mut projected_portfolio = ctx.portfolio.clone();
-        let stock_margin_ratio_override = stock_margin_ratio_override(ctx.risk_config);
-        let mut current_free_margin = calculate_free_margin(
-            &projected_portfolio,
-            ctx.last_prices,
-            ctx.instruments,
-            ctx.trade_tracker,
-            ctx.risk_config,
-        );
+        self.match_with_events(
+            std::slice::from_ref(event),
+            ctx,
+            |_order, _event| true,
+            true,
+        )
+    }
 
-        let mut queue: Vec<String> = self.order_queue.clone();
-        queue.sort_by_key(|order_id| {
-            self.orders
-                .get(order_id)
-                .map(|order| match order.side {
-                    crate::model::OrderSide::Sell => 0_u8,
-                    crate::model::OrderSide::Buy => 1_u8,
-                })
-                .unwrap_or(2_u8)
+    fn finalize_timestamp(
+        &mut self,
+        events: &[Event],
+        ctx: &crate::context::EngineContext,
+    ) -> Vec<Event> {
+        if events.is_empty() {
+            self.clear_slice_tracking();
+            return Vec::new();
+        }
+        self.prepare_slice_tracking(ctx.current_time);
+        let mut ordered_events: Vec<Event> = events.to_vec();
+        let reduce_symbols: HashSet<String> = self
+            .orders
+            .values()
+            .filter(|order| {
+                Self::is_order_active(order)
+                    && order.created_at == ctx.current_time
+                    && self.is_same_cycle_close_order(order, ctx)
+                    && crate::model::is_reduce_first_order(order.side, order.position_effect)
+            })
+            .map(|order| order.symbol.clone())
+            .collect();
+        ordered_events.sort_by_key(|event| {
+            let symbol = Self::event_symbol(event).unwrap_or_default().to_string();
+            (
+                if reduce_symbols.contains(&symbol) { 0_u8 } else { 1_u8 },
+                symbol,
+            )
         });
-
-        let matchers = &self.matchers;
-
-        for order_id in &queue {
-            if let Some(order) = self.orders.get_mut(order_id) {
-                if order.status == OrderStatus::Cancelled
-                    || order.status == OrderStatus::Filled
-                    || order.status == OrderStatus::Rejected
-                    || order.status == OrderStatus::Expired
-                {
-                    continue;
-                }
-
-                // Find Instrument
-                if let Some(instrument) = ctx.instruments.get(&order.symbol) {
-                    // Dispatch to specific matcher
-                    if let Some(matcher) = matchers.get(&instrument.asset_type) {
-                        let match_ctx = MatchContext {
-                            event,
-                            instrument,
-                            execution_policy_core: order
-                                .fill_policy_override
-                                .unwrap_or(ctx.execution_policy_core),
-                            slippage: self.slippage_model.as_ref(),
-                            volume_limit_pct: self.volume_limit_pct,
-                            bar_index: ctx.bar_index,
-                            last_price: ctx.last_prices.get(&order.symbol).copied(),
-                        };
-                        let report_opt = matcher.match_order(order, &match_ctx);
-
-                        if let Some(mut report) = report_opt {
-                            let mut replacement_report: Option<Event> = None;
-                            if let Event::ExecutionReport(ref mut report_order, Some(ref mut trade)) =
-                                report
-                            {
-                                let mut prices_for_margin = ctx.last_prices.clone();
-                                prices_for_margin.insert(trade.symbol.clone(), trade.price);
-
-                                // Calculate estimated commission
-                                let commission = ctx.market_model.calculate_commission(
-                                    instrument,
-                                    trade.side,
-                                    trade.price,
-                                    trade.quantity,
-                                );
-
-                                let base_used_margin =
-                                    projected_portfolio.calculate_used_margin_with_stock_ratio(
-                                        &prices_for_margin,
-                                        ctx.instruments,
-                                        stock_margin_ratio_override,
-                                    );
-                                let mut margin_projection = projected_portfolio.clone();
-                                let current_pos = margin_projection
-                                    .positions
-                                    .get(&trade.symbol)
-                                    .copied()
-                                    .unwrap_or(Decimal::ZERO);
-                                let next_pos = crate::model::project_position_after(
-                                    trade.side,
-                                    trade.position_effect,
-                                    current_pos,
-                                    trade.quantity,
-                                );
-                                margin_projection
-                                    .adjust_position(&trade.symbol, next_pos - current_pos);
-                                let next_used_margin =
-                                    margin_projection.calculate_used_margin_with_stock_ratio(
-                                        &prices_for_margin,
-                                        ctx.instruments,
-                                        stock_margin_ratio_override,
-                                    );
-                                let margin_required =
-                                    (next_used_margin - base_used_margin).max(Decimal::ZERO);
-                                let total_required = margin_required + commission;
-
-                                if total_required > current_free_margin {
-                                    if report_order.allow_quantity_auto_resize {
-                                        let lot_size = instrument.lot_size();
-                                        let safety_factor = Decimal::from_f64(0.9999)
-                                            .unwrap_or(Decimal::ONE);
-                                        let mut new_qty = if total_required > Decimal::ZERO
-                                            && current_free_margin > Decimal::ZERO
-                                        {
-                                            (trade.quantity
-                                                * current_free_margin
-                                                * safety_factor
-                                                / total_required)
-                                                .floor()
-                                        } else {
-                                            Decimal::ZERO
-                                        };
-                                        if lot_size > Decimal::ZERO {
-                                            new_qty = new_qty - (new_qty % lot_size);
-                                        }
-                                        if new_qty >= trade.quantity && lot_size > Decimal::ZERO {
-                                            new_qty -= lot_size;
-                                        }
-
-                                        while new_qty > Decimal::ZERO {
-                                            let new_comm = ctx.market_model.calculate_commission(
-                                                instrument,
-                                                trade.side,
-                                                trade.price,
-                                                new_qty,
-                                            );
-                                            let mut resized_projection =
-                                                projected_portfolio.clone();
-                                            let current_pos = resized_projection
-                                                .positions
-                                                .get(&trade.symbol)
-                                                .copied()
-                                                .unwrap_or(Decimal::ZERO);
-                                            let next_pos = crate::model::project_position_after(
-                                                trade.side,
-                                                trade.position_effect,
-                                                current_pos,
-                                                new_qty,
-                                            );
-                                            resized_projection.adjust_position(
-                                                &trade.symbol,
-                                                next_pos - current_pos,
-                                            );
-                                            let resized_used_margin = resized_projection
-                                                .calculate_used_margin_with_stock_ratio(
-                                                    &prices_for_margin,
-                                                    ctx.instruments,
-                                                    stock_margin_ratio_override,
-                                                );
-                                            let resized_required = (resized_used_margin
-                                                - base_used_margin)
-                                                .max(Decimal::ZERO);
-                                            if resized_required + new_comm <= current_free_margin {
-                                                break;
-                                            }
-                                            if new_qty >= lot_size && lot_size > Decimal::ZERO {
-                                                new_qty -= lot_size;
-                                            } else {
-                                                new_qty = Decimal::ZERO;
-                                            }
-                                        }
-
-                                        trade.quantity = new_qty;
-                                    } else {
-                                        let mut rejected_order = report_order.clone();
-                                        rejected_order.status = crate::model::OrderStatus::Rejected;
-                                        rejected_order.updated_at = ctx.current_time;
-                                        rejected_order.reject_reason = format!(
-                                            "Risk: Insufficient margin at execution. Required: {total_required}, Available: {current_free_margin}"
-                                        );
-                                        replacement_report =
-                                            Some(Event::ExecutionReport(rejected_order, None));
-                                    }
-                                }
-                            }
-
-                            if let Some(new_report) = replacement_report {
-                                report = new_report;
-                            }
-
-                            if let Event::ExecutionReport(_, Some(ref trade)) = report
-                                && trade.quantity > Decimal::ZERO
-                            {
-                                let mut prices_for_margin = ctx.last_prices.clone();
-                                prices_for_margin.insert(trade.symbol.clone(), trade.price);
-                                let commission = ctx.market_model.calculate_commission(
-                                    instrument,
-                                    trade.side,
-                                    trade.price,
-                                    trade.quantity,
-                                );
-                                projected_portfolio.adjust_cash(-commission);
-                                if is_futures_margin_account(instrument, ctx.risk_config) {
-                                    let realized = estimate_futures_realized_pnl(
-                                        ctx.trade_tracker,
-                                        &trade.symbol,
-                                        trade.side,
-                                        trade.quantity,
-                                        trade.price,
-                                        instrument.multiplier(),
-                                    );
-                                    projected_portfolio.adjust_cash(realized);
-                                } else {
-                                    let cost =
-                                        trade.price * trade.quantity * instrument.multiplier();
-                                    if trade.side == crate::model::OrderSide::Buy {
-                                        projected_portfolio.adjust_cash(-cost);
-                                    } else {
-                                        projected_portfolio.adjust_cash(cost);
-                                    }
-                                }
-                                let current_pos = projected_portfolio
-                                    .positions
-                                    .get(&trade.symbol)
-                                    .copied()
-                                    .unwrap_or(Decimal::ZERO);
-                                let next_pos = crate::model::project_position_after(
-                                    trade.side,
-                                    trade.position_effect,
-                                    current_pos,
-                                    trade.quantity,
-                                );
-                                projected_portfolio
-                                    .adjust_position(&trade.symbol, next_pos - current_pos);
-                                current_free_margin = calculate_free_margin(
-                                    &projected_portfolio,
-                                    &prices_for_margin,
-                                    ctx.instruments,
-                                    ctx.trade_tracker,
-                                    ctx.risk_config,
-                                );
-                            }
-
-                            let mut keep_report = true;
-                            if let Event::ExecutionReport(_, Some(ref trade)) = report
-                                && trade.quantity <= Decimal::ZERO
-                            {
-                                keep_report = false;
-                            }
-
-                            if keep_report {
-                                reports.push(report);
-                            }
-                        }
-                    } else {
-                        // No matcher found for this asset type, skip or log warning?
-                        // For now just skip
-                    }
-                }
-            }
-        }
-
-        // Cleanup filled/cancelled/rejected orders from pending list
-        for report in &reports {
-            if let Event::ExecutionReport(updated_order, _) = report
-                && let Some(existing) = self.orders.get_mut(&updated_order.id)
-            {
-                existing.status = updated_order.status;
-                existing.filled_quantity = updated_order.filled_quantity;
-                existing.average_filled_price = updated_order.average_filled_price;
-                existing.commission = updated_order.commission;
-                existing.updated_at = updated_order.updated_at;
-            }
-        }
-
-        // Clean up completed orders
-        let mut finished_ids = Vec::new();
-        for id in &self.order_queue {
-            if let Some(order) = self.orders.get(id) {
-                if order.status == OrderStatus::Filled
-                    || order.status == OrderStatus::Cancelled
-                    || order.status == OrderStatus::Rejected
-                    || order.status == OrderStatus::Expired
-                {
-                    finished_ids.push(id.clone());
-                }
-            } else {
-                finished_ids.push(id.clone()); // Orphaned
-            }
-        }
-
-        for id in finished_ids {
-            self.orders.remove(&id);
-        }
-
-        // Retain only existing orders in queue
-        self.order_queue.retain(|id| self.orders.contains_key(id));
-
+        let finalize_ids: HashSet<String> = self
+            .orders
+            .values()
+            .filter(|order| self.should_finalize_order(order, ctx))
+            .map(|order| order.id.clone())
+            .collect();
+        let reports = self.match_with_events(
+            &ordered_events,
+            ctx,
+            |order, _event| finalize_ids.contains(&order.id),
+            false,
+        );
+        self.clear_slice_tracking();
         reports
     }
 }

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -4,7 +4,8 @@ use crate::data::FeedAction;
 use crate::engine::Engine;
 use crate::event::Event;
 use crate::model::{
-    Bar, ExecutionPolicyCore, Order, OrderStatus, PriceBasis, TemporalPolicy, TradingSession,
+    Bar, ExecutionPolicyCore, Order, OrderStatus, PriceBasis, TemporalPolicy, Trade,
+    TradingSession,
 };
 use crate::pipeline::processor::{Processor, ProcessorResult};
 use pyo3::prelude::*;
@@ -198,6 +199,153 @@ fn emit_execution_reports_for_current_event(engine: &mut Engine) {
     }
 }
 
+fn flush_accumulated_trades(engine: &mut Engine, trades_to_process: &mut Vec<Trade>) {
+    if trades_to_process.is_empty() {
+        return;
+    }
+    engine.state.order_manager.process_trades(
+        std::mem::take(trades_to_process),
+        &mut engine.state.portfolio,
+        &engine.instruments,
+        &engine.risk_manager.config,
+        engine.market_manager.model.as_ref(),
+        &engine.history_buffer,
+        &engine.last_prices,
+    );
+}
+
+fn apply_execution_report(
+    engine: &mut Engine,
+    py: Python<'_>,
+    order: Order,
+    trade: Option<Trade>,
+    oco_suppressed_fill_order_ids: &mut HashSet<String>,
+    trades_to_process: &mut Vec<Trade>,
+) {
+    if order.status == OrderStatus::Filled && oco_suppressed_fill_order_ids.contains(&order.id) {
+        return;
+    }
+
+    let report_order_id = order.id.clone();
+    let report_status = order.status;
+    let report_updated_at = order.updated_at;
+    engine.state.order_manager.on_execution_report(order);
+    let updated_order = engine
+        .state
+        .order_manager
+        .get_all_orders()
+        .into_iter()
+        .find(|o| o.id == report_order_id);
+    if let Some(order_snapshot) = updated_order {
+        if order_snapshot.status == OrderStatus::Rejected {
+            engine
+                .state
+                .order_manager
+                .current_step_rejected_orders
+                .push(order_snapshot.clone());
+        }
+        let mut order_payload = HashMap::new();
+        order_payload.insert("order_id", order_snapshot.id.clone());
+        order_payload.insert("status", format!("{:?}", order_snapshot.status));
+        order_payload.insert("filled_qty", order_snapshot.filled_quantity.to_string());
+        order_payload.insert("symbol", order_snapshot.symbol.clone());
+        order_payload.insert(
+            "owner_strategy_id",
+            order_snapshot.owner_strategy_id.clone().unwrap_or_default(),
+        );
+        engine.emit_stream_event(
+            py,
+            "order",
+            Some(order_snapshot.symbol.as_str()),
+            "info",
+            order_payload,
+        );
+    }
+
+    if report_status == OrderStatus::Filled {
+        let peer_ids = engine
+            .state
+            .order_manager
+            .consume_oco_peer_cancels_on_fill(&report_order_id);
+        for peer_id in peer_ids {
+            oco_suppressed_fill_order_ids.insert(peer_id.clone());
+            engine.execution_model.on_cancel(&peer_id);
+            let cancelled_order_snapshot = engine
+                .state
+                .order_manager
+                .cancel_active_order(&peer_id, report_updated_at);
+            if let Some(cancelled_order_snapshot) = cancelled_order_snapshot {
+                let mut cancel_payload = HashMap::new();
+                cancel_payload.insert("order_id", cancelled_order_snapshot.id.clone());
+                cancel_payload.insert(
+                    "status",
+                    format!("{:?}", cancelled_order_snapshot.status),
+                );
+                cancel_payload.insert(
+                    "filled_qty",
+                    cancelled_order_snapshot.filled_quantity.to_string(),
+                );
+                cancel_payload.insert("symbol", cancelled_order_snapshot.symbol.clone());
+                cancel_payload.insert(
+                    "owner_strategy_id",
+                    cancelled_order_snapshot
+                        .owner_strategy_id
+                        .clone()
+                        .unwrap_or_default(),
+                );
+                engine.emit_stream_event(
+                    py,
+                    "order",
+                    Some(cancelled_order_snapshot.symbol.as_str()),
+                    "info",
+                    cancel_payload,
+                );
+            }
+        }
+
+        if let Some(filled_order_snapshot) = engine
+            .state
+            .order_manager
+            .get_all_orders()
+            .into_iter()
+            .find(|o| o.id == report_order_id)
+        {
+            let bracket_exit_orders = engine
+                .state
+                .order_manager
+                .consume_bracket_activation_on_fill(&filled_order_snapshot);
+            for bracket_order in bracket_exit_orders {
+                let _ = engine.event_manager.send(Event::OrderRequest(bracket_order));
+            }
+        }
+    }
+
+    if let Some(t) = trade {
+        engine.maybe_reset_risk_budget_usage(t.timestamp);
+        if engine.risk_budget_use_trade_mode() {
+            engine.apply_risk_budget_usage_from_trade(&t);
+        }
+        engine.apply_strategy_trade_position(&t);
+        let mut trade_payload = HashMap::new();
+        trade_payload.insert("trade_id", t.id.clone());
+        trade_payload.insert("order_id", t.order_id.clone());
+        trade_payload.insert("price", t.price.to_string());
+        trade_payload.insert("quantity", t.quantity.to_string());
+        trade_payload.insert(
+            "owner_strategy_id",
+            t.owner_strategy_id.clone().unwrap_or_default(),
+        );
+        engine.emit_stream_event(
+            py,
+            "trade",
+            Some(t.symbol.as_str()),
+            "info",
+            trade_payload,
+        );
+        trades_to_process.push(t);
+    }
+}
+
 impl Processor for ChannelProcessor {
     fn process(
         &mut self,
@@ -221,134 +369,14 @@ impl Processor for ChannelProcessor {
                         engine.state.order_manager.add_active_order(order);
                     }
                     Event::ExecutionReport(order, trade) => {
-                        if order.status == OrderStatus::Filled
-                            && oco_suppressed_fill_order_ids.contains(&order.id)
-                        {
-                            continue;
-                        }
-                        let report_order_id = order.id.clone();
-                        let report_status = order.status;
-                        let report_updated_at = order.updated_at;
-                        engine.state.order_manager.on_execution_report(order);
-                        let updated_order = engine
-                            .state
-                            .order_manager
-                            .get_all_orders()
-                            .into_iter()
-                            .find(|o| o.id == report_order_id);
-                        if let Some(order_snapshot) = updated_order {
-                            if order_snapshot.status == OrderStatus::Rejected {
-                                engine
-                                    .state
-                                    .order_manager
-                                    .current_step_rejected_orders
-                                    .push(order_snapshot.clone());
-                            }
-                            let mut order_payload = HashMap::new();
-                            order_payload.insert("order_id", order_snapshot.id.clone());
-                            order_payload.insert("status", format!("{:?}", order_snapshot.status));
-                            order_payload
-                                .insert("filled_qty", order_snapshot.filled_quantity.to_string());
-                            order_payload.insert("symbol", order_snapshot.symbol.clone());
-                            order_payload.insert(
-                                "owner_strategy_id",
-                                order_snapshot.owner_strategy_id.clone().unwrap_or_default(),
-                            );
-                            engine.emit_stream_event(
-                                py,
-                                "order",
-                                Some(order_snapshot.symbol.as_str()),
-                                "info",
-                                order_payload,
-                            );
-                        }
-
-                        if report_status == OrderStatus::Filled {
-                            let peer_ids = engine
-                                .state
-                                .order_manager
-                                .consume_oco_peer_cancels_on_fill(&report_order_id);
-                            for peer_id in peer_ids {
-                                oco_suppressed_fill_order_ids.insert(peer_id.clone());
-                                engine.execution_model.on_cancel(&peer_id);
-                                let cancelled_order_snapshot = engine
-                                    .state
-                                    .order_manager
-                                    .cancel_active_order(&peer_id, report_updated_at);
-                                if let Some(cancelled_order_snapshot) = cancelled_order_snapshot {
-                                    let mut cancel_payload = HashMap::new();
-                                    cancel_payload
-                                        .insert("order_id", cancelled_order_snapshot.id.clone());
-                                    cancel_payload.insert(
-                                        "status",
-                                        format!("{:?}", cancelled_order_snapshot.status),
-                                    );
-                                    cancel_payload.insert(
-                                        "filled_qty",
-                                        cancelled_order_snapshot.filled_quantity.to_string(),
-                                    );
-                                    cancel_payload
-                                        .insert("symbol", cancelled_order_snapshot.symbol.clone());
-                                    cancel_payload.insert(
-                                        "owner_strategy_id",
-                                        cancelled_order_snapshot
-                                            .owner_strategy_id
-                                            .clone()
-                                            .unwrap_or_default(),
-                                    );
-                                    engine.emit_stream_event(
-                                        py,
-                                        "order",
-                                        Some(cancelled_order_snapshot.symbol.as_str()),
-                                        "info",
-                                        cancel_payload,
-                                    );
-                                }
-                            }
-
-                            if let Some(filled_order_snapshot) = engine
-                                .state
-                                .order_manager
-                                .get_all_orders()
-                                .into_iter()
-                                .find(|o| o.id == report_order_id)
-                            {
-                                let bracket_exit_orders = engine
-                                    .state
-                                    .order_manager
-                                    .consume_bracket_activation_on_fill(&filled_order_snapshot);
-                                for bracket_order in bracket_exit_orders {
-                                    let _ = engine
-                                        .event_manager
-                                        .send(Event::OrderRequest(bracket_order));
-                                }
-                            }
-                        }
-
-                        if let Some(t) = trade {
-                            engine.maybe_reset_risk_budget_usage(t.timestamp);
-                            if engine.risk_budget_use_trade_mode() {
-                                engine.apply_risk_budget_usage_from_trade(&t);
-                            }
-                            engine.apply_strategy_trade_position(&t);
-                            let mut trade_payload = HashMap::new();
-                            trade_payload.insert("trade_id", t.id.clone());
-                            trade_payload.insert("order_id", t.order_id.clone());
-                            trade_payload.insert("price", t.price.to_string());
-                            trade_payload.insert("quantity", t.quantity.to_string());
-                            trade_payload.insert(
-                                "owner_strategy_id",
-                                t.owner_strategy_id.clone().unwrap_or_default(),
-                            );
-                            engine.emit_stream_event(
-                                py,
-                                "trade",
-                                Some(t.symbol.as_str()),
-                                "info",
-                                trade_payload,
-                            );
-                            trades_to_process.push(t);
-                        }
+                        apply_execution_report(
+                            engine,
+                            py,
+                            order,
+                            trade,
+                            &mut oco_suppressed_fill_order_ids,
+                            &mut trades_to_process,
+                        );
                     }
                     _ => {}
                 }
@@ -356,17 +384,7 @@ impl Processor for ChannelProcessor {
 
             if !pending_order_requests.is_empty() {
                 if settle_reductions_before_increases {
-                    if !trades_to_process.is_empty() {
-                        engine.state.order_manager.process_trades(
-                            std::mem::take(&mut trades_to_process),
-                            &mut engine.state.portfolio,
-                            &engine.instruments,
-                            &engine.risk_manager.config,
-                            engine.market_manager.model.as_ref(),
-                            &engine.history_buffer,
-                            &engine.last_prices,
-                        );
-                    }
+                    flush_accumulated_trades(engine, &mut trades_to_process);
                     settle_reductions_before_increases = false;
                 }
                 if run_intermediate_reduce_match {
@@ -435,17 +453,7 @@ impl Processor for ChannelProcessor {
             }
         }
 
-        if !trades_to_process.is_empty() {
-            engine.state.order_manager.process_trades(
-                trades_to_process,
-                &mut engine.state.portfolio,
-                &engine.instruments,
-                &engine.risk_manager.config,
-                engine.market_manager.model.as_ref(),
-                &engine.history_buffer,
-                &engine.last_prices,
-            );
-        }
+        flush_accumulated_trades(engine, &mut trades_to_process);
 
         Ok(ProcessorResult::Next)
     }
@@ -455,6 +463,7 @@ pub struct DataProcessor {
     last_timestamp: i64,
     finalized_timestamp: i64,
     seen_symbols: HashSet<String>,
+    current_symbol_events: HashMap<String, Event>,
 }
 
 impl Default for DataProcessor {
@@ -470,6 +479,7 @@ impl DataProcessor {
             last_timestamp: 0,
             finalized_timestamp: 0,
             seen_symbols: HashSet::new(),
+            current_symbol_events: HashMap::new(),
         }
     }
 
@@ -533,13 +543,46 @@ impl DataProcessor {
         }
     }
 
-    fn finalize_current_timestamp(&mut self, engine: &mut Engine) {
+    fn finalize_current_timestamp(&mut self, engine: &mut Engine, py: Python<'_>) {
         if self.last_timestamp == 0 || self.finalized_timestamp == self.last_timestamp {
             return;
+        }
+        let current_events: Vec<Event> = self.current_symbol_events.values().cloned().collect();
+        if !current_events.is_empty() {
+            let ctx = EngineContext {
+                instruments: &engine.instruments,
+                portfolio: &engine.state.portfolio,
+                last_prices: &engine.last_prices,
+                trade_tracker: &engine.state.order_manager.trade_tracker,
+                market_model: engine.market_manager.model.as_ref(),
+                execution_policy_core: engine.execution_policy_core(),
+                bar_index: engine.bar_count,
+                current_time: self.last_timestamp,
+                session: engine.clock.session,
+                active_orders: &engine.state.order_manager.active_orders,
+                risk_config: &engine.risk_manager.config,
+            };
+            let reports = engine.execution_model.finalize_timestamp(&current_events, &ctx);
+            let mut trades_to_process = Vec::new();
+            let mut oco_suppressed_fill_order_ids: HashSet<String> = HashSet::new();
+            for report in reports {
+                if let Event::ExecutionReport(order, trade) = report {
+                    apply_execution_report(
+                        engine,
+                        py,
+                        order,
+                        trade,
+                        &mut oco_suppressed_fill_order_ids,
+                        &mut trades_to_process,
+                    );
+                }
+            }
+            flush_accumulated_trades(engine, &mut trades_to_process);
         }
         self.fill_missing_bars(engine);
         self.reject_missing_symbol_orders(engine);
         self.finalized_timestamp = self.last_timestamp;
+        self.current_symbol_events.clear();
     }
 }
 
@@ -556,13 +599,13 @@ impl Processor for DataProcessor {
         match action {
             FeedAction::Wait => Ok(ProcessorResult::Loop),
             FeedAction::End => {
-                self.finalize_current_timestamp(engine);
+                self.finalize_current_timestamp(engine, py);
                 Ok(ProcessorResult::Break)
             }
             FeedAction::Timer(_timestamp) => {
                 if let Some(timer) = engine.timers.pop() {
                     if timer.payload.starts_with("__framework_rebalance__|") {
-                        self.finalize_current_timestamp(engine);
+                        self.finalize_current_timestamp(engine, py);
                     }
                     let local_dt =
                         Engine::local_datetime_from_ns(timer.timestamp, engine.timezone_offset);
@@ -588,8 +631,9 @@ impl Processor for DataProcessor {
                 }
 
                 if self.last_timestamp != 0 && timestamp > self.last_timestamp {
-                    self.finalize_current_timestamp(engine);
+                    self.finalize_current_timestamp(engine, py);
                     self.seen_symbols.clear();
+                    self.current_symbol_events.clear();
 
                     if engine.is_active_timestamp(timestamp) {
                         engine.bar_count += 1;
@@ -765,11 +809,16 @@ impl Processor for DataProcessor {
 
                 if let Event::Bar(ref b) = event {
                     self.seen_symbols.insert(b.symbol.clone());
+                    self.current_symbol_events
+                        .insert(b.symbol.clone(), Event::Bar(b.clone()));
                     // Update History Buffer
                     if let Ok(mut buffer) = engine.history_buffer.write() {
                         buffer.update(b);
                     }
                     // println!("DataProcessor: Bar Symbol={}, TS={}", b.symbol, b.timestamp);
+                } else if let Event::Tick(ref t) = event {
+                    self.current_symbol_events
+                        .insert(t.symbol.clone(), Event::Tick(t.clone()));
                 }
 
                 engine.current_event = Some(event);

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -374,6 +374,18 @@ def test_order_target_weights_uses_sell_proceeds_before_same_cycle_buy() -> None
         9000.0,
     ]
     assert set(orders_df["status"].astype(str).str.lower()) == {"filled"}
+    aaa_buy = orders_df[
+        (orders_df["symbol"] == "AAA") & (orders_df["side"] == "buy")
+    ].iloc[0]
+    aaa_sell = orders_df[
+        (orders_df["symbol"] == "AAA") & (orders_df["side"] == "sell")
+    ].iloc[0]
+    bbb_buy = orders_df[
+        (orders_df["symbol"] == "BBB") & (orders_df["side"] == "buy")
+    ].iloc[0]
+    assert aaa_buy["updated_at"] == timestamps[0]
+    assert aaa_sell["updated_at"] == timestamps[1]
+    assert bbb_buy["updated_at"] == timestamps[1]
     final_positions = result.positions.iloc[-1]
     assert float(final_positions.get("AAA", 0.0)) == 0.0
     assert float(final_positions.get("BBB", 0.0)) == 9000.0
@@ -473,6 +485,7 @@ def test_explicit_buy_quantity_is_rejected_without_resizing() -> None:
     row = orders_df.iloc[0]
     assert str(row["symbol"]) == "AAA"
     assert float(row["quantity"]) == 20_000.0
+    assert float(row["filled_quantity"]) == 0.0
     assert str(row["status"]).lower() == "rejected"
     assert "insufficient" in str(row["reject_reason"]).lower()
 
@@ -582,7 +595,23 @@ def test_same_cycle_sell_then_buy_uses_post_sell_cash_for_sizing() -> None:
         show_progress=False,
     )
 
-    orders_df = result.orders_df
+    orders_df = result.orders_df.sort_values("created_at").reset_index(drop=True)
+    assert not any(
+        str(status).lower() == "rejected" for status in orders_df["status"].tolist()
+    )
+    aaa_buy = orders_df[
+        (orders_df["symbol"] == "AAA") & (orders_df["side"] == "buy")
+    ].iloc[0]
+    aaa_sell = orders_df[
+        (orders_df["symbol"] == "AAA") & (orders_df["side"] == "sell")
+    ].iloc[0]
     bbb_buys = orders_df[(orders_df["symbol"] == "BBB") & (orders_df["side"] == "buy")]
     assert not bbb_buys.empty
+    assert set(bbb_buys["status"].astype(str).str.lower()) == {"filled"}
+    assert aaa_buy["updated_at"] == timestamps[0]
+    assert aaa_sell["updated_at"] == timestamps[1]
+    assert bbb_buys.iloc[0]["updated_at"] == timestamps[1]
     assert float(bbb_buys.iloc[0]["filled_quantity"]) >= 499.0
+    final_positions = result.positions.iloc[-1]
+    assert float(final_positions.get("AAA", 0.0)) == 0.0
+    assert float(final_positions.get("BBB", 0.0)) >= 499.0


### PR DESCRIPTION
- 更新项目版本至0.2.28
- 重构执行报告处理逻辑，提取通用函数减少代码重复
- 为ExecutionClient trait新增finalize_timestamp方法，支持同时间片收尾处理延迟订单
- 移除Python策略API中的旧版延迟买单逻辑，改为由引擎统一处理同周期订单
- 修复同周期先卖后买跨标的订单无法复用卖出所得资金的问题
- 补充测试用例验证同周期订单的执行时序与成交结果