### PR TITLE
fix(strategy): 修复连续交易会话钩子逻辑，更新文档并升级至v0.2.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -54,7 +54,7 @@ A strategy goes through the following stages from start to finish:
 | `on_before_trading` | First entry into `Normal` session each local trading day | Pre-market checks, trading-date level signal preparation | `examples/50_framework_hooks_demo.py` |
 | `on_pre_open` | Triggered by a framework timer before the first regular event of each trading day | Auction/pre-open signal generation with default next-open order semantics | `examples/52_pre_open_demo.py` |
 | `on_daily_rebalance` | At most once per trading day, same phase as `on_before_trading` | Cross-sectional ranking and one-shot rebalance | `examples/strategies/05_stock_momentum_rotation_timer.py` |
-| `on_after_trading` | When leaving `Normal`, or replayed on the next event if needed | End-of-day summaries, post-close cleanup, archiving | `examples/50_framework_hooks_demo.py` |
+| `on_after_trading` | When leaving the regular trading session, or replayed on the next event if needed | End-of-day summaries, post-close cleanup, archiving | `examples/50_framework_hooks_demo.py` |
 | `on_portfolio_update` | Incrementally when portfolio snapshot changes | Monitor cash/equity changes, push UI or alerts | `examples/50_framework_hooks_demo.py` |
 | `on_error` | When any user callback raises | Record callback source and choose continue vs fail-fast | `examples/22_strategy_runtime_config_demo.py` |
 | `on_timer` | When a registered timer fires | Scheduled rebalance, pre-market tasks, cadence checks | `examples/strategies/07_stock_momentum_rotation_on_timer.py` |
@@ -79,8 +79,8 @@ Notes:
 
 * `on_reject` is emitted once per order id when the order first becomes `Rejected`.
 * `on_pre_open` is emitted once per trading day before the first regular bar/tick callback of that day.
-* `on_before_trading` is emitted once per local trading date when session enters `Normal`.
-* `on_after_trading` is emitted once per local trading date when leaving `Normal`, or on next event if day rollover occurs first.
+* `on_before_trading` is emitted once per local trading date when the regular trading session starts; on the default backtest path this session is usually exposed as `Continuous`.
+* `on_after_trading` is emitted once per local trading date when leaving the regular trading session, or on the next event if day rollover occurs first.
 * Inside `on_pre_open`, plain `buy/sell/order_target_*` calls automatically resolve to `price_basis=open, bar_offset=1, temporal=same_cycle` unless an explicit `fill_policy` is provided.
 * Set `self.enable_precise_day_boundary_hooks = True` to enable boundary-timer based precise day hooks.
 * `on_portfolio_update` is incremental: emitted once at initialization, then only on order/trade or position-relevant price changes.
@@ -188,7 +188,7 @@ Practical tips:
 Timing note:
 
 * Do not treat `on_before_trading` as a stable same-day preparation stage that always runs before `on_pre_open`.
-* On the default path, `on_pre_open` runs before the first regular event, while `on_before_trading` is usually emitted on that first regular event after the session enters `Normal`.
+* On the default path, `on_pre_open` runs before the first regular event, while `on_before_trading` is usually emitted on that first regular event after the regular trading session begins.
 * Even with `enable_precise_day_boundary_hooks`, the boundary-timer version of `on_before_trading` should not be used as a deterministic same-day predecessor for `on_pre_open`.
 * For a true two-stage pattern, prepare in a later callback from the previous trading day and execute in the next trading day's `on_pre_open`, for example via a previous-day `on_timer` or `on_after_trading`.
 * See `examples/53_timer_to_pre_open_demo.py`.

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -687,9 +687,9 @@ Strategy base class. Users should inherit from this class and override callback 
 *   `on_expiry(event: Dict[str, Any])`: Triggered after an `expiry_date` driven settlement/removal is actually executed. Portfolio state is already updated when the callback runs. See `examples/49_on_expiry_demo.py` for a runnable example.
 *   `on_session_start(session, timestamp)`: Triggered on session transition start.
 *   `on_session_end(session, timestamp)`: Triggered on session transition end.
