### PR TITLE
修复: 修复示例和文档中的预热期问题，添加测试并升级版本至0.2.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.28"
+version = "0.2.29"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/guide/quant_basics.md
+++ b/docs/zh/guide/quant_basics.md
@@ -206,6 +206,7 @@ class DualMovingAverageStrategy(Strategy):
         # 定义策略参数：短期窗口5，长期窗口20
         self.short_window = 5
         self.long_window = 20
+        self.warmup_period = self.long_window + 1
 
     def on_bar(self, bar: Bar):
         # 获取历史收盘价数据
@@ -213,7 +214,7 @@ class DualMovingAverageStrategy(Strategy):
         hist = self.get_history(count=self.long_window + 1, field="close")
 
         # 如果数据不足，无法计算均线，直接返回
-        if len(hist) < self.long_window:
+        if len(hist) < self.long_window + 1:
             return
 
         # 计算短期和长期均线

--- a/examples/03_parameter_optimization_advanced.py
+++ b/examples/03_parameter_optimization_advanced.py
@@ -25,6 +25,7 @@ class DualMovingAverageStrategy(Strategy):
         # 定义策略参数：短期窗口5，长期窗口20
         self.short_window = short_window
         self.long_window = long_window
+        self.warmup_period = long_window + 1
 
     def on_bar(self, bar: Bar) -> None:
         """Handle new bar data.
@@ -37,7 +38,7 @@ class DualMovingAverageStrategy(Strategy):
         hist = self.get_history(count=self.long_window + 1, field="close")
 
         # 如果数据不足，无法计算均线，直接返回
-        if len(hist) < self.long_window:
+        if len(hist) < self.long_window + 1:
             return
 
         # 计算短期和长期均线

--- a/examples/12_wfo_integrated.py
+++ b/examples/12_wfo_integrated.py
@@ -24,6 +24,7 @@ class DualMovingAverageStrategy(Strategy):
         """
         self.short_window = short_window
         self.long_window = long_window
+        self.warmup_period = long_window + 1
 
     def on_bar(self, bar: Bar) -> None:
         """处理 Bar 数据.
@@ -33,7 +34,7 @@ class DualMovingAverageStrategy(Strategy):
         """
         # 获取历史收盘价
         hist = self.get_history(count=self.long_window + 1, field="close")
-        if len(hist) < self.long_window:
+        if len(hist) < self.long_window + 1:
             return
 
         closes = hist

--- a/examples/textbook/ch05_strategy.py
+++ b/examples/textbook/ch05_strategy.py
@@ -64,8 +64,9 @@ class MyFirstStrategy(Strategy):
         self.entry_price = 0.0  # 记录开仓价格
 
         # 设置预热期 (Warmup Period)
-        # 引擎会在正式回测前预加载数据，确保 get_history 能获取到足够的数据
-        self.warmup_period = long_window
+        # 本示例会请求 long_window + 1 根数据，并用 [:-1] 排除当前 Bar，
+        # 因此预热期也需要同步加 1，避免首次回调拿到前导 NaN。
+        self.warmup_period = long_window + 1
 
     # --------------------------------------------------------------------------
     # 2. 启动回调 (On Start)

--- a/examples/textbook/ch10_analysis.py
+++ b/examples/textbook/ch10_analysis.py
@@ -48,7 +48,8 @@ class AnalysisStrategy(Strategy):
         super().__init__()
         self.short_window = short_window
         self.long_window = long_window
-        self.warmup_period = long_window
+        # 本示例会请求 long_window + 1 根数据，并用 [:-1] 排除当前 Bar。
+        self.warmup_period = long_window + 1
 
     def on_bar(self, bar: Bar) -> None:
         """收到 Bar 事件的回调."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.28"
+version = "0.2.29"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/tests/test_examples_regression.py
+++ b/tests/test_examples_regression.py
@@ -132,6 +132,24 @@ def test_textbook_futures_strategy_uses_short_for_bearish_signal(
     assert captured["buy"] is None
 
 
+def test_textbook_dual_ma_examples_request_enough_warmup_bars() -> None:
+    """Dual-MA textbook examples should align warmup with N+1 history windows."""
+    ch05 = _load_example_module(
+        "example_textbook_ch05_strategy",
+        "examples/textbook/ch05_strategy.py",
+    )
+    ch10 = _load_example_module(
+        "example_textbook_ch10_analysis",
+        "examples/textbook/ch10_analysis.py",
+    )
+
+    ch05_strategy = ch05.MyFirstStrategy(short_window=5, long_window=20)
+    ch10_strategy = ch10.AnalysisStrategy(short_window=5, long_window=20)
+
+    assert ch05_strategy.warmup_period == 21
+    assert ch10_strategy.warmup_period == 21
+
+
 def test_textbook_futures_example_documents_fill_policy_and_bps_slippage() -> None:
     """Textbook futures example should retain safer fill/slippage configuration."""
     root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
涉及修改多个双均线策略示例的预热期配置，将其调整为long_window +1以匹配历史数据请求量；更新docs/zh/guide/quant_basics.md中的数据长度检查逻辑；新增测试用例验证预热期配置的正确性；同步更新Cargo.lock、Cargo.toml和pyproject.toml中的包版本号。