### PR TITLE
refactor(backtest): 提取重复的交易日元数据构建逻辑

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.29"
+version = "0.2.30"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.29"
+version = "0.2.30"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -370,6 +370,40 @@ def _index_to_local_trading_days(
     return cast(pd.DatetimeIndex, local_index.tz_convert(timezone))
 
 
+def _build_trading_day_metadata(
+    data_map_for_indicators: Dict[str, pd.DataFrame], timezone: str
+) -> Tuple[List[pd.Timestamp], Dict[str, Tuple[int, int]]]:
+    """Build sorted trading days and per-day nanosecond bounds."""
+    all_dates: set[pd.Timestamp] = set()
+    day_bounds: Dict[str, Tuple[int, int]] = {}
+
+    for df in data_map_for_indicators.values():
+        if df.empty or not isinstance(df.index, pd.DatetimeIndex):
+            continue
+
+        local_index = _index_to_local_trading_days(
+            cast(pd.DatetimeIndex, df.index), timezone
+        )
+        normalized_index = cast(pd.DatetimeIndex, local_index.normalize())
+        all_dates.update(normalized_index.unique())
+
+        grouped = df.groupby(normalized_index, sort=False)
+        for day_ts, day_df in grouped:
+            day_key = pd.Timestamp(day_ts).date().isoformat()
+            start_ns = int(day_df.index.min().value)
+            end_ns = int(day_df.index.max().value)
+            if day_key in day_bounds:
+                prev_start, prev_end = day_bounds[day_key]
+                day_bounds[day_key] = (
+                    min(prev_start, start_ns),
+                    max(prev_end, end_ns),
+                )
+            else:
+                day_bounds[day_key] = (start_ns, end_ns)
+
+    return sorted(all_dates), day_bounds
+
+
 BacktestDataInput = Union[
     pd.DataFrame, Dict[str, pd.DataFrame], List[Bar], DataFeed, DataFeedAdapter
 ]
@@ -2912,36 +2946,13 @@ def run_backtest(
     # Inject trading days to strategy (for add_daily_timer)
     all_strategy_instances = [strategy_instance, *slot_strategy_instances.values()]
     if data_map_for_indicators:
-        all_dates: set[pd.Timestamp] = set()
-        day_bounds: Dict[str, Tuple[int, int]] = {}
-        for df in data_map_for_indicators.values():
-            if not df.empty and isinstance(df.index, pd.DatetimeIndex):
-                local_index = _index_to_local_trading_days(
-                    cast(pd.DatetimeIndex, df.index), timezone
-                )
-                normalized_index = cast(pd.DatetimeIndex, local_index.normalize())
-                dates = normalized_index.unique()
-                all_dates.update(dates)
-                for raw_day_ts in dates:
-                    day_ts = pd.Timestamp(raw_day_ts)
-                    day_df = df[normalized_index == day_ts]
-                    if day_df.empty:
-                        continue
-                    day_key = day_ts.date().isoformat()
-                    start_ns = int(day_df.index.min().value)
-                    end_ns = int(day_df.index.max().value)
-                    if day_key in day_bounds:
-                        prev_start, prev_end = day_bounds[day_key]
-                        day_bounds[day_key] = (
-                            min(prev_start, start_ns),
-                            max(prev_end, end_ns),
-                        )
-                    else:
-                        day_bounds[day_key] = (start_ns, end_ns)
+        all_dates, day_bounds = _build_trading_day_metadata(
+            data_map_for_indicators, timezone
+        )
 
         for current_strategy in all_strategy_instances:
             if hasattr(current_strategy, "_trading_days") and all_dates:
-                current_strategy._trading_days = sorted(list(all_dates))
+                current_strategy._trading_days = all_dates
             if hasattr(current_strategy, "_trading_day_bounds"):
                 current_strategy._trading_day_bounds = day_bounds
 
@@ -4641,32 +4652,13 @@ def run_warm_start(
         warnings.warn(warning_message, RuntimeWarning, stacklevel=2)
         logger.warning(warning_message)
     if data_map_for_indicators:
-        all_dates: set[pd.Timestamp] = set()
-        day_bounds: Dict[str, Tuple[int, int]] = {}
-        for df in data_map_for_indicators.values():
-            if not df.empty and isinstance(df.index, pd.DatetimeIndex):
-                local_index = _index_to_local_trading_days(
-                    cast(pd.DatetimeIndex, df.index), timezone_name
-                )
-                dates = local_index.normalize().unique()
-                all_dates.update(dates)
-                grouped = df.groupby(local_index.normalize())
-                for day_ts, day_df in grouped:
-                    day_key = pd.Timestamp(day_ts).date().isoformat()
-                    start_ns = int(day_df.index.min().value)
-                    end_ns = int(day_df.index.max().value)
-                    if day_key in day_bounds:
-                        prev_start, prev_end = day_bounds[day_key]
-                        day_bounds[day_key] = (
-                            min(prev_start, start_ns),
-                            max(prev_end, end_ns),
-                        )
-                    else:
-                        day_bounds[day_key] = (start_ns, end_ns)
+        all_dates, day_bounds = _build_trading_day_metadata(
+            data_map_for_indicators, timezone_name
+        )
 
         for current_strategy in all_strategy_instances:
             if all_dates and hasattr(current_strategy, "_trading_days"):
-                current_strategy._trading_days = sorted(list(all_dates))
+                current_strategy._trading_days = all_dates
             if hasattr(current_strategy, "_trading_day_bounds"):
                 current_strategy._trading_day_bounds = day_bounds
             setattr(current_strategy, "_engine", engine)

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -29,6 +29,7 @@ from akquant.akquant import (
 )
 from akquant.backtest import FunctionalStrategy
 from akquant.backtest.engine import (
+    _build_trading_day_metadata,
     _prime_framework_boundary_timers,
     _prime_framework_pre_open_timers,
 )
@@ -3796,6 +3797,40 @@ def test_collect_boundary_timers_and_prime_globally_once() -> None:
         (start_ts, "__framework_boundary__|before|2023-01-03"),
         (end_ts + 1, "__framework_boundary__|after|2023-01-03"),
     ]
+
+
+def test_build_trading_day_metadata_merges_multi_symbol_day_bounds() -> None:
+    """Trading day metadata should merge per-day bounds across symbols."""
+    data_map = {
+        "AAA": pd.DataFrame(
+            {"close": [10.0, 10.5]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2023-01-03 01:30:00", tz="UTC"),
+                    pd.Timestamp("2023-01-03 07:00:00", tz="UTC"),
+                ]
+            ),
+        ),
+        "BBB": pd.DataFrame(
+            {"close": [20.0, 21.0]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2023-01-03 02:00:00", tz="UTC"),
+                    pd.Timestamp("2023-01-03 06:00:00", tz="UTC"),
+                ]
+            ),
+        ),
+    }
+
+    trading_days, day_bounds = _build_trading_day_metadata(data_map, "Asia/Shanghai")
+
+    assert trading_days == [pd.Timestamp("2023-01-03", tz="Asia/Shanghai")]
+    assert day_bounds == {
+        "2023-01-03": (
+            pd.Timestamp("2023-01-03 01:30:00", tz="UTC").value,
+            pd.Timestamp("2023-01-03 07:00:00", tz="UTC").value,
+        )
+    }
 
 
 def test_precise_boundary_hooks_delay_after_trading_until_day_end() -> None:


### PR DESCRIPTION
重构回测模块中`run_backtest`和`run_warm_start`函数里重复的交易日元数据构建代码，将其提取为独立的`_build_trading_day_metadata`公共函数以减少代码冗余；新增对应的单元测试验证多标的日期边界合并功能；同步更新项目版本至0.2.30。