-*   `on_before_trading(trading_date, timestamp)`: Triggered once when entering Normal session each local day.
+*   `on_before_trading(trading_date, timestamp)`: Triggered once when the regular trading session starts each local day; on the default backtest path this session is usually exposed as `Continuous`.
 *   `on_pre_open(event: Dict[str, Any])`: Triggered once before the first regular event of each trading day. Use it for "pre-open decision, current open fill" workflows; default order semantics resolve to `price_basis=open, bar_offset=1, temporal=same_cycle`. See `examples/52_pre_open_demo.py`.
-*   `on_after_trading(trading_date, timestamp)`: Triggered when leaving Normal session, or replayed on next event after day rollover.
+*   `on_after_trading(trading_date, timestamp)`: Triggered when leaving the regular trading session, or replayed on next event after day rollover.
 *   `on_portfolio_update(snapshot)`: Triggered when cash/equity/position snapshot changes.
 *   `on_error(error, source, payload=None)`: Triggered when user callback raises, then exception is re-raised by default.
 *   `on_timer(payload: str)`: Triggered by timer.

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -80,10 +80,10 @@
 
 * `on_reject` 对同一订单 id 只触发一次。
 * 回测中已终态拒单会通过上下文快照 `recent_rejected_orders` 在下一次事件分发时补发，避免因清理活跃订单导致漏触发。
-* `on_before_trading` 在本地交易日首次进入 Normal 会话时触发一次。
+* `on_before_trading` 在本地交易日首次进入常规交易会话时触发一次；默认回测路径下该会话通常表现为 `Continuous`。
 * `on_pre_open` 在每个交易日的首个常规行情事件前，由框架预注册 timer 先触发一次。
 * `on_daily_rebalance` 与 `on_before_trading` 同一阶段触发，每个交易日最多触发一次。
