### PR TITLE
fix(akquant): 修复期货利息计算与强制平仓逻辑，升级版本至0.2.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.32"
+version = "0.2.33"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.32"
+version = "0.2.33"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -275,11 +275,13 @@ impl OrderManager {
                 terminal_without_fill_id = Some(existing.id.clone());
             }
         } else {
-            // If it's a new order report (e.g. Rejected immediately), add to active so it can be moved to history later
+            // If the first report we see is already terminal/filled, keep a snapshot so
+            // downstream callbacks/history can still observe the order lifecycle.
             if report.status == OrderStatus::Rejected
                 || report.status == OrderStatus::New
                 || report.status == OrderStatus::PartiallyFilled
                 || report.status == OrderStatus::Submitted
+                || report.status == OrderStatus::Filled
             {
                 if report.status == OrderStatus::Rejected {
                     terminal_without_fill_id = Some(report.id.clone());

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -688,7 +688,11 @@ impl Processor for DataProcessor {
                         instruments: &engine.instruments,
                         last_prices: &engine.last_prices,
                         market_manager: &engine.market_manager,
+                        trade_tracker: &engine.state.order_manager.trade_tracker,
                         risk_config: &engine.risk_manager.config,
+                        timestamp,
+                        bar_index: engine.bar_count,
+                        default_strategy_id: engine.default_strategy_id.clone(),
                     };
                     let settlement_outcome = engine.settlement_manager.process_daily_settlement(
                         &mut engine.state.portfolio,
@@ -758,7 +762,17 @@ impl Processor for DataProcessor {
                             .insert("liquidated_count", liquidated_symbols.len().to_string());
                         risk_payload.insert("liquidated_symbols", liquidated_symbols.join(","));
                         risk_payload.insert("priority", priority);
+                        if let Some(owner_strategy_id) = engine
+                            .default_strategy_id
+                            .clone()
+                            .filter(|text| !text.trim().is_empty())
+                        {
+                            risk_payload.insert("owner_strategy_id", owner_strategy_id);
+                        }
                         engine.emit_stream_event(py, "risk", None, "warn", risk_payload);
+                    }
+                    for event in settlement_outcome.forced_liquidation_events {
+                        let _ = engine.event_manager.send(event);
                     }
                     let recent_expiry_events = engine.recent_expiry_events.clone();
                     for expiry_event in recent_expiry_events {

--- a/src/settlement/manager.rs
+++ b/src/settlement/manager.rs
@@ -1,5 +1,11 @@
+use crate::account::{calculate_account_metrics, estimate_futures_realized_pnl};
+use crate::analysis::TradeTracker;
+use crate::event::Event;
 use crate::market::manager::MarketManager;
-use crate::model::{Instrument, Order, OrderStatus, TimeInForce};
+use crate::model::{
+    Instrument, Order, OrderRole, OrderSide, OrderStatus, OrderType, PositionEffect, TimeInForce,
+    Trade,
+};
 use crate::portfolio::Portfolio;
 use crate::risk::RiskConfig;
 use chrono::NaiveDate;
@@ -7,6 +13,7 @@ use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
 use std::collections::HashMap;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use super::expiry::ExpirySettlementHandler;
 use super::handler::SettlementHandler;
@@ -18,7 +25,11 @@ pub struct SettlementContext<'a> {
     pub instruments: &'a HashMap<String, Instrument>,
     pub last_prices: &'a HashMap<String, Decimal>,
     pub market_manager: &'a MarketManager,
+    pub trade_tracker: &'a TradeTracker,
     pub risk_config: &'a RiskConfig,
+    pub timestamp: i64,
+    pub bar_index: usize,
+    pub default_strategy_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -42,6 +53,7 @@ pub struct SettlementOutcome {
     pub forced_liquidation: bool,
     pub liquidated_symbols: Vec<String>,
     pub expiry_events: Vec<ExecutedExpiryEvent>,
+    pub forced_liquidation_events: Vec<Event>,
 }
 
 /// Settlement Manager
@@ -177,17 +189,21 @@ impl SettlementManager {
             return outcome;
         }
 
-        let (_, _, short_market_value) =
-            compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
-
         let borrowed_cash = (-portfolio.cash).max(Decimal::ZERO);
+        let pre_interest_metrics = calculate_account_metrics(
+            portfolio,
+            ctx.last_prices,
+            ctx.instruments,
+            ctx.trade_tracker,
+            ctx.risk_config,
+        );
         let financing_rate =
             Decimal::from_f64(ctx.risk_config.financing_rate_annual).unwrap_or(Decimal::ZERO);
         let borrow_rate =
             Decimal::from_f64(ctx.risk_config.borrow_rate_annual).unwrap_or(Decimal::ZERO);
         let day_divisor = Decimal::from(365);
         let financing_interest = borrowed_cash * financing_rate / day_divisor;
-        let borrow_interest = short_market_value * borrow_rate / day_divisor;
+        let borrow_interest = pre_interest_metrics.short_market_value * borrow_rate / day_divisor;
         let total_interest = (financing_interest + borrow_interest).max(Decimal::ZERO);
         if total_interest > Decimal::ZERO {
             portfolio.cash -= total_interest;
@@ -198,13 +214,20 @@ impl SettlementManager {
             return outcome;
         }
 
-        let (_, equity, gross_exposure) =
-            compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
-        if gross_exposure <= Decimal::ZERO {
+        let required_maintenance = ctx.risk_config.maintenance_margin_ratio_decimal();
+        let mut simulated_portfolio = portfolio.clone();
+        let mut simulated_trade_tracker = ctx.trade_tracker.clone();
+        let account_metrics = calculate_account_metrics(
+            &simulated_portfolio,
+            ctx.last_prices,
+            ctx.instruments,
+            &simulated_trade_tracker,
+            ctx.risk_config,
+        );
+        if account_metrics.used_margin <= Decimal::ZERO {
             return outcome;
         }
-        let maintenance_ratio = equity / gross_exposure;
-        if maintenance_ratio >= ctx.risk_config.maintenance_margin_ratio_decimal() {
+        if account_metrics.maintenance_ratio >= required_maintenance {
             return outcome;
         }
 
@@ -265,7 +288,7 @@ impl SettlementManager {
             .map(|(symbol, _)| symbol)
             .collect();
         for symbol in symbols_to_close {
-            let qty = portfolio
+            let qty = simulated_portfolio
                 .positions
                 .get(&symbol)
                 .copied()
@@ -276,62 +299,176 @@ impl SettlementManager {
             let Some(price) = ctx.last_prices.get(&symbol).copied() else {
                 continue;
             };
-            let multiplier = ctx
-                .instruments
-                .get(&symbol)
-                .map(|i| i.multiplier())
-                .unwrap_or(Decimal::ONE);
-            portfolio.cash += qty * price * multiplier;
+            let side = if qty > Decimal::ZERO {
+                OrderSide::Sell
+            } else {
+                OrderSide::Buy
+            };
+            let quantity = qty.abs();
+            let order_id = Uuid::new_v4().to_string();
+            let trade_id = Uuid::new_v4().to_string();
+            let owner_strategy_id = normalized_strategy_id(ctx.default_strategy_id.clone());
+            let mut filled_order = forced_liquidation_order(
+                order_id.clone(),
+                symbol.clone(),
+                side,
+                quantity,
+                price,
+                ctx.timestamp,
+                owner_strategy_id.clone(),
+            );
+            filled_order.status = OrderStatus::Filled;
+            filled_order.filled_quantity = quantity;
+            filled_order.average_filled_price = Some(price);
+            filled_order.updated_at = ctx.timestamp;
+            let trade = Trade {
+                id: trade_id,
+                order_id,
+                symbol: symbol.clone(),
+                side,
+                position_effect: PositionEffect::Close,
+                quantity,
+                price,
+                commission: Decimal::ZERO,
+                timestamp: ctx.timestamp,
+                bar_index: ctx.bar_index,
+                owner_strategy_id,
+            };
+            outcome
+                .forced_liquidation_events
+                .push(Event::ExecutionReport(filled_order, Some(trade.clone())));
 
-            {
-                let positions = Arc::make_mut(&mut portfolio.positions);
-                positions.remove(&symbol);
-            }
-            {
-                let avail_pos = Arc::make_mut(&mut portfolio.available_positions);
-                avail_pos.remove(&symbol);
-            }
+            apply_liquidation_trade_simulation(
+                &mut simulated_portfolio,
+                &mut simulated_trade_tracker,
+                &trade,
+                ctx.instruments,
+                ctx.last_prices,
+                ctx.risk_config,
+            );
             outcome.liquidated_symbols.push(symbol.clone());
 
-            let (_, next_equity, next_exposure) =
-                compute_portfolio_metrics(portfolio, ctx.last_prices, ctx.instruments);
-            if next_exposure <= Decimal::ZERO {
+            let next_metrics = calculate_account_metrics(
+                &simulated_portfolio,
+                ctx.last_prices,
+                ctx.instruments,
+                &simulated_trade_tracker,
+                ctx.risk_config,
+            );
+            if next_metrics.used_margin <= Decimal::ZERO {
                 break;
             }
-            let next_ratio = next_equity / next_exposure;
-            if next_ratio >= ctx.risk_config.maintenance_margin_ratio_decimal() {
+            if next_metrics.maintenance_ratio >= required_maintenance {
                 break;
             }
         }
-        outcome.forced_liquidation = true;
+        outcome.forced_liquidation = !outcome.forced_liquidation_events.is_empty();
         outcome
     }
 }
 
-fn compute_portfolio_metrics(
-    portfolio: &Portfolio,
-    prices: &HashMap<String, Decimal>,
-    instruments: &HashMap<String, Instrument>,
-) -> (Decimal, Decimal, Decimal) {
-    let mut gross_exposure = Decimal::ZERO;
-    for (symbol, quantity) in portfolio.positions.iter() {
-        if quantity.is_zero() {
-            continue;
-        }
-        let Some(price) = prices.get(symbol).copied() else {
-            continue;
-        };
-        if price <= Decimal::ZERO {
-            continue;
-        }
-        let multiplier = instruments
-            .get(symbol)
-            .map(|i| i.multiplier())
-            .unwrap_or(Decimal::ONE);
-        gross_exposure += quantity.abs() * price * multiplier;
+fn normalized_strategy_id(value: Option<String>) -> Option<String> {
+    value
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn forced_liquidation_order(
+    id: String,
+    symbol: String,
+    side: OrderSide,
+    quantity: Decimal,
+    price: Decimal,
+    timestamp: i64,
+    owner_strategy_id: Option<String>,
+) -> Order {
+    Order {
+        id,
+        symbol,
+        side,
+        order_type: OrderType::Market,
+        quantity,
+        price: Some(price),
+        time_in_force: TimeInForce::Day,
+        trigger_price: None,
+        trail_offset: None,
+        trail_reference_price: None,
+        fill_policy_override: None,
+        slippage_type_override: None,
+        slippage_value_override: None,
+        commission_type_override: None,
+        commission_value_override: None,
+        graph_id: None,
+        parent_order_id: None,
+        order_role: OrderRole::Standalone,
+        position_effect: PositionEffect::Close,
+        status: OrderStatus::New,
+        filled_quantity: Decimal::ZERO,
+        average_filled_price: None,
+        created_at: timestamp,
+        updated_at: timestamp,
+        commission: Decimal::ZERO,
+        tag: "__forced_liquidation__".to_string(),
+        reject_reason: String::new(),
+        owner_strategy_id,
+        allow_quantity_auto_resize: false,
+        reduce_only: true,
     }
-    let equity = portfolio.calculate_equity(prices, instruments);
-    (portfolio.cash, equity, gross_exposure)
+}
+
+fn apply_liquidation_trade_simulation(
+    portfolio: &mut Portfolio,
+    trade_tracker: &mut TradeTracker,
+    trade: &Trade,
+    instruments: &HashMap<String, Instrument>,
+    prices: &HashMap<String, Decimal>,
+    risk_config: &RiskConfig,
+) {
+    let Some(instr) = instruments.get(&trade.symbol) else {
+        return;
+    };
+    let multiplier = instr.multiplier();
+
+    if crate::account::is_futures_margin_account(instr, risk_config) {
+        let realized = estimate_futures_realized_pnl(
+            trade_tracker,
+            &trade.symbol,
+            trade.side,
+            trade.quantity,
+            trade.price,
+            multiplier,
+        );
+        portfolio.adjust_cash(realized);
+        if trade.side == OrderSide::Buy {
+            portfolio.adjust_position(&trade.symbol, trade.quantity);
+        } else {
+            portfolio.adjust_position(&trade.symbol, -trade.quantity);
+        }
+    } else {
+        let notional = trade.price * trade.quantity * multiplier;
+        if trade.side == OrderSide::Buy {
+            portfolio.adjust_cash(-notional);
+            portfolio.adjust_position(&trade.symbol, trade.quantity);
+        } else {
+            portfolio.adjust_cash(notional);
+            portfolio.adjust_position(&trade.symbol, -trade.quantity);
+        }
+    }
+
+    let portfolio_value = calculate_account_metrics(
+        portfolio,
+        prices,
+        instruments,
+        trade_tracker,
+        risk_config,
+    )
+    .equity;
+    trade_tracker.process_trade(
+        trade,
+        Some("__forced_liquidation__"),
+        None,
+        portfolio_value,
+    );
 }
 
 impl Default for SettlementManager {
@@ -343,6 +480,7 @@ impl Default for SettlementManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analysis::TradeTracker;
     use crate::model::instrument::{InstrumentEnum, StockInstrument};
     use crate::model::types::AssetType;
     use std::str::FromStr;
@@ -376,13 +514,18 @@ mod tests {
         risk.borrow_rate_annual = 0.0;
         risk.allow_force_liquidation = false;
         let market_manager = MarketManager::new();
+        let tracker = TradeTracker::new();
 
         let ctx = SettlementContext {
             date: NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date"),
             instruments: &instruments,
             last_prices: &prices,
             market_manager: &market_manager,
+            trade_tracker: &tracker,
             risk_config: &risk,
+            timestamp: 0,
+            bar_index: 0,
+            default_strategy_id: None,
         };
         let outcome = SettlementManager::new().process_daily_settlement(
             &mut portfolio,
@@ -418,13 +561,18 @@ mod tests {
         risk.allow_force_liquidation = true;
         risk.maintenance_margin_ratio = 0.5;
         let market_manager = MarketManager::new();
+        let tracker = TradeTracker::new();
 
         let ctx = SettlementContext {
             date: NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date"),
             instruments: &instruments,
             last_prices: &prices,
             market_manager: &market_manager,
+            trade_tracker: &tracker,
             risk_config: &risk,
+            timestamp: 0,
+            bar_index: 0,
+            default_strategy_id: None,
         };
         let outcome = SettlementManager::new().process_daily_settlement(
             &mut portfolio,
@@ -432,11 +580,9 @@ mod tests {
             &mut Vec::new(),
             &ctx,
         );
-        assert!(portfolio.positions.is_empty());
-        assert!(portfolio.available_positions.is_empty());
-        assert_eq!(portfolio.cash, Decimal::from(-2000));
         assert!(outcome.forced_liquidation);
         assert_eq!(outcome.liquidated_symbols, vec!["AAA".to_string()]);
+        assert_eq!(outcome.forced_liquidation_events.len(), 1);
     }
 
     #[test]
@@ -466,6 +612,8 @@ mod tests {
 
         let market_manager = MarketManager::new();
         let date = NaiveDate::from_ymd_opt(2024, 1, 2).expect("valid date");
+        let tracker_short = TradeTracker::new();
+        let tracker_long = TradeTracker::new();
 
         let mut portfolio_short_first = Portfolio {
             cash: Decimal::from(2000),
@@ -477,29 +625,17 @@ mod tests {
             instruments: &instruments,
             last_prices: &prices,
             market_manager: &market_manager,
+            trade_tracker: &tracker_short,
             risk_config: &risk_short_first,
+            timestamp: 0,
+            bar_index: 0,
+            default_strategy_id: None,
         };
         let outcome_short_first = SettlementManager::new().process_daily_settlement(
             &mut portfolio_short_first,
             &mut Vec::new(),
             &mut Vec::new(),
             &ctx_short_first,
-        );
-        assert_eq!(
-            portfolio_short_first
-                .positions
-                .get("SHORT")
-                .copied()
-                .unwrap_or(Decimal::ZERO),
-            Decimal::ZERO
-        );
-        assert_eq!(
-            portfolio_short_first
-                .positions
-                .get("LONG")
-                .copied()
-                .unwrap_or(Decimal::ZERO),
-            Decimal::from(100)
         );
         assert_eq!(
             outcome_short_first.liquidated_symbols,
@@ -516,29 +652,17 @@ mod tests {
             instruments: &instruments,
             last_prices: &prices,
             market_manager: &market_manager,
+            trade_tracker: &tracker_long,
             risk_config: &risk_long_first,
+            timestamp: 0,
+            bar_index: 0,
+            default_strategy_id: None,
         };
         let outcome_long_first = SettlementManager::new().process_daily_settlement(
             &mut portfolio_long_first,
             &mut Vec::new(),
             &mut Vec::new(),
             &ctx_long_first,
-        );
-        assert_eq!(
-            portfolio_long_first
-                .positions
-                .get("LONG")
-                .copied()
-                .unwrap_or(Decimal::ZERO),
-            Decimal::ZERO
-        );
-        assert_eq!(
-            portfolio_long_first
-                .positions
-                .get("SHORT")
-                .copied()
-                .unwrap_or(Decimal::ZERO),
-            Decimal::from(-50)
         );
         assert_eq!(
             outcome_long_first.liquidated_symbols,

--- a/tests/test_account_risk_rules.py
+++ b/tests/test_account_risk_rules.py
@@ -681,6 +681,215 @@ def test_futures_margin_account_snapshot_uses_margin_accounting() -> None:
     )
 
 
+def test_futures_short_overnight_avoids_spurious_liquidation() -> None:
+    """Short futures should not accrue stock-style borrow interest.
+
+    It also should not trigger spurious liquidation.
+    """
+
+    class FuturesShortOvernightProbeStrategy(Strategy):
+        account_snapshots: list[dict[str, Any]] = []
+
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.short(bar.symbol, 1.0)
+                self.ordered = True
+            self.__class__.account_snapshots.append(self.get_account())
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-04 22:30:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-04 23:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-05 09:30:00", tz="Asia/Shanghai"),
+        ],
+        [4008.0, 3999.0, 3985.0],
+        symbol="RB2305",
+    )
+    FuturesShortOvernightProbeStrategy.account_snapshots = []
+    result = run_backtest(
+        data=bars,
+        strategy=FuturesShortOvernightProbeStrategy,
+        symbols="RB2305",
+        show_progress=False,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(
+                initial_cash=500000.0,
+                commission_rate=0.0,
+                slippage=0.0,
+                min_commission=0.0,
+                stamp_tax_rate=0.0,
+                transfer_fee_rate=0.0,
+                risk=RiskConfig(
+                    account_mode="margin",
+                    check_cash=True,
+                    initial_margin_ratio=0.1,
+                    maintenance_margin_ratio=0.3,
+                    enable_short_sell=True,
+                    allow_force_liquidation=True,
+                    liquidation_priority="long_first",
+                ),
+            ),
+            china_futures=ChinaFuturesConfig(
+                enforce_sessions=False,
+                instrument_templates_by_symbol_prefix=[
+                    ChinaFuturesInstrumentTemplateConfig(
+                        symbol_prefix="RB",
+                        multiplier=10.0,
+                        margin_ratio=0.1,
+                        commission_rate=0.0,
+                        tick_size=1.0,
+                        lot_size=1.0,
+                    )
+                ],
+            ),
+        ),
+    )
+
+    assert len(FuturesShortOvernightProbeStrategy.account_snapshots) >= 3
+    day2_snapshot = FuturesShortOvernightProbeStrategy.account_snapshots[-1]
+    assert float(day2_snapshot.get("daily_interest", 0.0)) == pytest.approx(
+        0.0, rel=0.0, abs=1e-6
+    )
+    assert float(day2_snapshot.get("accrued_interest", 0.0)) == pytest.approx(
+        0.0, rel=0.0, abs=1e-6
+    )
+    assert result.liquidation_audit_df.empty
+    assert float(result.positions.iloc[-1].get("RB2305", 0.0)) == pytest.approx(
+        -1.0, rel=0.0, abs=1e-6
+    )
+
+
+def test_futures_force_liquidation_emits_callbacks_and_realizes_pnl_only() -> None:
+    """Forced liquidation should emit order/trade callbacks.
+
+    It should also keep futures equity on a PnL basis.
+    """
+
+    class FuturesForcedLiquidationProbeStrategy(Strategy):
+        order_events: list[dict[str, Any]] = []
+        trade_events: list[dict[str, Any]] = []
+        position_snapshots: list[float] = []
+
+        def __init__(self) -> None:
+            self.ordered = False
+
+        def on_bar(self, bar: Bar) -> None:
+            if not self.ordered:
+                self.short(bar.symbol, 1.0)
+                self.ordered = True
+            self.__class__.position_snapshots.append(
+                float(self.get_position(bar.symbol))
+            )
+
+        def on_order(self, order: Any) -> None:
+            self.__class__.order_events.append(
+                {
+                    "symbol": str(order.symbol),
+                    "side": str(order.side),
+                    "status": str(order.status),
+                    "filled_quantity": float(order.filled_quantity),
+                    "tag": str(getattr(order, "tag", "")),
+                }
+            )
+
+        def on_trade(self, trade: Any) -> None:
+            self.__class__.trade_events.append(
+                {
+                    "symbol": str(trade.symbol),
+                    "side": str(trade.side),
+                    "quantity": float(trade.quantity),
+                    "price": float(trade.price),
+                }
+            )
+
+    bars = _build_bars(
+        [
+            pd.Timestamp("2023-01-04 22:30:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-04 23:00:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-05 09:30:00", tz="Asia/Shanghai"),
+            pd.Timestamp("2023-01-05 10:00:00", tz="Asia/Shanghai"),
+        ],
+        [4000.0, 6000.0, 6000.0, 6000.0],
+        symbol="RB2305",
+    )
+    FuturesForcedLiquidationProbeStrategy.order_events = []
+    FuturesForcedLiquidationProbeStrategy.trade_events = []
+    FuturesForcedLiquidationProbeStrategy.position_snapshots = []
+    result = run_backtest(
+        data=bars,
+        strategy=FuturesForcedLiquidationProbeStrategy,
+        symbols="RB2305",
+        show_progress=False,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(
+                initial_cash=5000.0,
+                commission_rate=0.0,
+                slippage=0.0,
+                min_commission=0.0,
+                stamp_tax_rate=0.0,
+                transfer_fee_rate=0.0,
+                risk=RiskConfig(
+                    account_mode="margin",
+                    check_cash=True,
+                    initial_margin_ratio=0.1,
+                    maintenance_margin_ratio=0.3,
+                    enable_short_sell=True,
+                    allow_force_liquidation=True,
+                    liquidation_priority="long_first",
+                ),
+            ),
+            china_futures=ChinaFuturesConfig(
+                enforce_sessions=False,
+                instrument_templates_by_symbol_prefix=[
+                    ChinaFuturesInstrumentTemplateConfig(
+                        symbol_prefix="RB",
+                        multiplier=10.0,
+                        margin_ratio=0.1,
+                        commission_rate=0.0,
+                        tick_size=1.0,
+                        lot_size=1.0,
+                    )
+                ],
+            ),
+        ),
+    )
+
+    assert not result.liquidation_audit_df.empty
+    assert (
+        result.orders_df["status"].astype(str).str.lower().tolist().count("filled") == 2
+    )
+    assert len(result.trades_df) == 1
+    assert float(result.trades_df.iloc[0]["exit_price"]) == pytest.approx(
+        6000.0, rel=0.0, abs=1e-6
+    )
+    assert float(result.positions.iloc[-1].get("RB2305", 0.0)) == pytest.approx(
+        0.0, rel=0.0, abs=1e-6
+    )
+    assert float(result.equity_curve.iloc[-1]) == pytest.approx(
+        -15000.0, rel=0.0, abs=1e-6
+    )
+
+    assert any(
+        event["tag"] == "__forced_liquidation__"
+        and event["status"].lower().endswith("filled")
+        for event in FuturesForcedLiquidationProbeStrategy.order_events
+    )
+    assert len(FuturesForcedLiquidationProbeStrategy.trade_events) == 2
+    assert (
+        FuturesForcedLiquidationProbeStrategy.trade_events[-1]["side"]
+        .lower()
+        .endswith("buy")
+    )
+    assert FuturesForcedLiquidationProbeStrategy.position_snapshots[
+        -1
+    ] == pytest.approx(0.0, rel=0.0, abs=1e-6)
+
+
 def test_futures_margin_portfolio_update_can_read_account_metrics() -> None:
     """Portfolio update callback should read cached futures account metrics safely."""
 


### PR DESCRIPTION
- 修复期货空仓账户的隔夜利息计算错误，避免收取非现货空仓的不必要利息
- 完善订单管理器逻辑，支持处理直接为成交状态的订单报告
- 重构结算管理器，新增强制平仓事件回调与正确的保证金清算逻辑
- 新增两个测试用例覆盖期货空仓隔夜防虚假平仓和强制平仓场景
- 完善流水线处理器的参数传递，添加策略ID到风险告警日志