-* `on_after_trading` 在离开 Normal 会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `on_after_trading`。
+* `on_after_trading` 在离开常规交易会话时触发；若先跨日再收到事件，会在下一事件补发上一交易日的 `on_after_trading`。
 * `on_pre_open` 内若直接调用 `buy/sell/order_target_*` 且未显式传 `fill_policy`，框架会自动解析为 `price_basis=open, bar_offset=1, temporal=same_cycle`。
 * 这里表达的是框架侧“盘前决策，本次 open 成交”的时序语义，不等同于交易所或券商柜台已经实现了集合竞价专用报单、撤单窗口控制或专有价格类型。
 * 新股/新债打新不属于 `on_pre_open` 或当前统一 `submit_order(...)` 的默认承诺范围；若要支持，通常需要补齐 broker 专有字段与业务路由。

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -711,10 +711,10 @@ result = run_backtest(
 *   `on_expiry(event: Dict[str, Any])`: 到期结算回调。仅当引擎实际执行 `expiry_date` 驱动的到期结算/移除后触发；回调时账户状态已更新。示例见：`examples/49_on_expiry_demo.py`。
 *   `on_session_start(session, timestamp)`: 会话切换开始时触发。
 *   `on_session_end(session, timestamp)`: 会话切换结束时触发。
-*   `on_before_trading(trading_date, timestamp)`: 每个本地交易日首次进入 Normal 会话时触发一次。
+*   `on_before_trading(trading_date, timestamp)`: 每个本地交易日首次进入常规交易会话时触发一次；默认回测路径下该会话通常表现为 `Continuous`。
 *   `on_pre_open(event: Dict[str, Any])`: 每个交易日首个常规行情事件前触发一次。适合“盘前决策，本次 open 成交”；默认下单语义会自动解析为 `price_basis=open, bar_offset=1, temporal=same_cycle`。示例见：`examples/52_pre_open_demo.py`。
 *   `on_daily_rebalance(trading_date, timestamp)`: 交易日调仓钩子，每个交易日最多触发一次。
-*   `on_after_trading(trading_date, timestamp)`: 离开 Normal 会话时触发；若先跨日则在下一事件补发。
+*   `on_after_trading(trading_date, timestamp)`: 离开常规交易会话时触发；若先跨日则在下一事件补发。
 *   `on_portfolio_update(snapshot)`: 账户快照变化时触发。
 *   `on_error(error, source, payload=None)`: 用户回调抛异常时触发，默认触发后继续抛出。
 *   `on_timer(payload: str)`: 定时器触发。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.30"
+version = "0.2.31"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -44,10 +44,16 @@ def _use_precise_day_boundary_hooks(strategy: Any) -> bool:
 
 def _is_normal_session(session: Any) -> bool:
     normal = getattr(TradingSession, "Normal", None)
-    if normal is not None:
-        return bool(session == normal)
+    continuous = getattr(TradingSession, "Continuous", None)
+    if normal is not None or continuous is not None:
+        return bool(session == normal or session == continuous)
     text = str(session).lower()
-    return text == "normal" or text.endswith(".normal")
+    return (
+        text == "normal"
+        or text.endswith(".normal")
+        or text == "continuous"
+        or text.endswith(".continuous")
+    )
 
 
 def _is_pre_open_session(session: Any) -> bool:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -3905,7 +3905,81 @@ def test_precise_boundary_hooks_delay_after_trading_until_day_end() -> None:
     assert day1_after in strategy.events
     assert strategy.events.index(day1_before) < strategy.events.index(day1_last_bar)
     assert strategy.events.index(day1_rebalance) < strategy.events.index(day1_after)
-    assert strategy.events.index(day1_last_bar) < strategy.events.index(day1_after)
+
+
+def test_non_precise_boundary_hooks_fire_with_continuous_session_backtest() -> None:
+    """Default backtest path should emit day hooks even when session is Continuous."""
+
+    class NonPreciseBoundaryRegressionStrategy(Strategy):
+        def __init__(self) -> None:
+            self.enable_precise_day_boundary_hooks = False
+            self.events: list[tuple[str, object, int]] = []
+
+        def on_start(self) -> None:
+            self.subscribe("HOOKS_DEMO")
+
+        def on_before_trading(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("before", trading_date, timestamp))
+
+        def on_daily_rebalance(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("rebalance", trading_date, timestamp))
+
+        def on_after_trading(self, trading_date: object, timestamp: int) -> None:
+            self.events.append(("after", trading_date, timestamp))
+
+        def on_bar(self, bar: Bar) -> None:
+            self.events.append(("bar", bar.symbol, int(bar.timestamp)))
+
+    day1_open = pd.Timestamp("2023-01-03 09:30:00", tz="Asia/Shanghai").value
+    day1_close = pd.Timestamp("2023-01-03 15:00:00", tz="Asia/Shanghai").value
+    day2_open = pd.Timestamp("2023-01-04 09:30:00", tz="Asia/Shanghai").value
+    bars = [
+        Bar(
+            timestamp=timestamp,
+            open=close,
+            high=close + 0.2,
+            low=close - 0.2,
+            close=close,
+            volume=1000.0,
+            symbol="HOOKS_DEMO",
+        )
+        for timestamp, close in [
+            (day1_open, 10.0),
+            (day1_close, 10.5),
+            (day2_open, 10.8),
+        ]
+    ]
+
+    strategy = NonPreciseBoundaryRegressionStrategy()
+    run_backtest(
+        data=bars,
+        strategy=strategy,
+        symbols=["HOOKS_DEMO"],
+        initial_cash=1000.0,
+        show_progress=False,
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+    )
+
+    day1 = pd.Timestamp("2023-01-03").date()
+    day2 = pd.Timestamp("2023-01-04").date()
+    day1_before = ("before", day1, day1_open)
+    day1_rebalance = ("rebalance", day1, day1_open)
+    day1_after = ("after", day1, day2_open)
+    day2_before = ("before", day2, day2_open)
+    day2_rebalance = ("rebalance", day2, day2_open)
+
+    assert day1_before in strategy.events
+    assert day1_rebalance in strategy.events
+    assert day1_after in strategy.events
+    assert day2_before in strategy.events
+    assert day2_rebalance in strategy.events
+    assert strategy.events.index(day1_before) < strategy.events.index(
+        ("bar", "HOOKS_DEMO", day1_open)
+    )
+    assert strategy.events.index(
+        ("bar", "HOOKS_DEMO", day1_open)
+    ) < strategy.events.index(day1_rebalance)
+    assert strategy.events.index(day1_after) < strategy.events.index(day2_before)
     assert (
         "after",
         pd.Timestamp("2023-01-03").date(),


### PR DESCRIPTION
重构`_is_normal_session`函数以支持识别Continuous交易会话；更新所有中英文文档，将"Normal session"统一改为"常规交易会话"并补充回测默认使用Continuous会话的说明；新增测试用例验证连续交易会话下日间交易钩子正确触发；同步更新Cargo.lock、Cargo.toml及pyproject.toml中的版本号至0.2.31