### PR TITLE
feat(indicator): 新增自定义指标可视化、流式传输与导出功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 # Local cargo config
 .cargo/config.toml
 /data_catalog/
+plans/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.33"
+version = "0.2.34"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.33"
+version = "0.2.34"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/custom_indicator.md
+++ b/docs/en/guide/custom_indicator.md
@@ -199,6 +199,228 @@ Many users mix up "custom strategy indicators" and "extending `akquant.talib`". 
 
 If you only need a private signal inside one strategy, prefer a custom strategy indicator instead of extending `akquant.talib`.
 
+## Export Indicators For Frontend Use
+
+If your goal is not only to use a custom indicator inside the strategy, but also to send the indicator output to a web frontend, treat indicator calculation and indicator output as separate concerns:
+
+- keep indicator calculation inside `Strategy` / `Indicator`;
+- use `Strategy.record_indicator(...)` to record normalized indicator points;
+- after the run, use `BacktestResult.indicator_df(...)` or `export_indicators(...)` for downstream systems.
+
+### Minimal example
+
+```python
+from akquant import Bar, Strategy
+
+
+class IndicatorExportStrategy(Strategy):
+    def on_bar(self, bar: Bar) -> None:
+        spread = bar.high - bar.low
+        self.record_indicator(
+            name="intrabar_spread",
+            value=spread,
+            display_name="Intra Bar Spread",
+            pane="sub",
+            render_type="line",
+            precision=4,
+            meta={"source": ["high", "low"]},
+        )
+```
+
+After the run:
+
+```python
+result = ...
+
+# 1) Read inside Python
+indicator_df = result.indicator_df(name="intrabar_spread", symbol="AAPL")
+
+# 2) Generate a lightweight local preview
+fig = result.plot_indicators(
+    name="intrabar_spread",
+    symbol="AAPL",
+    show=False,
+    filename="indicator_preview.html",
+)
+
+# 3) Export for frontend or external services
+result.export_indicators("indicator_outputs.json", format="json")
+result.export_indicators("indicator_outputs", format="parquet")
+```
+
+When available, the JSON export also includes a top-level `run_id` so downstream services can correlate offline exports with the streaming event flow.
+
+### Built-in Minimal Visualization
+
+If you only want a quick history preview before wiring a full frontend, use:
+
+- `result.plot_indicators(...)`
+- `from akquant.plot import plot_indicators`
+
+This built-in path is intentionally lightweight:
+
+- it keeps `result.plot()` focused on the existing account dashboard;
+- it splits subplots by `pane`;
+- it reuses `render_type`, with day-one support for common `line` and `bar`;
+- it supports filtering by `name`, `symbol`, and `include_warmup`;
+- it can write a local HTML file for quick inspection alongside exported JSON.
+
+Example:
+
+```python
+fig = result.plot_indicators(
+    name="intrabar_spread",
+    symbol="AAPL",
+    include_warmup=False,
+    show=False,
+    filename="indicator_preview.html",
+    title="Indicator Preview",
+)
+```
+
+If you need enterprise-grade multi-panel UX, persistence, permissions, or realtime subscriptions, keep those concerns in external systems and let AKQuant stay responsible for the preview plus normalized data production.
+
+### Optional Indicator Section In Reports
+
+If you want the indicator preview embedded into the built-in HTML report instead of a separate figure, enable it explicitly:
+
+```python
+result.report(
+    filename="akquant_report.html",
+    show=False,
+    include_indicators=True,
+    indicator_name="intrabar_spread",
+    indicator_symbol="AAPL",
+    indicator_include_warmup=False,
+)
+```
+
+This path is intentionally constrained:
+
+- it is off by default, so existing `report()` output does not change;
+- it is meant for a lightweight indicator section inside the strategy report;
+- if no indicator data exists, the report shows an empty-state notice;
+- if you need richer interaction or layout control, keep that in external frontend systems.
+
+### Bridging Stream Events To Frontend Messages
+
+If your external service is a WebSocket or SSE gateway, keep the raw payload parsing out of your business code and use:
+
+- `akquant.is_indicator_stream_event(event)`
+- `akquant.to_indicator_message(event)`
+- `akquant.to_indicator_messages(events)`
+
+Example:
+
+```python
+def on_event(event):
+    if not aq.is_indicator_stream_event(event):
+        return
+    message = aq.to_indicator_message(event)
+    if message is not None:
+        websocket.broadcast_json(message)
+```
+
+These helpers are meant to:
+
+- bridge only `indicator_point` and `indicator_snapshot`
+- coerce numeric fields into frontend-friendly values
+- unpack `meta_json` and `items_json`
+- preserve the outer stream semantics such as `run_id`, `seq`, and `ts`
+
+The bridged `snapshot` payload now also includes a few shortcut fields so frontend
+code does not have to rescan `items` on every update:
+
+- `indicator_keys`
+- `panes`
+- `render_types`
+- `value_by_key`
+- `items_by_key`
+- `warmup_count`
+- `has_warmup`
+
+The bridge helper also normalizes `_unknown` or empty `symbol` values into `None`,
+and accepts already-decoded `dict/list` values for `meta_json` and `items_json`,
+which makes gateway-side wrapping easier.
+
+This is not a new transport layer. It is just a normalization layer that turns AKQuant stream events into steadier frontend message objects.
+
+### Zero-Dependency Browser Live Preview
+
+If you want a browser-based demo that product or frontend teammates can open
+immediately, but you do not want to introduce `fastapi`, `uvicorn`, or
+`websockets` yet, use `examples/64_indicator_live_web.py`.
+
+This example does three things:
+
+- consumes stream events with `run_backtest(..., on_event=...)`
+- normalizes them with `aq.to_indicator_message(event)`
+- serves a tiny `/state` JSON endpoint via built-in `http.server`, then lets the browser poll and draw the `close_echo` line
+
+It now supports two polling modes:
+
+- request `/state` for the recent full snapshot window
+- request `/state?since_seq=123` for incremental messages with `seq > 123`, while still returning total counts and the latest cursor
+
+The payload shape now separates common metadata from message bodies:
+
+- shared fields live under `cursor`, `counts`, and `latest_indicator_values`
+- full snapshot mode returns message windows under `window.point_messages` and `window.snapshot_messages`
+- incremental mode returns only new messages under `delta.point_messages` and `delta.snapshot_messages`
+
+Run it with:
+
+```bash
+UV_INDEX_URL=https://pypi.org/simple uv run python examples/64_indicator_live_web.py --open
+```
+
+For a quick smoke check, keep the server alive for a shorter window:
+
+```bash
+UV_INDEX_URL=https://pypi.org/simple uv run python examples/64_indicator_live_web.py --keep-seconds 1
+```
+
+The goal is not to become a full frontend product. The goal is to help you:
+
+- verify that indicator stream data is leaving the backtest correctly
+- give frontend code a stable `/state` JSON shape to consume first
+- demonstrate live indicator rendering without adding new dependencies
+
+### Current output shape
+
+The first implementation exposes three structured layers:
+
+- indicator definitions, such as `display_name`, `pane`, and `render_type`
+- indicator instances grouped by `strategy/symbol/indicator/meta`
+- indicator points as the actual time series values
+
+This keeps AKQuant focused on producing stable indicator data instead of coupling the framework to a specific charting library.
+
+### Recommended boundary
+
+Suggested split of responsibilities:
+
+- `AKQuant` owns:
+  - indicator calculation
+  - indicator recording
+  - indicator query
+  - indicator export
+- external systems own:
+  - persistence
+  - APIs
+  - websocket delivery
+  - frontend applications
+
+In short, AKQuant should act as the indicator producer, not the full enterprise frontend platform.
+
+### Recommended examples
+
+- [60_custom_indicator_demo.py](https://github.com/akfamily/akquant/blob/main/examples/60_custom_indicator_demo.py)
+- [61_indicator_visualization_export_demo.py](https://github.com/akfamily/akquant/blob/main/examples/61_indicator_visualization_export_demo.py)
+- [62_indicator_streaming_demo.py](https://github.com/akfamily/akquant/blob/main/examples/62_indicator_streaming_demo.py)
+- [63_indicator_ws_bridge_demo.py](https://github.com/akfamily/akquant/blob/main/examples/63_indicator_ws_bridge_demo.py)
+- [64_indicator_live_web.py](https://github.com/akfamily/akquant/blob/main/examples/64_indicator_live_web.py)
+
 ## Common Pitfalls
 
 - Pitfall 1: every custom indicator must inherit from `Indicator`

--- a/docs/zh/guide/custom_indicator.md
+++ b/docs/zh/guide/custom_indicator.md
@@ -201,6 +201,226 @@ def __setstate__(self, state):
 
 如果你只是要一个策略内的私有信号，优先写自定义指标，而不是去扩展 `akquant.talib`。
 
+## 导出指标给前端
+
+如果你的目标不只是“在策略里使用指标”，而是要把指标结果进一步交给 Web 前端展示，建议把“计算指标”和“输出指标”分开处理：
+
+- 指标计算仍然放在 `Strategy` / `Indicator` 里；
+- 指标输出使用 `Strategy.record_indicator(...)` 记录标准化点位；
+- 回测结束后，通过 `BacktestResult.indicator_df(...)` 或 `export_indicators(...)` 交给外部服务或前端。
+
+### 最小示例
+
+```python
+from akquant import Bar, Strategy
+
+
+class IndicatorExportStrategy(Strategy):
+    def on_bar(self, bar: Bar) -> None:
+        spread = bar.high - bar.low
+        self.record_indicator(
+            name="intrabar_spread",
+            value=spread,
+            display_name="Intra Bar Spread",
+            pane="sub",
+            render_type="line",
+            precision=4,
+            meta={"source": ["high", "low"]},
+        )
+```
+
+运行结束后：
+
+```python
+result = ...
+
+# 1) 在 Python 里直接读取
+indicator_df = result.indicator_df(name="intrabar_spread", symbol="AAPL")
+
+# 2) 在本地做一个轻量预览
+fig = result.plot_indicators(
+    name="intrabar_spread",
+    symbol="AAPL",
+    show=False,
+    filename="indicator_preview.html",
+)
+
+# 3) 导出给前端或外部服务
+result.export_indicators("indicator_outputs.json", format="json")
+result.export_indicators("indicator_outputs", format="parquet")
+```
+
+其中 JSON 导出在可用时会额外带上顶层 `run_id`，方便外部服务把离线导出与流式事件链路关联起来。
+
+### 内置最小可视化
+
+如果你只是想快速确认指标历史形态，而不是立刻接入完整前端，可以直接使用：
+
+- `result.plot_indicators(...)`
+- `from akquant.plot import plot_indicators`
+
+这条内置路径的定位是“轻量 history preview”，特点是：
+
+- 保持现有 `result.plot()` 继续只做账户 dashboard；
+- 按 `pane` 自动拆分子图；
+- 复用 `render_type`，第一版支持常见的 `line` / `bar`；
+- 支持 `name`、`symbol`、`include_warmup` 过滤；
+- 可直接输出为本地 HTML，方便和导出的 JSON 一起联调。
+
+例如：
+
+```python
+fig = result.plot_indicators(
+    name="intrabar_spread",
+    symbol="AAPL",
+    include_warmup=False,
+    show=False,
+    filename="indicator_preview.html",
+    title="Indicator Preview",
+)
+```
+
+如果你需要的是企业级多图联动、权限、持久化和实时订阅，这些仍建议放在外部平台实现；AKQuant 内部只提供最小预览和标准化数据输出。
+
+### 报告中的可选指标区块
+
+如果你希望把指标预览放进内置 HTML 报告，而不是单独输出一个图，也可以显式开启：
+
+```python
+result.report(
+    filename="akquant_report.html",
+    show=False,
+    include_indicators=True,
+    indicator_name="intrabar_spread",
+    indicator_symbol="AAPL",
+    indicator_include_warmup=False,
+)
+```
+
+这条路径有几个约束：
+
+- 默认关闭，不会改变现有 `report()` 的输出；
+- 适合把“一个轻量指标区块”嵌进策略报告；
+- 如果没有指标数据，会在报告里显示空状态提示；
+- 如果你需要复杂交互布局，仍建议交给外部前端实现。
+
+### 流式桥接到前端消息
+
+如果你的外部服务是 WebSocket / SSE 网关，推荐不要把原始 `payload` 解析逻辑散落在业务代码里，可以直接使用：
+
+- `akquant.is_indicator_stream_event(event)`
+- `akquant.to_indicator_message(event)`
+- `akquant.to_indicator_messages(events)`
+
+例如：
+
+```python
+def on_event(event):
+    if not aq.is_indicator_stream_event(event):
+        return
+    message = aq.to_indicator_message(event)
+    if message is not None:
+        websocket.broadcast_json(message)
+```
+
+这条 helper 的目标是：
+
+- 只桥接 `indicator_point` / `indicator_snapshot`
+- 把数值字段转成更适合前端消费的类型
+- 自动解开 `meta_json` / `items_json`
+- 保留 `run_id`、`seq`、`ts` 等外层流式语义
+
+当前 `snapshot` 桥接结果除了 `items` 之外，还会补充几组快捷字段，方便前端减少二次遍历：
+
+- `indicator_keys`
+- `panes`
+- `render_types`
+- `value_by_key`
+- `items_by_key`
+- `warmup_count`
+- `has_warmup`
+
+另外，bridge helper 也会把 `_unknown` / 空 `symbol` 规整为 `None`，并兼容已经预先解码成
+`dict/list` 的 `meta_json` / `items_json` 值，便于网关层做二次封装。
+
+它不是新的传输层，只是把 AKQuant 的事件结构整理成更稳定的“前端消息对象”。
+
+### 零依赖浏览器实时预览
+
+如果你想先给业务方或前端同事一个“打开浏览器就能看到”的最小接入样板，而暂时不引入
+`fastapi`、`uvicorn` 或 `websockets` 等依赖，可以直接参考
+`examples/64_indicator_live_web.py`。
+
+这个示例做了三件事：
+
+- 用 `run_backtest(..., on_event=...)` 接收流式事件；
+- 用 `aq.to_indicator_message(event)` 规整成前端友好消息；
+- 用内置 `http.server` 暴露 `/state` JSON，并由浏览器轮询绘制 `close_echo` 折线。
+
+现在这个示例同时支持两种轮询方式：
+
+- 直接请求 `/state`，拿最近窗口内的完整快照；
+- 请求 `/state?since_seq=123`，只拿 `seq > 123` 的增量消息，同时保留总量统计和最新游标。
+
+当前返回结构也做了区分，便于前端减少分支歧义：
+
+- 公共字段放在 `cursor`、`counts`、`latest_indicator_values`
+- 全量模式把消息窗口放在 `window.point_messages` / `window.snapshot_messages`
+- 增量模式把新增消息放在 `delta.point_messages` / `delta.snapshot_messages`
+
+运行方式：
+
+```bash
+UV_INDEX_URL=https://pypi.org/simple uv run python examples/64_indicator_live_web.py --open
+```
+
+如果你只是想快速验证链路，也可以缩短保活时间：
+
+```bash
+UV_INDEX_URL=https://pypi.org/simple uv run python examples/64_indicator_live_web.py --keep-seconds 1
+```
+
+这个样板的定位不是完整前端产品，而是帮助你更快完成以下工作：
+
+- 验证指标流是否已经成功出站；
+- 让前端先对接稳定的消息结构和 `/state` JSON；
+- 在不新增依赖栈的前提下演示实时指标预览效果。
+
+### 当前输出结构
+
+第一版实现会输出三类结构化结果：
+
+- 指标定义：如 `display_name`、`pane`、`render_type`
+- 指标实例：按 `strategy/symbol/indicator/meta` 归并后的实例信息
+- 指标点位：按时间记录的数值序列
+
+这三层结构的目的，是让 AKQuant 负责“生产标准化指标数据”，而不是直接耦合某个具体前端图表库。
+
+### 推荐边界
+
+建议把职责切开：
+
+- `AKQuant` 内部负责：
+  - 指标计算
+  - 指标记录
+  - 指标查询
+  - 指标导出
+- 外部平台负责：
+  - 存储服务
+  - API 查询
+  - WebSocket 推送
+  - 前端图表页面
+
+也就是说，AKQuant 更适合作为“指标生产者”，而不是企业前端平台本身。
+
+### 推荐示例
+
+- [60_custom_indicator_demo.py](https://github.com/akfamily/akquant/blob/main/examples/60_custom_indicator_demo.py)
+- [61_indicator_visualization_export_demo.py](https://github.com/akfamily/akquant/blob/main/examples/61_indicator_visualization_export_demo.py)
+- [62_indicator_streaming_demo.py](https://github.com/akfamily/akquant/blob/main/examples/62_indicator_streaming_demo.py)
+- [63_indicator_ws_bridge_demo.py](https://github.com/akfamily/akquant/blob/main/examples/63_indicator_ws_bridge_demo.py)
+- [64_indicator_live_web.py](https://github.com/akfamily/akquant/blob/main/examples/64_indicator_live_web.py)
+
 ## 常见误区
 
 - 误区 1：所有自定义指标都必须继承 `Indicator`

--- a/examples/61_indicator_visualization_export_demo.py
+++ b/examples/61_indicator_visualization_export_demo.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+AKQuant indicator visualization export demo.
+
+This example shows the minimal workflow for frontend-facing indicator output:
+1. Run a strategy that records custom indicator points.
+2. Read indicator series from `BacktestResult.indicator_df(...)`.
+3. Render a lightweight local preview with `plot_indicators(...)`.
+4. Export normalized indicator outputs to JSON.
+"""
+
+from pathlib import Path
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def make_demo_bars() -> list[Bar]:
+    """Build deterministic data for indicator export demo."""
+    closes = [10.0, 10.4, 10.9, 10.7, 11.2]
+    bars: list[Bar] = []
+    for i, close in enumerate(closes):
+        bars.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2024-02-0{i + 1} 10:00:00").value,
+                open=close - 0.1,
+                high=close + 0.2,
+                low=close - 0.3,
+                close=close,
+                volume=1000.0 + float(i) * 50.0,
+                symbol="VIS",
+            )
+        )
+    return bars
+
+
+class IndicatorVisualizationStrategy(Strategy):
+    """Record one custom visualization-oriented indicator on every bar."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Record one spread-style indicator for export and preview."""
+        intrabar_spread = bar.high - bar.low
+        self.record_indicator(
+            name="intrabar_spread",
+            value=intrabar_spread,
+            display_name="Intra Bar Spread",
+            pane="sub",
+            render_type="line",
+            precision=4,
+            meta={"source": ["high", "low"]},
+        )
+
+
+def main() -> None:
+    """Run backtest, preview indicator history, and export indicator data."""
+    result = aq.run_backtest(
+        data=make_demo_bars(),
+        strategy=IndicatorVisualizationStrategy,
+        symbols="VIS",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+    )
+
+    indicator_df = result.indicator_df(name="intrabar_spread", symbol="VIS")
+    html_path = Path(__file__).with_name("indicator_visualization_preview.html")
+    export_path = Path(__file__).with_name("indicator_visualization_outputs.json")
+    result.plot_indicators(
+        name="intrabar_spread",
+        symbol="VIS",
+        show=False,
+        filename=str(html_path),
+        title="AKQuant Indicator Preview",
+    )
+    result.export_indicators(str(export_path), format="json")
+
+    print(indicator_df[["datetime", "indicator_key", "symbol", "value"]])
+    print(f"indicator_rows={len(indicator_df)}")
+    print(f"indicator_plot_html={html_path.resolve()}")
+    print(f"indicator_export_json={export_path.resolve()}")
+    print("done_indicator_visualization_export_demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/62_indicator_streaming_demo.py
+++ b/examples/62_indicator_streaming_demo.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+AKQuant indicator streaming demo.
+
+This example shows the minimal runtime workflow for indicator stream events:
+1. Run a strategy that records custom indicators.
+2. Consume `indicator_point` and `indicator_snapshot` from `on_event`.
+3. Demonstrate stream sampling controls for indicator events.
+"""
+
+import json
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def make_demo_bars() -> list[Bar]:
+    """Build deterministic bars for indicator stream consumption."""
+    closes = [10.0, 10.4, 10.9, 10.7, 11.2]
+    bars: list[Bar] = []
+    for i, close in enumerate(closes):
+        bars.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2024-03-0{i + 1} 10:00:00").value,
+                open=close - 0.1,
+                high=close + 0.2,
+                low=close - 0.3,
+                close=close,
+                volume=1000.0 + float(i) * 10.0,
+                symbol="STREAM_IND",
+            )
+        )
+    return bars
+
+
+class IndicatorStreamingStrategy(Strategy):
+    """Record two indicators so stream events can show point and snapshot payloads."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Emit a price echo and a simple range metric on every bar."""
+        self.record_indicator(
+            name="close_echo",
+            value=bar.close,
+            display_name="Close Echo",
+            pane="main",
+            render_type="line",
+            precision=2,
+        )
+        self.record_indicator(
+            name="intrabar_range",
+            value=bar.high - bar.low,
+            display_name="Intrabar Range",
+            pane="signal",
+            render_type="bar",
+            precision=2,
+        )
+
+
+def run_full_stream(data: list[Bar]) -> list[aq.BacktestStreamEvent]:
+    """Collect all stream events without indicator sampling."""
+    events: list[aq.BacktestStreamEvent] = []
+    aq.run_backtest(
+        data=data,
+        strategy=IndicatorStreamingStrategy,
+        symbols="STREAM_IND",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+        on_event=events.append,
+        stream_progress_interval=16,
+        stream_equity_interval=16,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+    return events
+
+
+def run_sampled_stream(data: list[Bar]) -> list[aq.BacktestStreamEvent]:
+    """Collect stream events with indicator sampling enabled."""
+    events: list[aq.BacktestStreamEvent] = []
+    aq.run_backtest(
+        data=data,
+        strategy=IndicatorStreamingStrategy,
+        symbols="STREAM_IND",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+        on_event=events.append,
+        indicator_stream_point_interval=2,
+        indicator_stream_snapshot_interval=2,
+        stream_progress_interval=16,
+        stream_equity_interval=16,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+    return events
+
+
+def main() -> None:
+    """Run full and sampled indicator streams, then print compact summaries."""
+    data = make_demo_bars()
+    full_events = run_full_stream(data)
+    sampled_events = run_sampled_stream(data)
+
+    full_point_events = [
+        event for event in full_events if event["event_type"] == "indicator_point"
+    ]
+    full_snapshot_events = [
+        event for event in full_events if event["event_type"] == "indicator_snapshot"
+    ]
+    sampled_point_events = [
+        event for event in sampled_events if event["event_type"] == "indicator_point"
+    ]
+    sampled_snapshot_events = [
+        event for event in sampled_events if event["event_type"] == "indicator_snapshot"
+    ]
+
+    first_point_payload = full_point_events[0]["payload"] if full_point_events else {}
+    first_snapshot_payload = (
+        full_snapshot_events[0]["payload"] if full_snapshot_events else {}
+    )
+    first_snapshot_items = json.loads(first_snapshot_payload.get("items_json", "[]"))
+
+    full_seq_values = [int(event["seq"]) for event in full_events]
+    print(f"full_indicator_point_events={len(full_point_events)}")
+    print(f"full_indicator_snapshot_events={len(full_snapshot_events)}")
+    print(f"sampled_indicator_point_events={len(sampled_point_events)}")
+    print(f"sampled_indicator_snapshot_events={len(sampled_snapshot_events)}")
+    print(f"stream_seq_monotonic={full_seq_values == sorted(full_seq_values)}")
+    print(
+        "first_indicator_point="
+        f"{first_point_payload.get('indicator_key')}:{first_point_payload.get('value')}"
+    )
+    print(
+        "first_indicator_snapshot_count="
+        f"{first_snapshot_payload.get('indicator_count', '0')}"
+    )
+    print(f"first_indicator_snapshot_items={len(first_snapshot_items)}")
+    print("done_indicator_streaming_demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/63_indicator_ws_bridge_demo.py
+++ b/examples/63_indicator_ws_bridge_demo.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+AKQuant indicator websocket bridge demo.
+
+This example shows one minimal enterprise-facing workflow:
+1. Run a strategy that records custom indicators.
+2. Receive indicator events from `on_event`.
+3. Convert those events into frontend-friendly websocket messages.
+"""
+
+import json
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def make_demo_bars() -> list[Bar]:
+    """Build deterministic bars for websocket bridge demo."""
+    closes = [10.0, 10.3, 10.8, 10.6]
+    bars: list[Bar] = []
+    for i, close in enumerate(closes):
+        bars.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2024-04-0{i + 1} 10:00:00").value,
+                open=close - 0.1,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=1000.0 + float(i) * 20.0,
+                symbol="WS_IND",
+            )
+        )
+    return bars
+
+
+class IndicatorBridgeStrategy(Strategy):
+    """Record indicators that are later bridged to websocket-style messages."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Emit one line-series point and one bar-style signal."""
+        self.record_indicator(
+            name="close_echo",
+            value=bar.close,
+            display_name="Close Echo",
+            pane="main",
+            render_type="line",
+            meta={"source": "close"},
+        )
+        self.record_indicator(
+            name="daily_range",
+            value=bar.high - bar.low,
+            display_name="Daily Range",
+            pane="signal",
+            render_type="bar",
+            meta={"source": ["high", "low"]},
+        )
+
+
+def main() -> None:
+    """Run the bridge demo and print example websocket-ready messages."""
+    events: list[aq.BacktestStreamEvent] = []
+    aq.run_backtest(
+        data=make_demo_bars(),
+        strategy=IndicatorBridgeStrategy,
+        symbols="WS_IND",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+        on_event=events.append,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+
+    messages = aq.to_indicator_messages(events)
+    point_messages = [message for message in messages if message["type"] == "point"]
+    snapshot_messages = [
+        message for message in messages if message["type"] == "snapshot"
+    ]
+
+    print(f"bridge_message_count={len(messages)}")
+    print(f"bridge_point_message_count={len(point_messages)}")
+    print(f"bridge_snapshot_message_count={len(snapshot_messages)}")
+    if point_messages:
+        print(
+            "bridge_first_point_message="
+            + json.dumps(point_messages[0], ensure_ascii=True)
+        )
+    if snapshot_messages:
+        print(
+            "bridge_first_snapshot_message="
+            + json.dumps(snapshot_messages[0], ensure_ascii=True)
+        )
+    print("done_indicator_ws_bridge_demo")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/64_indicator_live_web.py
+++ b/examples/64_indicator_live_web.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+AKQuant live indicator web demo.
+
+This example shows a zero-extra-dependency browser demo for enterprise integration:
+1. Run a backtest with indicator stream events enabled.
+2. Bridge raw events into frontend-friendly indicator messages.
+3. Serve a tiny polling web page that renders live indicator values.
+"""
+
+import argparse
+import json
+import threading
+import time
+import webbrowser
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import parse_qs, urlsplit
+
+import akquant as aq
+import pandas as pd
+from akquant import Bar, Strategy
+
+
+def build_data(n: int = 90) -> pd.DataFrame:
+    """Build synthetic bars that generate visible indicator movement."""
+    ts = pd.date_range("2024-01-01", periods=n, freq="D")
+    rows = []
+    for i, dt in enumerate(ts):
+        close = 100.0 + 0.12 * i + 2.6 * __import__("math").sin(i / 6.0)
+        rows.append(
+            {
+                "date": dt,
+                "open": close - 0.2,
+                "high": close + 0.4,
+                "low": close - 0.5,
+                "close": close,
+                "volume": 1000.0 + float(i % 20) * 50.0,
+                "symbol": "LIVE_IND",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+class LiveIndicatorStrategy(Strategy):
+    """Emit two simple indicators for live browser preview."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Record a main-pane line and a signal-pane bar metric."""
+        self.record_indicator(
+            name="close_echo",
+            value=bar.close,
+            display_name="Close Echo",
+            pane="main",
+            render_type="line",
+            meta={"source": "close"},
+        )
+        self.record_indicator(
+            name="intrabar_range",
+            value=bar.high - bar.low,
+            display_name="Intrabar Range",
+            pane="signal",
+            render_type="bar",
+            meta={"source": ["high", "low"]},
+        )
+
+
+@dataclass
+class IndicatorLiveState:
+    """Shared state polled by the browser page."""
+
+    started: bool = False
+    finished: bool = False
+    run_id: str = ""
+    point_messages: list[dict[str, Any]] | None = None
+    snapshot_messages: list[dict[str, Any]] | None = None
+    latest_indicator_values: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        """Initialize mutable defaults."""
+        self.point_messages = []
+        self.snapshot_messages = []
+        self.latest_indicator_values = {}
+
+
+def _message_seq(message: dict[str, Any]) -> int:
+    """Extract comparable seq from one bridged message."""
+    try:
+        return int(message.get("seq", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _build_state_payload(
+    state: IndicatorLiveState,
+    *,
+    since_seq: int | None = None,
+) -> dict[str, Any]:
+    """Build full or incremental browser state payload."""
+    point_messages = list(state.point_messages or [])
+    snapshot_messages = list(state.snapshot_messages or [])
+    latest_seq = 0
+    if point_messages:
+        latest_seq = max(
+            latest_seq, max(_message_seq(message) for message in point_messages)
+        )
+    if snapshot_messages:
+        latest_seq = max(
+            latest_seq, max(_message_seq(message) for message in snapshot_messages)
+        )
+
+    payload = {
+        "started": state.started,
+        "finished": state.finished,
+        "run_id": state.run_id,
+        "latest_indicator_values": dict(state.latest_indicator_values or {}),
+        "counts": {
+            "point_messages": len(point_messages),
+            "snapshot_messages": len(snapshot_messages),
+        },
+        "cursor": {
+            "latest_seq": latest_seq,
+            "since_seq": since_seq,
+            "incremental": since_seq is not None,
+        },
+    }
+    if since_seq is None:
+        payload["window"] = {
+            "point_messages": point_messages,
+            "snapshot_messages": snapshot_messages,
+        }
+        return payload
+
+    payload["delta"] = {
+        "point_messages": [
+            message for message in point_messages if _message_seq(message) > since_seq
+        ],
+        "snapshot_messages": [
+            message
+            for message in snapshot_messages
+            if _message_seq(message) > since_seq
+        ],
+    }
+    return payload
+
+
+def make_handler(
+    state: IndicatorLiveState, lock: threading.Lock
+) -> type[BaseHTTPRequestHandler]:
+    """Create one request handler bound to shared indicator state."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            split_result = urlsplit(self.path)
+            req_path = split_result.path
+            if req_path == "/state":
+                query = parse_qs(split_result.query)
+                since_seq_raw = query.get("since_seq", [None])[0]
+                since_seq: int | None = None
+                if isinstance(since_seq_raw, str) and since_seq_raw != "":
+                    try:
+                        since_seq = int(since_seq_raw)
+                    except (TypeError, ValueError):
+                        since_seq = None
+                with lock:
+                    payload = _build_state_payload(state, since_seq=since_seq)
+                body = json.dumps(payload, ensure_ascii=True).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+
+            if req_path != "/":
+                self.send_response(404)
+                self.end_headers()
+                return
+
+            html = """
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>AKQuant Indicator Live Demo</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 20px;
+      background: #fafafa;
+      color: #222;
+    }
+    .row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+    .card {
+      background: #fff;
+      border: 1px solid #e6e6e6;
+      border-radius: 8px;
+      padding: 14px;
+      min-width: 220px;
+    }
+    .title { font-size: 13px; color: #666; margin-bottom: 6px; }
+    .value { font-size: 22px; font-weight: 700; }
+    .section {
+      background: #fff;
+      border: 1px solid #e6e6e6;
+      border-radius: 8px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }
+    canvas {
+      width: 100%;
+      height: 280px;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      background: #fff;
+    }
+    pre { margin: 0; white-space: pre-wrap; word-break: break-word; }
+  </style>
+</head>
+<body>
+  <h2>AKQuant Indicator Live Browser Demo</h2>
+  <div class="row">
+    <div class="card">
+      <div class="title">run_id</div>
+      <div class="value" id="run_id">-</div>
+    </div>
+    <div class="card">
+      <div class="title">status</div>
+      <div class="value" id="status">waiting</div>
+    </div>
+    <div class="card">
+      <div class="title">point_messages</div>
+      <div class="value" id="point_count">0</div>
+    </div>
+    <div class="card">
+      <div class="title">snapshot_messages</div>
+      <div class="value" id="snapshot_count">0</div>
+    </div>
+  </div>
+  <div class="section">
+    <h3>Close Echo</h3>
+    <canvas id="close_chart" width="1200" height="280"></canvas>
+  </div>
+  <div class="section">
+    <h3>Latest Indicator Values</h3>
+    <pre id="latest_values">{}</pre>
+  </div>
+  <div class="section">
+    <h3>Latest Snapshot</h3>
+    <pre id="latest_snapshot">-</pre>
+  </div>
+  <script>
+    const closeCtx = document.getElementById("close_chart").getContext("2d");
+    const runIdEl = document.getElementById("run_id");
+    const statusEl = document.getElementById("status");
+    const pointCountEl = document.getElementById("point_count");
+    const snapshotCountEl = document.getElementById("snapshot_count");
+    const latestValuesEl = document.getElementById("latest_values");
+    const latestSnapshotEl = document.getElementById("latest_snapshot");
+    let livePointMessages = [];
+    let liveSnapshotMessages = [];
+    let lastSeq = null;
+
+    function drawLine(ctx, values) {
+      const w = ctx.canvas.width;
+      const h = ctx.canvas.height;
+      ctx.clearRect(0, 0, w, h);
+      if (!values || values.length < 2) return;
+      let minV = Math.min(...values);
+      let maxV = Math.max(...values);
+      if (maxV <= minV) maxV = minV + 1;
+      ctx.strokeStyle = "#d32f2f";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      for (let i = 0; i < values.length; i++) {
+        const x = (i / (values.length - 1)) * (w - 20) + 10;
+        const y = h - ((values[i] - minV) / (maxV - minV)) * (h - 20) - 10;
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+
+    async function tickState() {
+      try {
+        const qs = lastSeq === null
+          ? ""
+          : ("since_seq=" + encodeURIComponent(String(lastSeq)) + "&");
+        const res = await fetch("/state?" + qs + "_=" + Date.now());
+        const s = await res.json();
+        const cursor = s.cursor || {};
+        const counts = s.counts || {};
+        if (cursor.incremental) {
+          const delta = s.delta || {};
+          livePointMessages = livePointMessages
+            .concat(delta.point_messages || [])
+            .slice(-240);
+          liveSnapshotMessages = liveSnapshotMessages
+            .concat(delta.snapshot_messages || [])
+            .slice(-60);
+        } else {
+          const windowData = s.window || {};
+          livePointMessages = (windowData.point_messages || []).slice(-240);
+          liveSnapshotMessages = (windowData.snapshot_messages || []).slice(-60);
+        }
+        if (typeof cursor.latest_seq === "number") {
+          lastSeq = cursor.latest_seq;
+        }
+        runIdEl.textContent = s.run_id || "-";
+        statusEl.textContent = s.finished
+          ? "finished"
+          : (s.started ? "running" : "waiting");
+        pointCountEl.textContent = String(
+          counts.point_messages || livePointMessages.length
+        );
+        snapshotCountEl.textContent = String(
+          counts.snapshot_messages || liveSnapshotMessages.length
+        );
+        latestValuesEl.textContent = JSON.stringify(
+          s.latest_indicator_values || {},
+          null,
+          2
+        );
+        latestSnapshotEl.textContent = liveSnapshotMessages.length
+          ? JSON.stringify(
+              liveSnapshotMessages[liveSnapshotMessages.length - 1],
+              null,
+              2
+            )
+          : "-";
+        const closeValues = livePointMessages
+          .filter(
+            m =>
+              m.type === "point"
+              && m.indicator
+              && m.indicator.indicator_key === "close_echo"
+          )
+          .map(m => Number(m.indicator.value))
+          .filter(v => !Number.isNaN(v));
+        drawLine(closeCtx, closeValues);
+      } catch (_e) {}
+    }
+    setInterval(tickState, 250);
+    tickState();
+  </script>
+</body>
+</html>
+            """.strip()
+            body = html.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+    return Handler
+
+
+def run_backtest_thread(
+    state: IndicatorLiveState,
+    lock: threading.Lock,
+    sleep_ms: int,
+    done_event: threading.Event,
+) -> None:
+    """Run the stream-enabled backtest and update browser state."""
+
+    def on_event(event: aq.BacktestStreamEvent) -> None:
+        message = aq.to_indicator_message(event)
+        with lock:
+            if str(event.get("event_type", "")) == "started":
+                state.started = True
+                state.run_id = str(event.get("run_id", ""))
+            elif str(event.get("event_type", "")) == "finished":
+                state.finished = True
+            if message is not None:
+                if message["type"] == "point":
+                    points = state.point_messages or []
+                    points.append(message)
+                    state.point_messages = points[-240:]
+                    indicator = message.get("indicator", {})
+                    if isinstance(indicator, dict):
+                        key = str(indicator.get("indicator_key", ""))
+                        latest_values = state.latest_indicator_values or {}
+                        latest_values[key] = indicator.get("value")
+                        state.latest_indicator_values = latest_values
+                elif message["type"] == "snapshot":
+                    snapshots = state.snapshot_messages or []
+                    snapshots.append(message)
+                    state.snapshot_messages = snapshots[-60:]
+        if sleep_ms > 0:
+            time.sleep(float(sleep_ms) / 1000.0)
+
+    aq.run_backtest(
+        data=build_data(),
+        strategy=LiveIndicatorStrategy,
+        symbols="LIVE_IND",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        show_progress=False,
+        on_event=on_event,
+        stream_progress_interval=6,
+        stream_equity_interval=12,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+    with lock:
+        state.finished = True
+    done_event.set()
+
+
+def main() -> None:
+    """Serve a lightweight browser page that polls live indicator state."""
+    parser = argparse.ArgumentParser(description="Live indicator browser demo.")
+    parser.add_argument("--port", type=int, default=8899)
+    parser.add_argument("--open", action="store_true")
+    parser.add_argument("--sleep-ms", type=int, default=30)
+    parser.add_argument("--keep-seconds", type=int, default=20)
+    args = parser.parse_args()
+
+    state = IndicatorLiveState()
+    lock = threading.Lock()
+    done_event = threading.Event()
+    handler_cls = make_handler(state, lock)
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), handler_cls)
+    server.timeout = 0.2
+    url = f"http://127.0.0.1:{args.port}/"
+
+    thread = threading.Thread(
+        target=run_backtest_thread,
+        args=(state, lock, args.sleep_ms, done_event),
+        daemon=True,
+    )
+    thread.start()
+
+    if args.open:
+        webbrowser.open(url)
+    print(f"indicator_live_web_url={url}")
+    print(f"sleep_ms={args.sleep_ms}")
+    print(f"keep_seconds={args.keep_seconds}")
+
+    end_after = None
+    try:
+        while True:
+            server.handle_request()
+            if done_event.is_set() and end_after is None:
+                end_after = time.time() + float(args.keep_seconds)
+            if end_after is not None and time.time() >= end_after:
+                break
+    finally:
+        server.server_close()
+    thread.join(timeout=1.0)
+    with lock:
+        point_count = len(state.point_messages or [])
+        snapshot_count = len(state.snapshot_messages or [])
+        latest_keys = sorted((state.latest_indicator_values or {}).keys())
+    print(f"indicator_live_point_messages={point_count}")
+    print(f"indicator_live_snapshot_messages={snapshot_count}")
+    print(f"indicator_live_latest_keys={latest_keys}")
+    print("done_indicator_live_web")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.33"
+version = "0.2.34"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -51,6 +51,11 @@ from .feed_adapter import (
     ResampledFeedAdapter,
 )
 from .indicator import Indicator, IndicatorSet
+from .indicator_stream import (
+    is_indicator_stream_event,
+    to_indicator_message,
+    to_indicator_messages,
+)
 from .log import get_logger, register_logger
 from .optimize import OptimizationResult, run_grid_search, run_walk_forward
 from .params import (
@@ -69,7 +74,7 @@ from .params_adapter import (
     resolve_param_model,
     validate_strategy_params,
 )
-from .plot import plot_result
+from .plot import plot_indicators, plot_result
 from .sizer import AllInSizer, FixedSize, PercentSizer, Sizer
 from .strategy import InstrumentSnapshot, Strategy, StrategyRuntimeConfig
 from .strategy_loader import register_strategy_loader, resolve_strategy_input
@@ -116,10 +121,14 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "ChinaOptionsSessionConfig",
         "Indicator",
         "IndicatorSet",
+        "is_indicator_stream_event",
+        "to_indicator_message",
+        "to_indicator_messages",
         "run_backtest",
         "run_warm_start",
         "make_fill_policy",
         "plot_result",
+        "plot_indicators",
         "BacktestResult",
         "BacktestStreamEvent",
         "run_grid_search",
@@ -186,10 +195,14 @@ else:
         "ChinaOptionsSessionConfig",
         "Indicator",
         "IndicatorSet",
+        "is_indicator_stream_event",
+        "to_indicator_message",
+        "to_indicator_messages",
         "run_backtest",
         "run_warm_start",
         "make_fill_policy",
         "plot_result",
+        "plot_indicators",
         "BacktestResult",
         "BacktestStreamEvent",
         "run_grid_search",

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -229,6 +229,7 @@ class BacktestResult:
     metrics_df: typing.Any
     orders_df: typing.Any
     resolved_execution_policy: typing.Optional[dict[str, typing.Any]]
+    stream_run_id: typing.Optional[str]
     def get_trades_ipc(self) -> bytes:
         r"""Get trades as Arrow IPC bytes (Zero-Copy-ish to Python)."""
         ...
@@ -250,6 +251,58 @@ class BacktestResult:
         ...
 
     def get_event_stats(self) -> dict[str, typing.Any]: ...
+    def indicator_df(
+        self,
+        name: typing.Optional[str] = ...,
+        symbol: typing.Optional[str] = ...,
+    ) -> typing.Any: ...
+    @property
+    def indicator_definitions(self) -> typing.Any: ...
+    @property
+    def indicator_instances(self) -> typing.Any: ...
+    def export_indicators(self, path: str, format: str = ...) -> None: ...
+    def plot(
+        self,
+        symbol: typing.Optional[str] = ...,
+        show: bool = ...,
+        title: str = ...,
+    ) -> typing.Any: ...
+    def plot_indicators(
+        self,
+        name: typing.Optional[str] = ...,
+        symbol: typing.Optional[str] = ...,
+        include_warmup: bool = ...,
+        show: bool = ...,
+        title: str = ...,
+        theme: str = ...,
+        filename: typing.Optional[str] = ...,
+    ) -> typing.Any: ...
+    def report(
+        self,
+        title: str = ...,
+        filename: str = ...,
+        show: bool = ...,
+        compact_currency: bool = ...,
+        market_data: typing.Optional[
+            typing.Union[typing.Any, dict[str, typing.Any]]
+        ] = ...,
+        plot_symbol: typing.Optional[str] = ...,
+        include_trade_kline: bool = ...,
+        include_indicators: bool = ...,
+        indicator_name: typing.Optional[str] = ...,
+        indicator_symbol: typing.Optional[str] = ...,
+        indicator_include_warmup: bool = ...,
+        benchmark: typing.Optional[typing.Union[str, typing.Any]] = ...,
+        curve_freq: str = ...,
+    ) -> None: ...
+    def report_quantstats(
+        self,
+        benchmark: typing.Optional[typing.Union[str, typing.Any]] = ...,
+        title: str = ...,
+        filename: str = ...,
+        **kwargs: typing.Any,
+    ) -> None: ...
+    def to_quantstats(self) -> typing.Any: ...
 
 class Bar:
     r"""
@@ -738,6 +791,13 @@ class Engine:
 
     def set_stream_callback(self, callback: typing.Any) -> None: ...
     def clear_stream_callback(self) -> None: ...
+    def emit_stream_event_py(
+        self,
+        event_type: str,
+        symbol: typing.Optional[str],
+        level: str,
+        payload: dict[str, str],
+    ) -> None: ...
     def set_stream_options(
         self,
         progress_interval: int,
@@ -2094,6 +2154,14 @@ class ABS:
         :return: 当前 ABS 值
         """
         ...
+
+def is_indicator_stream_event(event: typing.Any) -> bool: ...
+def to_indicator_message(
+    event: typing.Any,
+) -> typing.Optional[dict[str, typing.Any]]: ...
+def to_indicator_messages(
+    events: typing.Iterable[typing.Any],
+) -> list[dict[str, typing.Any]]: ...
 
 class SIGN:
     r"""符号变换指标 (SIGN)."""

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -44,6 +44,7 @@ from ..config import (
 )
 from ..data import ParquetDataCatalog
 from ..feed_adapter import DataFeedAdapter, FeedSlice
+from ..indicator_recording import IndicatorRecorder
 from ..log import get_logger, register_logger
 from ..risk import apply_risk_config
 from ..strategy import (
@@ -193,6 +194,11 @@ class PreparedStreamRuntime:
     """Prepared stream runtime components shared by backtest/warm_start."""
 
     stream_on_event: Callable[[BacktestStreamEvent], None]
+    indicator_stream_emitter: Optional[
+        Callable[[str, Optional[str], str, Dict[str, str]], None]
+    ]
+    indicator_stream_point_interval: int
+    indicator_stream_snapshot_interval: int
     event_stats_snapshot: Dict[str, Any]
     stream_progress_interval: int
     stream_equity_interval: int
@@ -482,12 +488,28 @@ def _prepare_stream_runtime(
     if stream_on_event is None:
         stream_on_event = _noop_stream_event_handler
     original_stream_handler = stream_on_event
+    indicator_stream_point_interval = _parse_positive_int_option(
+        "indicator_stream_point_interval",
+        kwargs.pop("indicator_stream_point_interval", 1),
+    )
+    indicator_stream_snapshot_interval = _parse_positive_int_option(
+        "indicator_stream_snapshot_interval",
+        kwargs.pop("indicator_stream_snapshot_interval", 1),
+    )
     event_stats_snapshot: Dict[str, Any] = {}
+    stream_state: Dict[str, Any] = {
+        "run_id": None,
+        "last_rust_seq": 0,
+        "seq_offset": 0,
+        "indicator_point_seen": 0,
+        "indicator_snapshot_seen": 0,
+    }
 
     def wrapped_stream_on_event(event: BacktestStreamEvent) -> None:
-        event_type = str(event.get("event_type", ""))
+        forwarded_event: Dict[str, Any] = dict(event)
+        event_type = str(forwarded_event.get("event_type", ""))
         if event_type == "finished":
-            payload_obj = event.get("payload", {})
+            payload_obj = forwarded_event.get("payload", {})
             if isinstance(payload_obj, dict):
                 for key in (
                     "processed_events",
@@ -503,19 +525,74 @@ def _prepare_stream_runtime(
                         event_stats_snapshot[key] = payload_obj.get(key)
         if patch_owner_strategy_id and owner_strategy_id is not None:
             if event_type in {"order", "trade", "risk"}:
-                payload_obj = event.get("payload", {})
+                payload_obj = forwarded_event.get("payload", {})
                 if isinstance(payload_obj, dict):
                     current_owner = payload_obj.get("owner_strategy_id")
                     if current_owner is None or str(current_owner) == "":
-                        patched_event = dict(event)
                         patched_payload = dict(payload_obj)
                         patched_payload["owner_strategy_id"] = owner_strategy_id
-                        patched_event["payload"] = cast(Dict[str, str], patched_payload)
-                        original_stream_handler(
-                            cast(BacktestStreamEvent, patched_event)
+                        forwarded_event["payload"] = cast(
+                            Dict[str, str], patched_payload
                         )
-                        return
-        original_stream_handler(event)
+        run_id = forwarded_event.get("run_id")
+        if run_id is not None and str(run_id):
+            normalized_run_id = str(run_id)
+            stream_state["run_id"] = normalized_run_id
+            event_stats_snapshot["run_id"] = normalized_run_id
+        raw_seq = int(forwarded_event.get("seq", 0))
+        forwarded_event["seq"] = raw_seq + int(stream_state["seq_offset"])
+        stream_state["last_rust_seq"] = raw_seq
+        original_stream_handler(cast(BacktestStreamEvent, forwarded_event))
+
+    def emit_indicator_stream_event(
+        event_type: str,
+        symbol: Optional[str],
+        level: str,
+        payload: Dict[str, str],
+    ) -> None:
+        run_id = stream_state.get("run_id")
+        if not run_id:
+            return
+        if event_type == "indicator_point":
+            stream_state["indicator_point_seen"] = (
+                int(stream_state["indicator_point_seen"]) + 1
+            )
+            if (
+                int(stream_state["indicator_point_seen"])
+                % indicator_stream_point_interval
+                != 0
+            ):
+                return
+        elif event_type == "indicator_snapshot":
+            stream_state["indicator_snapshot_seen"] = (
+                int(stream_state["indicator_snapshot_seen"]) + 1
+            )
+            if (
+                int(stream_state["indicator_snapshot_seen"])
+                % indicator_stream_snapshot_interval
+                != 0
+            ):
+                return
+        try:
+            event_ts = int(str(payload.get("timestamp", "0")))
+        except (TypeError, ValueError):
+            event_ts = 0
+        next_offset = int(stream_state["seq_offset"]) + 1
+        stream_state["seq_offset"] = next_offset
+        original_stream_handler(
+            cast(
+                BacktestStreamEvent,
+                {
+                    "run_id": str(run_id),
+                    "seq": int(stream_state["last_rust_seq"]) + next_offset,
+                    "ts": event_ts,
+                    "event_type": str(event_type),
+                    "symbol": None if symbol is None else str(symbol),
+                    "level": str(level),
+                    "payload": {str(key): str(value) for key, value in payload.items()},
+                },
+            )
+        )
 
     stream_progress_interval = _parse_positive_int_option(
         "stream_progress_interval", kwargs.pop("stream_progress_interval", 1)
@@ -540,6 +617,9 @@ def _prepare_stream_runtime(
         )
     return PreparedStreamRuntime(
         stream_on_event=wrapped_stream_on_event,
+        indicator_stream_emitter=emit_indicator_stream_event,
+        indicator_stream_point_interval=indicator_stream_point_interval,
+        indicator_stream_snapshot_interval=indicator_stream_snapshot_interval,
         event_stats_snapshot=event_stats_snapshot,
         stream_progress_interval=stream_progress_interval,
         stream_equity_interval=stream_equity_interval,
@@ -561,6 +641,8 @@ def _attach_result_runtime_metadata(
     setattr(result, "_engine_summary", engine_summary)
     setattr(result, "_event_stats", dict(event_stats_snapshot))
     setattr(result, "_owner_strategy_id", owner_strategy_id)
+    run_id = event_stats_snapshot.get("run_id")
+    result.stream_run_id = None if run_id in (None, "") else str(run_id)
     if resolved_policy is not None:
         setattr(
             result,
@@ -575,6 +657,22 @@ def _attach_result_runtime_metadata(
         result.resolved_execution_policy = cast(
             Dict[str, Any], getattr(result, "_resolved_execution_policy")
         )
+
+
+def _attach_indicator_recorder(
+    *,
+    stream_emitter: Optional[
+        Callable[[str, Optional[str], str, Dict[str, str]], None]
+    ] = None,
+    strategy_instance: Strategy,
+    slot_strategy_instances: Dict[str, Strategy],
+) -> IndicatorRecorder:
+    """Attach one shared indicator recorder to all strategy instances."""
+    recorder = IndicatorRecorder(stream_emitter=stream_emitter)
+    setattr(strategy_instance, "_indicator_recorder", recorder)
+    for slot_strategy in slot_strategy_instances.values():
+        setattr(slot_strategy, "_indicator_recorder", recorder)
+    return recorder
 
 
 def _normalize_symbols_argument(
@@ -2161,6 +2259,9 @@ def run_backtest(
     )
     risk_budget_reset_daily = bool(risk_budget_reset_daily)
     effective_strategy_id = strategy_id or "_default"
+    indicator_stream_requested = (
+        on_event is not None or kwargs.get("_stream_on_event") is not None
+    )
     prepared_stream_runtime = _prepare_stream_runtime(
         on_event=on_event,
         kwargs=kwargs,
@@ -2168,6 +2269,11 @@ def run_backtest(
         patch_owner_strategy_id=True,
     )
     stream_on_event = prepared_stream_runtime.stream_on_event
+    indicator_stream_emitter = (
+        prepared_stream_runtime.indicator_stream_emitter
+        if indicator_stream_requested
+        else None
+    )
     event_stats_snapshot = prepared_stream_runtime.event_stats_snapshot
     stream_progress_interval = prepared_stream_runtime.stream_progress_interval
     stream_equity_interval = prepared_stream_runtime.stream_equity_interval
@@ -2404,6 +2510,11 @@ def run_backtest(
     setattr(strategy_instance, "_owner_strategy_id", effective_strategy_id)
     for slot_key, slot_strategy in slot_strategy_instances.items():
         setattr(slot_strategy, "_owner_strategy_id", slot_key)
+    indicator_recorder = _attach_indicator_recorder(
+        stream_emitter=indicator_stream_emitter,
+        strategy_instance=strategy_instance,
+        slot_strategy_instances=slot_strategy_instances,
+    )
     setattr(strategy_instance, "_slot_strategies", dict(slot_strategy_instances))
     setattr(strategy_instance, "_strategy_slot_ids", list(configured_slot_ids))
     if normalized_strategy_fill_policy is not None:
@@ -3996,6 +4107,7 @@ def run_backtest(
         initial_cash=initial_cash,
         strategy=strategy_instance,
         engine=engine,
+        indicator_outputs=indicator_recorder.build_payload(),
     )
     _attach_result_runtime_metadata(
         result=result,
@@ -4139,8 +4251,16 @@ def run_warm_start(
         risk_budget_mode=risk_budget_mode,
     )
     risk_budget_reset_daily = bool(risk_budget_reset_daily)
+    indicator_stream_requested = (
+        on_event is not None or kwargs.get("_stream_on_event") is not None
+    )
     prepared_stream_runtime = _prepare_stream_runtime(on_event=on_event, kwargs=kwargs)
     stream_on_event = prepared_stream_runtime.stream_on_event
+    indicator_stream_emitter = (
+        prepared_stream_runtime.indicator_stream_emitter
+        if indicator_stream_requested
+        else None
+    )
     event_stats_snapshot = prepared_stream_runtime.event_stats_snapshot
     stream_progress_interval = prepared_stream_runtime.stream_progress_interval
     stream_equity_interval = prepared_stream_runtime.stream_equity_interval
@@ -4354,6 +4474,11 @@ def run_warm_start(
     setattr(strategy_instance, "_owner_strategy_id", effective_strategy_id)
     for slot_key, slot_strategy in slot_strategy_instances.items():
         setattr(slot_strategy, "_owner_strategy_id", slot_key)
+    indicator_recorder = _attach_indicator_recorder(
+        stream_emitter=indicator_stream_emitter,
+        strategy_instance=strategy_instance,
+        slot_strategy_instances=slot_strategy_instances,
+    )
     setattr(strategy_instance, "_slot_strategies", dict(slot_strategy_instances))
     setattr(strategy_instance, "_strategy_slot_ids", list(configured_slot_ids))
     if normalized_strategy_fill_policy is not None:
@@ -5166,6 +5291,7 @@ def run_warm_start(
         initial_cash=float(restored_cash),
         strategy=strategy_instance,
         engine=engine,
+        indicator_outputs=indicator_recorder.build_payload(),
     )
     _attach_result_runtime_metadata(
         result=result,

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -1,7 +1,10 @@
+import json
 import re
 from functools import cached_property
+from pathlib import Path
 from typing import (
     Any,
+    Dict,
     List,
     Optional,
     Union,
@@ -29,6 +32,7 @@ class BacktestResult:
         initial_cash: float = 0.0,
         strategy: Optional[Any] = None,
         engine: Optional[Any] = None,
+        indicator_outputs: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     ):
         """
         Initialize the BacktestResult wrapper.
@@ -46,6 +50,12 @@ class BacktestResult:
         self.engine = engine
         self.analyzer_outputs: dict[str, dict[str, Any]] = {}
         self.resolved_execution_policy: Optional[dict[str, Any]] = None
+        self.stream_run_id: Optional[str] = None
+        self.indicator_outputs: Dict[str, List[Dict[str, Any]]] = (
+            indicator_outputs
+            if indicator_outputs is not None
+            else {"definitions": [], "instances": [], "points": []}
+        )
 
     @property
     def equity_curve(self) -> pd.Series:
@@ -1417,6 +1427,140 @@ class BacktestResult:
         )
         return cast(pd.DataFrame, grouped[columns])
 
+    @cached_property
+    def indicator_definitions(self) -> pd.DataFrame:
+        """Get normalized indicator definition metadata."""
+        rows = list(self.indicator_outputs.get("definitions", []))
+        columns = [
+            "indicator_key",
+            "display_name",
+            "pane",
+            "render_type",
+            "unit",
+            "precision",
+            "color",
+        ]
+        if not rows:
+            return pd.DataFrame(columns=columns)
+        frame = pd.DataFrame(rows)
+        for column in columns:
+            if column not in frame.columns:
+                frame[column] = None
+        frame = frame[columns].sort_values("indicator_key").reset_index(drop=True)
+        return cast(pd.DataFrame, frame)
+
+    @cached_property
+    def indicator_instances(self) -> pd.DataFrame:
+        """Get normalized indicator instance metadata."""
+        rows = list(self.indicator_outputs.get("instances", []))
+        columns = [
+            "instance_id",
+            "owner_strategy_id",
+            "symbol",
+            "indicator_key",
+            "meta_json",
+        ]
+        if not rows:
+            return pd.DataFrame(columns=columns)
+        frame = pd.DataFrame(rows)
+        for column in columns:
+            if column not in frame.columns:
+                frame[column] = ""
+        frame = frame[columns].sort_values(
+            ["owner_strategy_id", "symbol", "indicator_key", "instance_id"]
+        )
+        return cast(pd.DataFrame, frame.reset_index(drop=True))
+
+    @cached_property
+    def _indicator_points_df(self) -> pd.DataFrame:
+        rows = list(self.indicator_outputs.get("points", []))
+        columns = [
+            "instance_id",
+            "owner_strategy_id",
+            "symbol",
+            "indicator_key",
+            "timestamp",
+            "value",
+            "warmup",
+        ]
+        if not rows:
+            return pd.DataFrame(columns=columns + ["datetime"])
+        frame = pd.DataFrame(rows)
+        for column in columns:
+            if column not in frame.columns:
+                frame[column] = None
+        frame["timestamp"] = pd.to_numeric(frame["timestamp"], errors="coerce").astype(
+            "Int64"
+        )
+        frame["datetime"] = pd.to_datetime(
+            frame["timestamp"],
+            unit="ns",
+            utc=True,
+            errors="coerce",
+        ).dt.tz_convert(self._timezone)
+        frame["value"] = pd.to_numeric(frame["value"], errors="coerce")
+        frame["warmup"] = frame["warmup"].fillna(False).astype(bool)
+        frame = frame.sort_values(
+            ["owner_strategy_id", "symbol", "indicator_key", "timestamp"]
+        ).reset_index(drop=True)
+        return cast(pd.DataFrame, frame[columns + ["datetime"]])
+
+    def indicator_df(
+        self,
+        name: Optional[str] = None,
+        symbol: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Get recorded indicator points as a DataFrame."""
+        frame = cast(pd.DataFrame, self._indicator_points_df.copy())
+        if frame.empty:
+            return cast(pd.DataFrame, frame)
+        if name is not None:
+            frame = frame.loc[frame["indicator_key"] == str(name)]
+        if symbol is not None:
+            frame = frame.loc[frame["symbol"] == str(symbol)]
+        return cast(pd.DataFrame, frame.reset_index(drop=True))
+
+    def export_indicators(self, path: str, format: str = "json") -> None:
+        """Export indicator outputs to json or a parquet directory bundle."""
+        output_format = str(format).strip().lower()
+        output_path = Path(path)
+        if output_format == "json":
+            payload = {
+                "run_id": self.stream_run_id,
+                "definitions": self._json_ready_records(self.indicator_definitions),
+                "instances": self._json_ready_records(self.indicator_instances),
+                "points": self._json_ready_records(self._indicator_points_df),
+            }
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(payload, ensure_ascii=True, indent=2),
+                encoding="utf-8",
+            )
+            return
+        if output_format == "parquet":
+            output_path.mkdir(parents=True, exist_ok=True)
+            self.indicator_definitions.to_parquet(output_path / "definitions.parquet")
+            self.indicator_instances.to_parquet(output_path / "instances.parquet")
+            self._indicator_points_df.to_parquet(output_path / "points.parquet")
+            return
+        raise ValueError("format must be 'json' or 'parquet'")
+
+    @staticmethod
+    def _json_ready_records(frame: pd.DataFrame) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        for row in frame.to_dict(orient="records"):
+            normalized: Dict[str, Any] = {}
+            for key, value in row.items():
+                key_str = str(key)
+                if pd.isna(value):
+                    normalized[key_str] = None
+                elif isinstance(value, pd.Timestamp):
+                    normalized[key_str] = value.isoformat()
+                else:
+                    normalized[key_str] = value
+            records.append(normalized)
+        return records
+
     def __getattr__(self, name: str) -> Any:
         """Delegate attribute access to the raw result."""
         return getattr(self._raw, name)
@@ -1456,6 +1600,48 @@ class BacktestResult:
             return None
 
         return plot_dashboard(result=self, show=show, title=title)
+
+    def plot_indicators(
+        self,
+        name: Optional[str] = None,
+        symbol: Optional[str] = None,
+        include_warmup: bool = True,
+        show: bool = True,
+        title: str = "Indicator History",
+        theme: str = "light",
+        filename: Optional[str] = None,
+    ) -> Any:
+        """
+        Plot recorded indicator history in a lightweight multi-pane figure.
+
+        :param name: Optional indicator key filter.
+        :param symbol: Optional symbol filter.
+        :param include_warmup: Whether to keep warmup points.
+        :param show: Whether to display the plot immediately.
+        :param title: Figure title.
+        :param theme: Plot theme key.
+        :param filename: Optional HTML output path.
+        :return: Plotly Figure object.
+        """
+        try:
+            from ..plot import plot_indicators
+        except ImportError:
+            print(
+                "Plotly is not installed. Please install it using `pip install plotly` "
+                "or `pip install akquant[plot]`."
+            )
+            return None
+
+        return plot_indicators(
+            result=self,
+            name=name,
+            symbol=symbol,
+            include_warmup=include_warmup,
+            show=show,
+            title=title,
+            theme=theme,
+            filename=filename,
+        )
 
     def to_quantstats(self) -> pd.Series:
         """
@@ -1532,6 +1718,10 @@ class BacktestResult:
         market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
         plot_symbol: Optional[str] = None,
         include_trade_kline: bool = True,
+        include_indicators: bool = False,
+        indicator_name: Optional[str] = None,
+        indicator_symbol: Optional[str] = None,
+        indicator_include_warmup: bool = True,
         benchmark: Optional[Union[str, pd.Series]] = None,
         curve_freq: str = "raw",
     ) -> None:
@@ -1547,6 +1737,10 @@ class BacktestResult:
         :param market_data: 可选行情数据，用于绘制 K 线买卖点图
         :param plot_symbol: 可选标的代码，指定 K 线复盘标的
         :param include_trade_kline: 是否在报告中包含 K 线复盘图
+        :param include_indicators: 是否在报告中包含自定义指标预览区块
+        :param indicator_name: 可选指标键过滤，仅展示指定指标
+        :param indicator_symbol: 可选标的过滤，仅展示指定标的指标
+        :param indicator_include_warmup: 是否在指标报告区块中保留预热点
         :param benchmark: 基准收益序列 (pd.Series) 或基准标识字符串
         :param curve_freq: 曲线频率，"raw" 为原始频率，"D" 为日频末值
         """
@@ -1566,6 +1760,10 @@ class BacktestResult:
             market_data=market_data,
             plot_symbol=plot_symbol,
             include_trade_kline=include_trade_kline,
+            include_indicators=include_indicators,
+            indicator_name=indicator_name,
+            indicator_symbol=indicator_symbol,
+            indicator_include_warmup=indicator_include_warmup,
             benchmark=benchmark,
             curve_freq=curve_freq,
         )

--- a/python/akquant/indicator_recording.py
+++ b/python/akquant/indicator_recording.py
@@ -1,0 +1,225 @@
+import json
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import pandas as pd
+
+
+def _normalize_text(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _normalize_meta_json(meta: Optional[Dict[str, Any]]) -> str:
+    if not meta:
+        return ""
+    return json.dumps(meta, ensure_ascii=True, sort_keys=True, default=str)
+
+
+def _normalize_timestamp_ns(timestamp: Any) -> int:
+    if isinstance(timestamp, pd.Timestamp):
+        return int(timestamp.value)
+    return int(pd.Timestamp(timestamp).value)
+
+
+class IndicatorRecorder:
+    """Collect normalized indicator metadata and point values during a run."""
+
+    def __init__(
+        self,
+        stream_emitter: Optional[
+            Callable[[str, Optional[str], str, Dict[str, str]], None]
+        ] = None,
+    ) -> None:
+        """Initialize recorder state and optional stream emitter."""
+        self._definitions: Dict[str, Dict[str, Any]] = {}
+        self._instances: Dict[Tuple[str, str, str, str], Dict[str, Any]] = {}
+        self._points: list[Dict[str, Any]] = []
+        self._stream_emitter = stream_emitter
+        self._pending_snapshots: Dict[Tuple[str, str, int], list[Dict[str, Any]]] = {}
+
+    @property
+    def has_data(self) -> bool:
+        """Return whether any indicator point has been recorded."""
+        return bool(self._points)
+
+    def set_stream_emitter(
+        self,
+        stream_emitter: Optional[
+            Callable[[str, Optional[str], str, Dict[str, str]], None]
+        ],
+    ) -> None:
+        """Attach or replace the runtime stream emitter."""
+        self._stream_emitter = stream_emitter
+
+    def record(
+        self,
+        *,
+        name: str,
+        value: Any,
+        symbol: str,
+        timestamp: Any,
+        owner_strategy_id: str,
+        display_name: Optional[str] = None,
+        pane: str = "sub",
+        render_type: str = "line",
+        unit: Optional[str] = None,
+        precision: Optional[int] = None,
+        color: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        warmup: bool = False,
+    ) -> None:
+        """Record one indicator definition, instance, and point update."""
+        indicator_key = _normalize_text(name)
+        if not indicator_key:
+            raise ValueError("indicator name cannot be empty")
+
+        symbol_text = _normalize_text(symbol, default="_unknown")
+        strategy_id = _normalize_text(owner_strategy_id, default="_default")
+        pane_text = _normalize_text(pane, default="sub")
+        render_type_text = _normalize_text(render_type, default="line")
+        display_name_text = _normalize_text(display_name, default=indicator_key)
+        unit_text = _normalize_text(unit)
+        color_text = _normalize_text(color)
+        meta_json = _normalize_meta_json(meta)
+        timestamp_ns = _normalize_timestamp_ns(timestamp)
+
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            numeric_value = float("nan")
+
+        definition = self._definitions.get(indicator_key)
+        if definition is None:
+            self._definitions[indicator_key] = {
+                "indicator_key": indicator_key,
+                "display_name": display_name_text,
+                "pane": pane_text,
+                "render_type": render_type_text,
+                "unit": unit_text,
+                "precision": precision,
+                "color": color_text,
+            }
+        else:
+            if not definition.get("display_name"):
+                definition["display_name"] = display_name_text
+            if not definition.get("pane"):
+                definition["pane"] = pane_text
+            if not definition.get("render_type"):
+                definition["render_type"] = render_type_text
+            if not definition.get("unit"):
+                definition["unit"] = unit_text
+            if definition.get("precision") is None and precision is not None:
+                definition["precision"] = precision
+            if not definition.get("color"):
+                definition["color"] = color_text
+
+        instance_key = (strategy_id, symbol_text, indicator_key, meta_json)
+        instance = self._instances.get(instance_key)
+        if instance is None:
+            instance = {
+                "instance_id": f"ins_{len(self._instances) + 1}",
+                "owner_strategy_id": strategy_id,
+                "symbol": symbol_text,
+                "indicator_key": indicator_key,
+                "meta_json": meta_json,
+            }
+            self._instances[instance_key] = instance
+
+        self._points.append(
+            {
+                "instance_id": instance["instance_id"],
+                "owner_strategy_id": strategy_id,
+                "symbol": symbol_text,
+                "indicator_key": indicator_key,
+                "timestamp": timestamp_ns,
+                "value": numeric_value,
+                "warmup": bool(warmup),
+            }
+        )
+        if self._stream_emitter is not None:
+            self._stream_emitter(
+                "indicator_point",
+                None if symbol_text == "_unknown" else symbol_text,
+                "info",
+                {
+                    "owner_strategy_id": strategy_id,
+                    "indicator_key": indicator_key,
+                    "display_name": display_name_text,
+                    "pane": pane_text,
+                    "render_type": render_type_text,
+                    "symbol": symbol_text,
+                    "timestamp": str(timestamp_ns),
+                    "value": repr(numeric_value),
+                    "warmup": str(bool(warmup)).lower(),
+                    "meta_json": meta_json,
+                },
+            )
+            snapshot_key = (strategy_id, symbol_text, timestamp_ns)
+            snapshot_items = self._pending_snapshots.setdefault(snapshot_key, [])
+            snapshot_items.append(
+                {
+                    "indicator_key": indicator_key,
+                    "display_name": display_name_text,
+                    "pane": pane_text,
+                    "render_type": render_type_text,
+                    "value": numeric_value,
+                    "warmup": bool(warmup),
+                    "meta_json": meta_json,
+                }
+            )
+
+    def flush_stream_snapshot(self) -> None:
+        """Emit pending indicator snapshots for the latest callback cycle."""
+        if self._stream_emitter is None or not self._pending_snapshots:
+            self._pending_snapshots.clear()
+            return
+        for (strategy_id, symbol_text, timestamp_ns), items in list(
+            self._pending_snapshots.items()
+        ):
+            self._stream_emitter(
+                "indicator_snapshot",
+                None if symbol_text == "_unknown" else symbol_text,
+                "info",
+                {
+                    "owner_strategy_id": strategy_id,
+                    "symbol": symbol_text,
+                    "timestamp": str(timestamp_ns),
+                    "indicator_count": str(len(items)),
+                    "items_json": json.dumps(
+                        items,
+                        ensure_ascii=True,
+                        sort_keys=True,
+                        default=str,
+                    ),
+                },
+            )
+        self._pending_snapshots.clear()
+
+    def build_payload(self) -> Dict[str, list[Dict[str, Any]]]:
+        """Return stable row-oriented outputs for result access and export."""
+        definitions = [
+            self._definitions[key] for key in sorted(self._definitions.keys(), key=str)
+        ]
+        instances = sorted(
+            self._instances.values(),
+            key=lambda row: (
+                str(row.get("owner_strategy_id", "")),
+                str(row.get("symbol", "")),
+                str(row.get("indicator_key", "")),
+                str(row.get("instance_id", "")),
+            ),
+        )
+        points = sorted(
+            self._points,
+            key=lambda row: (
+                str(row.get("owner_strategy_id", "")),
+                str(row.get("symbol", "")),
+                str(row.get("indicator_key", "")),
+                int(row.get("timestamp", 0)),
+            ),
+        )
+        return {
+            "definitions": definitions,
+            "instances": instances,
+            "points": points,
+        }

--- a/python/akquant/indicator_stream.py
+++ b/python/akquant/indicator_stream.py
@@ -1,0 +1,148 @@
+"""Helpers for bridging indicator stream events to frontend-friendly messages."""
+
+import json
+from typing import Any, Iterable, Optional
+
+from .backtest import BacktestStreamEvent
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    """Convert values into integers with a safe fallback."""
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float_or_text(value: Any) -> Any:
+    """Prefer numeric values for charts while keeping unparseable text intact."""
+    if value is None:
+        return None
+    text = str(value)
+    try:
+        return float(text)
+    except (TypeError, ValueError):
+        return text
+
+
+def _to_bool(value: Any) -> bool:
+    """Parse common string boolean forms."""
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _json_loads_or_default(value: Any, default: Any) -> Any:
+    """Decode JSON strings and fall back to the provided default."""
+    if value in (None, ""):
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(str(value))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return default
+
+
+def _normalize_symbol(value: Any) -> Optional[str]:
+    """Normalize unknown or empty symbols into None."""
+    if value in (None, "", "_unknown"):
+        return None
+    return str(value)
+
+
+def is_indicator_stream_event(event: BacktestStreamEvent) -> bool:
+    """Return whether the event belongs to indicator streaming."""
+    return str(event.get("event_type", "")) in {"indicator_point", "indicator_snapshot"}
+
+
+def to_indicator_message(event: BacktestStreamEvent) -> Optional[dict[str, Any]]:
+    """Convert one indicator stream event into a frontend-friendly message."""
+    event_type = str(event.get("event_type", ""))
+    if event_type not in {"indicator_point", "indicator_snapshot"}:
+        return None
+
+    payload = event.get("payload", {})
+    symbol = _normalize_symbol(event.get("symbol"))
+
+    base_message: dict[str, Any] = {
+        "channel": "indicator",
+        "type": "point" if event_type == "indicator_point" else "snapshot",
+        "run_id": str(event.get("run_id", "")),
+        "seq": _to_int(event.get("seq", 0)),
+        "ts": _to_int(event.get("ts", 0)),
+        "symbol": symbol,
+        "level": str(event.get("level", "info")),
+    }
+
+    if event_type == "indicator_point":
+        base_message["indicator"] = {
+            "owner_strategy_id": str(payload.get("owner_strategy_id", "")),
+            "indicator_key": str(payload.get("indicator_key", "")),
+            "display_name": str(payload.get("display_name", "")),
+            "pane": str(payload.get("pane", "")),
+            "render_type": str(payload.get("render_type", "")),
+            "symbol": _normalize_symbol(payload.get("symbol")),
+            "timestamp": _to_int(payload.get("timestamp", 0)),
+            "value": _to_float_or_text(payload.get("value")),
+            "warmup": _to_bool(payload.get("warmup", False)),
+            "meta": _json_loads_or_default(payload.get("meta_json"), {}),
+        }
+        return base_message
+
+    raw_items = _json_loads_or_default(payload.get("items_json"), [])
+    items: list[dict[str, Any]] = []
+    if isinstance(raw_items, list):
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+            items.append(
+                {
+                    "indicator_key": str(raw_item.get("indicator_key", "")),
+                    "display_name": str(raw_item.get("display_name", "")),
+                    "pane": str(raw_item.get("pane", "")),
+                    "render_type": str(raw_item.get("render_type", "")),
+                    "value": _to_float_or_text(raw_item.get("value")),
+                    "warmup": _to_bool(raw_item.get("warmup", False)),
+                    "meta": _json_loads_or_default(raw_item.get("meta_json"), {}),
+                }
+            )
+
+    indicator_keys = [item["indicator_key"] for item in items if item["indicator_key"]]
+    panes = sorted({item["pane"] for item in items if item["pane"]})
+    render_types = sorted(
+        {item["render_type"] for item in items if item["render_type"]}
+    )
+    value_by_key = {
+        item["indicator_key"]: item["value"] for item in items if item["indicator_key"]
+    }
+    items_by_key = {
+        item["indicator_key"]: item for item in items if item["indicator_key"]
+    }
+    warmup_count = sum(1 for item in items if bool(item.get("warmup", False)))
+
+    base_message["snapshot"] = {
+        "owner_strategy_id": str(payload.get("owner_strategy_id", "")),
+        "symbol": _normalize_symbol(payload.get("symbol")),
+        "timestamp": _to_int(payload.get("timestamp", 0)),
+        "indicator_count": _to_int(payload.get("indicator_count", len(items))),
+        "items": items,
+        "indicator_keys": indicator_keys,
+        "panes": panes,
+        "render_types": render_types,
+        "value_by_key": value_by_key,
+        "items_by_key": items_by_key,
+        "warmup_count": warmup_count,
+        "has_warmup": warmup_count > 0,
+    }
+    return base_message
+
+
+def to_indicator_messages(
+    events: Iterable[BacktestStreamEvent],
+) -> list[dict[str, Any]]:
+    """Convert an event iterable into indicator-only frontend messages."""
+    messages: list[dict[str, Any]] = []
+    for event in events:
+        message = to_indicator_message(event)
+        if message is not None:
+            messages.append(message)
+    return messages

--- a/python/akquant/plot/__init__.py
+++ b/python/akquant/plot/__init__.py
@@ -6,6 +6,7 @@ Provides professional-grade plotting capabilities for backtest results.
 
 from .analysis import plot_pnl_vs_duration, plot_trades_distribution
 from .dashboard import plot_dashboard
+from .indicator import plot_indicators
 from .report import plot_report
 from .strategy import plot_strategy
 
@@ -14,6 +15,7 @@ plot_result = plot_dashboard
 
 __all__ = [
     "plot_dashboard",
+    "plot_indicators",
     "plot_strategy",
     "plot_trades_distribution",
     "plot_pnl_vs_duration",

--- a/python/akquant/plot/indicator.py
+++ b/python/akquant/plot/indicator.py
@@ -1,0 +1,193 @@
+"""Indicator plotting module."""
+
+from typing import TYPE_CHECKING, Optional
+
+import pandas as pd
+
+from .utils import check_plotly, get_color, go, make_subplots
+
+if TYPE_CHECKING:
+    from ..backtest import BacktestResult
+
+
+def _build_trace_name(
+    *,
+    display_name: str,
+    owner_strategy_id: str,
+    symbol: str,
+    include_owner: bool,
+    include_symbol: bool,
+) -> str:
+    """Build a readable trace name from normalized indicator metadata."""
+    parts = [display_name]
+    if include_symbol and symbol:
+        parts.append(f"[{symbol}]")
+    if include_owner and owner_strategy_id:
+        parts.append(f"<{owner_strategy_id}>")
+    return " ".join(parts)
+
+
+def plot_indicators(
+    result: "BacktestResult",
+    name: Optional[str] = None,
+    symbol: Optional[str] = None,
+    include_warmup: bool = True,
+    title: str = "Indicator History",
+    theme: str = "light",
+    show: bool = True,
+    filename: Optional[str] = None,
+) -> Optional["go.Figure"]:
+    """
+    Plot recorded indicator history as one lightweight multi-pane figure.
+
+    :param result: Backtest result that contains indicator outputs.
+    :param name: Optional indicator key filter.
+    :param symbol: Optional symbol filter.
+    :param include_warmup: Whether to keep warmup points.
+    :param title: Figure title.
+    :param theme: Plot theme key.
+    :param show: Whether to display the figure immediately.
+    :param filename: Optional HTML output path.
+    :return: Plotly Figure or ``None`` when no indicator data is available.
+    """
+    if not check_plotly():
+        return None
+
+    frame = result.indicator_df(name=name, symbol=symbol).copy()
+    if frame.empty:
+        print("No indicator data available.")
+        return None
+    if not include_warmup:
+        frame = frame.loc[~frame["warmup"]]
+    if frame.empty:
+        print("No indicator data available after filtering.")
+        return None
+
+    definitions = result.indicator_definitions.copy()
+    if definitions.empty:
+        definitions = pd.DataFrame(
+            columns=["indicator_key", "display_name", "pane", "render_type", "color"]
+        )
+
+    merged = frame.merge(
+        definitions,
+        on="indicator_key",
+        how="left",
+        suffixes=("", "_definition"),
+    )
+    merged["display_name"] = merged["display_name"].fillna(merged["indicator_key"])
+    merged["pane"] = merged["pane"].fillna("main").replace("", "main")
+    merged["render_type"] = merged["render_type"].fillna("line").replace("", "line")
+    merged["owner_strategy_id"] = merged["owner_strategy_id"].fillna("").astype(str)
+    merged["symbol"] = merged["symbol"].fillna("").astype(str)
+    merged = merged.dropna(subset=["datetime", "value"]).sort_values(
+        ["pane", "indicator_key", "symbol", "timestamp"]
+    )
+    if merged.empty:
+        print("No indicator data available after filtering invalid rows.")
+        return None
+
+    panes = merged["pane"].drop_duplicates().tolist()
+    subplot_titles = [str(pane) for pane in panes]
+    row_count = max(len(panes), 1)
+
+    fig = make_subplots(
+        rows=row_count,
+        cols=1,
+        shared_xaxes=True,
+        vertical_spacing=0.06,
+        subplot_titles=tuple(subplot_titles),
+    )
+
+    include_owner = merged["owner_strategy_id"].nunique(dropna=True) > 1
+    include_symbol = merged["symbol"].replace("", pd.NA).nunique(dropna=True) > 1
+    use_webgl = len(merged) > 10000
+
+    for row_index, pane_name in enumerate(panes, start=1):
+        pane_frame = merged.loc[merged["pane"] == pane_name]
+        for _, series_frame in pane_frame.groupby(
+            [
+                "indicator_key",
+                "display_name",
+                "owner_strategy_id",
+                "symbol",
+                "render_type",
+            ],
+            dropna=False,
+            sort=False,
+        ):
+            display_name = str(series_frame["display_name"].iloc[0])
+            owner_strategy_id = str(series_frame["owner_strategy_id"].iloc[0])
+            symbol_text = str(series_frame["symbol"].iloc[0])
+            render_type = str(series_frame["render_type"].iloc[0]).strip().lower()
+            color_value = (
+                series_frame["color"].iloc[0] if "color" in series_frame else None
+            )
+            trace_name = _build_trace_name(
+                display_name=display_name,
+                owner_strategy_id=owner_strategy_id,
+                symbol=symbol_text,
+                include_owner=include_owner,
+                include_symbol=include_symbol,
+            )
+            x_data = series_frame["datetime"]
+            y_data = series_frame["value"].astype(float)
+
+            if render_type in {"bar", "histogram", "column"}:
+                fig.add_trace(
+                    go.Bar(
+                        x=x_data,
+                        y=y_data,
+                        name=trace_name,
+                        marker=dict(color=color_value) if color_value else None,
+                    ),
+                    row=row_index,
+                    col=1,
+                )
+            else:
+                trace_type = go.Scattergl if use_webgl else go.Scatter
+                fig.add_trace(
+                    trace_type(
+                        x=x_data,
+                        y=y_data,
+                        mode="lines",
+                        name=trace_name,
+                        line=(
+                            dict(color=color_value, width=2)
+                            if color_value
+                            else dict(width=2)
+                        ),
+                    ),
+                    row=row_index,
+                    col=1,
+                )
+
+            fig.update_yaxes(title_text=str(pane_name), row=row_index, col=1)
+
+    xaxis_format = "%Y-%m-%d"
+    if len(merged) > 1:
+        datetimes = merged["datetime"].sort_values()
+        if (
+            len(datetimes) > 1
+            and (datetimes.iloc[1] - datetimes.iloc[0]).total_seconds() < 86400
+        ):
+            xaxis_format = "%Y-%m-%d %H:%M"
+
+    fig.update_xaxes(tickformat=xaxis_format)
+    fig.update_layout(
+        title=title,
+        template="plotly_dark" if theme == "dark" else "plotly_white",
+        height=max(360, 280 * row_count),
+        hovermode="x unified",
+        paper_bgcolor=get_color(theme, "bg_color"),
+        plot_bgcolor=get_color(theme, "bg_color"),
+        font=dict(color=get_color(theme, "text_color")),
+        legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="left", x=0),
+        margin=dict(l=60, r=30, t=70, b=50),
+    )
+
+    if filename is not None:
+        fig.write_html(filename)
+    if show:
+        fig.show()
+    return fig

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -15,6 +15,7 @@ from .analysis import (
     plot_yearly_returns,
 )
 from .dashboard import plot_dashboard
+from .indicator import plot_indicators
 from .strategy import plot_strategy
 from .utils import check_plotly
 
@@ -401,6 +402,8 @@ HTML_TEMPLATE = """
         <div class="chart-container">
             {dashboard_html}
         </div>
+
+        {indicator_section_html}
 
         <div class="section-title">收益分析 (Return Analysis)</div>
         <div class="row">
@@ -1118,6 +1121,10 @@ def _build_chart_html_sections(
     market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
     plot_symbol: Optional[str] = None,
     include_trade_kline: bool = True,
+    include_indicators: bool = False,
+    indicator_name: Optional[str] = None,
+    indicator_symbol: Optional[str] = None,
+    indicator_include_warmup: bool = True,
     benchmark: Optional[Union[str, pd.Series]] = None,
     curve_freq: str = "raw",
 ) -> dict[str, str]:
@@ -1139,6 +1146,103 @@ def _build_chart_html_sections(
         if fig_dashboard
         else "<div>暂无数据</div>"
     )
+    indicator_section_html = ""
+    if include_indicators:
+        indicator_df = result.indicator_df(name=indicator_name, symbol=indicator_symbol)
+        if not indicator_include_warmup and not indicator_df.empty:
+            indicator_df = indicator_df.loc[~indicator_df["warmup"]]
+        indicator_defs = result.indicator_definitions.copy()
+        if indicator_name is not None and not indicator_defs.empty:
+            indicator_defs = indicator_defs.loc[
+                indicator_defs["indicator_key"] == str(indicator_name)
+            ]
+        indicator_symbol_count = (
+            indicator_df["symbol"].dropna().astype(str).nunique()
+            if not indicator_df.empty
+            else 0
+        )
+        overview_html = (
+            '<div class="analysis-overview-grid">'
+            f'<div class="analysis-card"><div class="analysis-card-label">'
+            "指标定义数 (Indicator Definitions)</div>"
+            f'<div class="analysis-card-value">{len(indicator_defs)}</div></div>'
+            f'<div class="analysis-card"><div class="analysis-card-label">'
+            "指标点位数 (Indicator Points)</div>"
+            f'<div class="analysis-card-value">{len(indicator_df)}</div></div>'
+            f'<div class="analysis-card"><div class="analysis-card-label">'
+            "标的数 (Symbols)</div>"
+            f'<div class="analysis-card-value">'
+            f"{indicator_symbol_count}"
+            "</div></div>"
+            "</div>"
+        )
+        filter_parts: list[str] = []
+        if indicator_name is not None:
+            filter_parts.append(f"指标={indicator_name}")
+        if indicator_symbol is not None:
+            filter_parts.append(f"标的={indicator_symbol}")
+        if not indicator_include_warmup:
+            filter_parts.append("已排除预热点")
+        filter_text = " | ".join(filter_parts)
+        filter_hint = (
+            '<div class="empty-panel" style="margin-bottom: 16px;">'
+            f"过滤条件: {filter_text}</div>"
+            if filter_parts
+            else ""
+        )
+        if indicator_df.empty:
+            indicator_chart_html = "<div class='empty-panel'>暂无指标数据</div>"
+        else:
+            fig_indicator = plot_indicators(
+                result=result,
+                name=indicator_name,
+                symbol=indicator_symbol,
+                include_warmup=indicator_include_warmup,
+                show=False,
+                title="报告内指标预览 (Indicator Preview)",
+                theme="light",
+            )
+            indicator_chart_html = (
+                fig_indicator.to_html(
+                    full_html=False,
+                    include_plotlyjs=False,
+                    config=config,
+                )
+                if fig_indicator
+                else "<div class='empty-panel'>暂无指标图表</div>"
+            )
+        if indicator_defs.empty:
+            indicator_defs_html = "<div>暂无指标定义数据</div>"
+        else:
+            indicator_defs_view = _rename_table_columns(
+                indicator_defs,
+                {
+                    "indicator_key": "指标键 (Indicator Key)",
+                    "display_name": "展示名 (Display Name)",
+                    "pane": "面板 (Pane)",
+                    "render_type": "绘制方式 (Render Type)",
+                    "unit": "单位 (Unit)",
+                    "precision": "精度 (Precision)",
+                    "color": "颜色 (Color)",
+                },
+            )
+            indicator_defs_html = _format_table(
+                indicator_defs_view,
+                max_rows=20,
+                compact_currency=False,
+            )
+        indicator_section_html = (
+            '<div class="section-title">自定义指标 (Custom Indicators)</div>'
+            f"{filter_hint}"
+            f"{overview_html}"
+            '<div class="chart-container">'
+            f"{indicator_chart_html}"
+            "</div>"
+            '<details class="details-block" style="margin-top: 20px;">'
+            "<summary>指标定义明细 (Indicator Definitions)</summary>"
+            f'<div class="details-content">{indicator_defs_html}</div>'
+            "</details>"
+        )
 
     returns_series = _build_daily_returns_from_equity(equity_curve)
     fig_rolling = plot_rolling_metrics(returns_series, theme="light")
@@ -1636,6 +1740,7 @@ def _build_chart_html_sections(
 
     return {
         "dashboard_html": dashboard_html,
+        "indicator_section_html": indicator_section_html,
         "yearly_returns_html": yearly_returns_html,
         "returns_dist_html": returns_dist_html,
         "rolling_metrics_html": rolling_metrics_html,
@@ -1985,6 +2090,10 @@ def plot_report(
     market_data: Optional[Union[pd.DataFrame, dict[str, pd.DataFrame]]] = None,
     plot_symbol: Optional[str] = None,
     include_trade_kline: bool = True,
+    include_indicators: bool = False,
+    indicator_name: Optional[str] = None,
+    indicator_symbol: Optional[str] = None,
+    indicator_include_warmup: bool = True,
     benchmark: Optional[Union[str, pd.Series]] = None,
     curve_freq: str = "raw",
 ) -> None:
@@ -1997,6 +2106,10 @@ def plot_report(
     3. 交易分布与持仓时间分析 (Trade Analysis)
 
     :param compact_currency: 是否将金额列按 K/M/B 紧凑显示
+    :param include_indicators: 是否在报告中包含自定义指标预览区块
+    :param indicator_name: 可选指标键过滤，仅展示指定指标
+    :param indicator_symbol: 可选标的过滤，仅展示指定标的指标
+    :param indicator_include_warmup: 是否在指标报告区块中保留预热点
     :param benchmark: 基准收益序列 (pd.Series) 或基准标识字符串
     :param curve_freq: 曲线频率，"raw" 为原始频率，"D" 为日频末值
     """
@@ -2015,6 +2128,10 @@ def plot_report(
         market_data=market_data,
         plot_symbol=plot_symbol,
         include_trade_kline=include_trade_kline,
+        include_indicators=include_indicators,
+        indicator_name=indicator_name,
+        indicator_symbol=indicator_symbol,
+        indicator_include_warmup=indicator_include_warmup,
         benchmark=benchmark,
         curve_freq=normalized_curve_freq,
     )
@@ -2035,6 +2152,7 @@ def plot_report(
         final_equity=summary_context["final_equity"],
         metrics_html=metrics_html,
         dashboard_html=chart_sections["dashboard_html"],
+        indicator_section_html=chart_sections["indicator_section_html"],
         yearly_returns_html=chart_sections["yearly_returns_html"],
         returns_dist_html=chart_sections["returns_dist_html"],
         rolling_metrics_html=chart_sections["rolling_metrics_html"],

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -26,6 +26,7 @@ from .akquant import (
     Tick,
     TimeInForce,
 )
+from .indicator_recording import IndicatorRecorder
 from .sizer import FixedSize, Sizer
 from .strategy_events import (
     on_bar_event as _on_bar_event_impl,
@@ -364,6 +365,7 @@ class Strategy:
     _pending_schedules: List[Tuple[Union[str, dt.datetime, pd.Timestamp], str]]
     _pending_daily_timers: List[Tuple[str, str]]
     _instrument_snapshots: Dict[str, InstrumentSnapshot]
+    _indicator_recorder: Optional[IndicatorRecorder]
 
     _trading_days: List[pd.Timestamp]
 
@@ -490,6 +492,7 @@ class Strategy:
         instance._pending_schedules = []
         instance._pending_daily_timers = []
         instance._instrument_snapshots = {}
+        instance._indicator_recorder = None
 
         return instance
 
@@ -528,6 +531,8 @@ class Strategy:
             del state["_framework_stop_flushed"]
         if "_framework_boundary_timers_registered" in state:
             del state["_framework_boundary_timers_registered"]
+        if "_indicator_recorder" in state:
+            del state["_indicator_recorder"]
         incremental_indicators = state.get("_incremental_indicators")
         if isinstance(incremental_indicators, dict):
             for name in incremental_indicators.keys():
@@ -594,6 +599,7 @@ class Strategy:
             self._pending_daily_timers = []
         if not hasattr(self, "_instrument_snapshots"):
             self._instrument_snapshots = {}
+        self._indicator_recorder = None
         if not hasattr(self, "_ml_validation_lifecycle"):
             self._ml_validation_lifecycle = False
         if not hasattr(self, "_ml_model_template"):
@@ -1497,6 +1503,66 @@ class Strategy:
 
     def _resolve_symbol(self, symbol: Optional[str] = None) -> str:
         return _resolve_symbol_impl(self, symbol)
+
+    def _resolve_record_timestamp(self) -> int:
+        """Resolve the current runtime timestamp for indicator recording."""
+        if self.current_bar is not None:
+            return int(self.current_bar.timestamp)
+        if self.current_tick is not None:
+            return int(self.current_tick.timestamp)
+        if self.ctx is not None:
+            current_time = getattr(self.ctx, "current_time", None)
+            if current_time is not None:
+                return int(current_time)
+        raise RuntimeError(
+            "record_indicator requires an active bar/tick or context timestamp"
+        )
+
+    def record_indicator(
+        self,
+        name: str,
+        value: Any,
+        symbol: Optional[str] = None,
+        *,
+        timestamp: Optional[Any] = None,
+        display_name: Optional[str] = None,
+        pane: str = "sub",
+        render_type: str = "line",
+        unit: Optional[str] = None,
+        precision: Optional[int] = None,
+        color: Optional[str] = None,
+        meta: Optional[Dict[str, Any]] = None,
+        warmup: bool = False,
+    ) -> None:
+        """Record one indicator point for downstream visualization and export."""
+        recorder = getattr(self, "_indicator_recorder", None)
+        if recorder is None:
+            return
+
+        resolved_symbol = self._resolve_symbol(symbol)
+        resolved_timestamp = (
+            self._resolve_record_timestamp()
+            if timestamp is None
+            else int(pd.Timestamp(timestamp).value)
+        )
+        owner_strategy_id = str(
+            getattr(self, "_owner_strategy_id", "_default") or "_default"
+        )
+        recorder.record(
+            name=name,
+            value=value,
+            symbol=resolved_symbol,
+            timestamp=resolved_timestamp,
+            owner_strategy_id=owner_strategy_id,
+            display_name=display_name,
+            pane=pane,
+            render_type=render_type,
+            unit=unit,
+            precision=precision,
+            color=color,
+            meta=meta,
+            warmup=warmup,
+        )
 
     def get_position(self, symbol: Optional[str] = None) -> float:
         """

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -33,6 +33,13 @@ def _is_before_active_start(strategy: Any, timestamp: int) -> bool:
     return active_start_time is not None and timestamp < int(active_start_time)
 
 
+def _flush_indicator_snapshots(strategy: Any) -> None:
+    """Flush one callback cycle of pending indicator snapshot events."""
+    recorder = getattr(strategy, "_indicator_recorder", None)
+    if recorder is not None:
+        recorder.flush_stream_snapshot()
+
+
 def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     """引擎调用的 Bar 回调 (Internal)."""
     ensure_framework_state(strategy)
@@ -113,6 +120,7 @@ def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
             )
         except Exception:
             pass
+    _flush_indicator_snapshots(strategy)
 
 
 def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
@@ -140,6 +148,7 @@ def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
     strategy._last_prices[tick.symbol] = tick.price
     dispatch_portfolio_update(strategy)
     call_user_callback(strategy, "on_tick", tick, payload=tick)
+    _flush_indicator_snapshots(strategy)
 
 
 def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
@@ -159,12 +168,15 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
     dispatch_portfolio_update(strategy)
 
     if dispatch_daily_rebalance_timer(strategy, payload):
+        _flush_indicator_snapshots(strategy)
         return
 
     if dispatch_boundary_timer(strategy, payload):
+        _flush_indicator_snapshots(strategy)
         return
 
     if dispatch_pre_open_timer(strategy, payload):
+        _flush_indicator_snapshots(strategy)
         return
 
     if payload.startswith("__daily__|"):
@@ -188,6 +200,8 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
                     strategy.schedule(target, payload)
                 except Exception as e:
                     print(f"Error processing daily timer: {e}")
+            _flush_indicator_snapshots(strategy)
             return
 
     call_user_callback(strategy, "on_timer", payload, payload=payload)
+    _flush_indicator_snapshots(strategy)

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -834,6 +834,21 @@ impl Engine {
         }
     }
 
+    pub(crate) fn emit_stream_event_owned(
+        &mut self,
+        py: Python<'_>,
+        event_type: &str,
+        symbol: Option<String>,
+        level: &str,
+        payload: HashMap<String, String>,
+    ) {
+        let payload_ref: HashMap<&str, String> = payload
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.clone()))
+            .collect();
+        self.emit_stream_event(py, event_type, symbol.as_deref(), level, payload_ref);
+    }
+
     pub(crate) fn flush_stream_events(&mut self, py: Python<'_>) {
         let (Some(callback_ref), Some(run_id_ref)) = (&self.stream_callback, &self.stream_run_id)
         else {

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -98,6 +98,19 @@ impl Engine {
         self.set_stream_callback_internal(None);
     }
 
+    fn emit_stream_event_py(
+        &mut self,
+        py: Python<'_>,
+        event_type: &str,
+        symbol: Option<String>,
+        level: &str,
+        payload: HashMap<String, String>,
+    ) {
+        super::core::Engine::emit_stream_event_owned(
+            self, py, event_type, symbol, level, payload,
+        );
+    }
+
     fn add_timer(&mut self, timestamp: i64, payload: String) {
         self.timers.push(Timer { timestamp, payload });
     }
@@ -1105,9 +1118,16 @@ impl Engine {
 
         // Run Pipeline
         if let Err(e) = pipeline.run(self, py, strategy) {
-            let mut payload = HashMap::new();
-            payload.insert("message", e.to_string());
-            self.emit_stream_event(py, "error", None, "error", payload);
+            let mut payload: HashMap<String, String> = HashMap::new();
+            payload.insert("message".to_string(), e.to_string());
+            super::core::Engine::emit_stream_event_owned(
+                self,
+                py,
+                "error",
+                None,
+                "error",
+                payload,
+            );
             self.finish_stream_run(py, "failed", Some(&e.to_string()));
             // Clean up pb if error
             self.progress_bar = None;

--- a/tests/test_indicator_live_web_example.py
+++ b/tests/test_indicator_live_web_example.py
@@ -1,0 +1,92 @@
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_live_web_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1] / "examples" / "64_indicator_live_web.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "indicator_live_web_example", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_state_payload_returns_full_snapshot_window() -> None:
+    """Full state reads should return the current window payload."""
+    module = _load_live_web_module()
+    state = module.IndicatorLiveState(
+        started=True,
+        finished=False,
+        run_id="demo-run",
+    )
+    state.latest_indicator_values["close_echo"] = 101.5
+    state.point_messages.extend(
+        [
+            {"seq": 5, "type": "point", "indicator": {"indicator_key": "close_echo"}},
+            {"seq": 7, "type": "point", "indicator": {"indicator_key": "close_echo"}},
+        ]
+    )
+    state.snapshot_messages.append(
+        {"seq": 6, "type": "snapshot", "snapshot": {"indicator_count": 1}}
+    )
+
+    payload = module._build_state_payload(state)
+
+    assert payload["run_id"] == "demo-run"
+    assert payload["cursor"] == {
+        "latest_seq": 7,
+        "since_seq": None,
+        "incremental": False,
+    }
+    assert payload["counts"] == {
+        "point_messages": 2,
+        "snapshot_messages": 1,
+    }
+    assert "window" in payload
+    assert "delta" not in payload
+    assert len(payload["window"]["point_messages"]) == 2
+    assert len(payload["window"]["snapshot_messages"]) == 1
+
+
+def test_build_state_payload_returns_incremental_delta_only() -> None:
+    """Incremental state reads should return only delta payloads."""
+    module = _load_live_web_module()
+    state = module.IndicatorLiveState(
+        started=True,
+        finished=True,
+        run_id="demo-run",
+    )
+    state.point_messages.extend(
+        [
+            {"seq": 10, "type": "point", "indicator": {"indicator_key": "close_echo"}},
+            {"seq": 14, "type": "point", "indicator": {"indicator_key": "close_echo"}},
+        ]
+    )
+    state.snapshot_messages.extend(
+        [
+            {"seq": 11, "type": "snapshot", "snapshot": {"indicator_count": 1}},
+            {"seq": 15, "type": "snapshot", "snapshot": {"indicator_count": 1}},
+        ]
+    )
+
+    payload = module._build_state_payload(state, since_seq=11)
+
+    assert payload["cursor"] == {
+        "latest_seq": 15,
+        "since_seq": 11,
+        "incremental": True,
+    }
+    assert payload["counts"] == {
+        "point_messages": 2,
+        "snapshot_messages": 2,
+    }
+    assert "delta" in payload
+    assert "window" not in payload
+    assert [message["seq"] for message in payload["delta"]["point_messages"]] == [14]
+    assert [message["seq"] for message in payload["delta"]["snapshot_messages"]] == [15]

--- a/tests/test_indicator_recording.py
+++ b/tests/test_indicator_recording.py
@@ -1,0 +1,415 @@
+import json
+from pathlib import Path
+
+import akquant
+import pandas as pd
+import pytest
+from akquant import (
+    Bar,
+    Strategy,
+    is_indicator_stream_event,
+    run_backtest,
+    to_indicator_message,
+    to_indicator_messages,
+)
+
+
+def _build_data() -> list[Bar]:
+    closes = [10.0, 10.5, 11.0]
+    bars: list[Bar] = []
+    for i, close in enumerate(closes):
+        bars.append(
+            Bar(
+                timestamp=pd.Timestamp(f"2024-01-0{i + 1} 10:00:00").value,
+                open=close - 0.1,
+                high=close + 0.2,
+                low=close - 0.2,
+                close=close,
+                volume=1000.0,
+                symbol="IND",
+            )
+        )
+    return bars
+
+
+class IndicatorRecordingStrategy(Strategy):
+    """Record one simple indicator point on every bar."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Emit two indicators so bridge and snapshot paths can be verified."""
+        self.record_indicator(
+            name="close_echo",
+            value=bar.close,
+            display_name="Close Echo",
+            pane="main",
+            render_type="line",
+            precision=2,
+            meta={"source": "close"},
+        )
+        self.record_indicator(
+            name="range_echo",
+            value=bar.high - bar.low,
+            display_name="Range Echo",
+            pane="signal",
+            render_type="bar",
+            meta={"source": ["high", "low"]},
+            warmup=bar.close < 10.5,
+        )
+
+
+class LegacyNoIndicatorStrategy(Strategy):
+    """Legacy strategy that never records custom indicator outputs."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Access one field without recording any custom indicator."""
+        _ = bar.close
+
+
+def test_indicator_recording_round_trip(tmp_path: Path) -> None:
+    """Recorded indicator points should be accessible and exportable."""
+    events: list[akquant.BacktestStreamEvent] = []
+    result = run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        on_event=events.append,
+    )
+
+    indicator_df = result.indicator_df(name="close_echo", symbol="IND")
+    assert len(indicator_df) == 3
+    assert indicator_df["indicator_key"].tolist() == ["close_echo"] * 3
+    assert indicator_df["symbol"].tolist() == ["IND"] * 3
+    assert indicator_df["value"].tolist() == [10.0, 10.5, 11.0]
+    assert "datetime" in indicator_df.columns
+
+    definitions = result.indicator_definitions
+    assert len(definitions) == 2
+    assert definitions.iloc[0]["display_name"] == "Close Echo"
+    assert definitions.iloc[0]["pane"] == "main"
+    assert definitions.iloc[0]["render_type"] == "line"
+    assert definitions.iloc[1]["display_name"] == "Range Echo"
+
+    export_path = tmp_path / "indicators.json"
+    result.export_indicators(str(export_path), format="json")
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    assert sorted(payload.keys()) == ["definitions", "instances", "points", "run_id"]
+    assert result.stream_run_id == events[0]["run_id"]
+    assert payload["run_id"] == result.stream_run_id
+    assert len(payload["definitions"]) == 2
+    assert len(payload["instances"]) == 2
+    assert len(payload["points"]) == 6
+
+
+def test_legacy_strategy_without_indicator_recording_stays_empty() -> None:
+    """Legacy strategies should still work and expose empty indicator outputs."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=LegacyNoIndicatorStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+    )
+
+    assert result.indicator_df().empty
+    assert result.indicator_definitions.empty
+    assert result.indicator_instances.empty
+
+
+def test_indicator_recording_emits_stream_events() -> None:
+    """Indicator recording should emit point and snapshot stream events."""
+    if not hasattr(akquant.Engine(), "emit_stream_event_py"):
+        pytest.skip("Engine bindings do not expose emit_stream_event_py yet")
+
+    events: list[akquant.BacktestStreamEvent] = []
+    run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        on_event=events.append,
+        stream_progress_interval=16,
+        stream_equity_interval=16,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+
+    point_events = [
+        event for event in events if event["event_type"] == "indicator_point"
+    ]
+    snapshot_events = [
+        event for event in events if event["event_type"] == "indicator_snapshot"
+    ]
+
+    assert len(point_events) == 6
+    assert len(snapshot_events) == 3
+
+    point_values = [
+        float(event["payload"]["value"])
+        for event in point_events
+        if "value" in event["payload"]
+    ]
+    assert point_values == pytest.approx([10.0, 0.4, 10.5, 0.4, 11.0, 0.4])
+    assert {event["payload"]["indicator_key"] for event in point_events} == {
+        "close_echo",
+        "range_echo",
+    }
+    assert {event["payload"]["owner_strategy_id"] for event in point_events} == {
+        "_default"
+    }
+
+    snapshot_values = [
+        [float(item["value"]) for item in json.loads(event["payload"]["items_json"])]
+        for event in snapshot_events
+    ]
+    assert len(snapshot_values) == 3
+    assert snapshot_values[0] == pytest.approx([10.0, 0.4])
+    assert snapshot_values[1] == pytest.approx([10.5, 0.4])
+    assert snapshot_values[2] == pytest.approx([11.0, 0.4])
+    assert {event["payload"]["indicator_count"] for event in snapshot_events} == {"2"}
+    seq_values = [int(event["seq"]) for event in events]
+    assert seq_values == sorted(seq_values)
+    assert len(seq_values) == len(set(seq_values))
+    assert len({event["run_id"] for event in events}) == 1
+
+
+def test_indicator_recording_stream_sampling_controls() -> None:
+    """Indicator stream intervals should reduce emitted point and snapshot events."""
+    events: list[akquant.BacktestStreamEvent] = []
+    run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        on_event=events.append,
+        indicator_stream_point_interval=2,
+        indicator_stream_snapshot_interval=2,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+
+    point_events = [
+        event for event in events if event["event_type"] == "indicator_point"
+    ]
+    snapshot_events = [
+        event for event in events if event["event_type"] == "indicator_snapshot"
+    ]
+
+    assert len(point_events) == 3
+    assert len(snapshot_events) == 1
+    assert {event["payload"]["indicator_key"] for event in point_events} == {
+        "range_echo"
+    }
+    assert [
+        float(event["payload"]["value"]) for event in point_events
+    ] == pytest.approx([0.4, 0.4, 0.4])
+    snapshot_items = json.loads(snapshot_events[0]["payload"]["items_json"])
+    assert [float(item["value"]) for item in snapshot_items] == pytest.approx(
+        [10.5, 0.4]
+    )
+
+
+def test_indicator_stream_bridge_builds_frontend_messages() -> None:
+    """Indicator stream helper should normalize point and snapshot payloads."""
+    events: list[akquant.BacktestStreamEvent] = []
+    run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        on_event=events.append,
+        stream_batch_size=1,
+        stream_max_buffer=128,
+    )
+
+    messages = to_indicator_messages(events)
+    assert len(messages) == 9
+    assert all(message["channel"] == "indicator" for message in messages)
+    assert {message["type"] for message in messages} == {"point", "snapshot"}
+
+    first_point = next(message for message in messages if message["type"] == "point")
+    assert first_point["indicator"]["indicator_key"] == "close_echo"
+    assert first_point["indicator"]["display_name"] == "Close Echo"
+    assert first_point["indicator"]["pane"] == "main"
+    assert first_point["indicator"]["render_type"] == "line"
+    assert first_point["indicator"]["value"] == 10.0
+    assert first_point["indicator"]["meta"] == {"source": "close"}
+    assert first_point["indicator"]["warmup"] is False
+    assert is_indicator_stream_event(events[0]) is False
+
+    first_snapshot = next(
+        message for message in messages if message["type"] == "snapshot"
+    )
+    assert first_snapshot["snapshot"]["indicator_count"] == 2
+    assert first_snapshot["snapshot"]["items"][0]["indicator_key"] == "close_echo"
+    assert first_snapshot["snapshot"]["items"][0]["value"] == 10.0
+    assert first_snapshot["snapshot"]["items"][0]["meta"] == {"source": "close"}
+    assert first_snapshot["snapshot"]["items"][1]["indicator_key"] == "range_echo"
+    assert first_snapshot["snapshot"]["items"][1]["warmup"] is True
+    assert first_snapshot["snapshot"]["items"][1]["meta"] == {"source": ["high", "low"]}
+    assert first_snapshot["snapshot"]["indicator_keys"] == ["close_echo", "range_echo"]
+    assert first_snapshot["snapshot"]["panes"] == ["main", "signal"]
+    assert first_snapshot["snapshot"]["render_types"] == ["bar", "line"]
+    assert first_snapshot["snapshot"]["value_by_key"]["close_echo"] == pytest.approx(
+        10.0
+    )
+    assert first_snapshot["snapshot"]["value_by_key"]["range_echo"] == pytest.approx(
+        0.4
+    )
+    assert first_snapshot["snapshot"]["items_by_key"]["range_echo"]["pane"] == "signal"
+    assert first_snapshot["snapshot"]["warmup_count"] == 1
+    assert first_snapshot["snapshot"]["has_warmup"] is True
+
+
+def test_indicator_stream_bridge_ignores_non_indicator_events() -> None:
+    """Non-indicator stream events should not be converted into bridge messages."""
+    event = akquant.BacktestStreamEvent(
+        run_id="demo",
+        seq=1,
+        ts=0,
+        event_type="started",
+        symbol=None,
+        level="info",
+        payload={"status": "started"},
+    )
+
+    assert is_indicator_stream_event(event) is False
+    assert to_indicator_message(event) is None
+    assert to_indicator_messages([event]) == []
+
+
+def test_indicator_stream_bridge_normalizes_unknown_symbols() -> None:
+    """Unknown symbols should be normalized to None in bridged messages."""
+    point_event = akquant.BacktestStreamEvent(
+        run_id="demo",
+        seq=2,
+        ts=1,
+        event_type="indicator_point",
+        symbol="_unknown",
+        level="info",
+        payload={
+            "owner_strategy_id": "_default",
+            "indicator_key": "close_echo",
+            "display_name": "Close Echo",
+            "pane": "main",
+            "render_type": "line",
+            "symbol": "_unknown",
+            "timestamp": "1",
+            "value": "10.0",
+            "warmup": "false",
+            "meta_json": "{}",
+        },
+    )
+    snapshot_event = akquant.BacktestStreamEvent(
+        run_id="demo",
+        seq=3,
+        ts=1,
+        event_type="indicator_snapshot",
+        symbol="_unknown",
+        level="info",
+        payload={
+            "owner_strategy_id": "_default",
+            "symbol": "_unknown",
+            "timestamp": "1",
+            "indicator_count": "1",
+            "items_json": json.dumps(
+                [
+                    {
+                        "indicator_key": "close_echo",
+                        "display_name": "Close Echo",
+                        "pane": "main",
+                        "render_type": "line",
+                        "value": 10.0,
+                        "warmup": False,
+                        "meta_json": "{}",
+                    }
+                ]
+            ),
+        },
+    )
+
+    point_message = to_indicator_message(point_event)
+    snapshot_message = to_indicator_message(snapshot_event)
+
+    assert point_message is not None
+    assert snapshot_message is not None
+    assert point_message["symbol"] is None
+    assert point_message["indicator"]["symbol"] is None
+    assert snapshot_message["symbol"] is None
+    assert snapshot_message["snapshot"]["symbol"] is None
+
+
+def test_indicator_stream_bridge_accepts_predecoded_payloads() -> None:
+    """Bridge helper should also accept already-decoded list/dict payload values."""
+    event = akquant.BacktestStreamEvent(
+        run_id="demo",
+        seq=4,
+        ts=2,
+        event_type="indicator_snapshot",
+        symbol="IND",
+        level="info",
+        payload={
+            "owner_strategy_id": "_default",
+            "symbol": "IND",
+            "timestamp": "2",
+            "indicator_count": "2",
+            "items_json": [
+                {
+                    "indicator_key": "close_echo",
+                    "display_name": "Close Echo",
+                    "pane": "main",
+                    "render_type": "line",
+                    "value": 10.5,
+                    "warmup": False,
+                    "meta_json": {"source": "close"},
+                },
+                {
+                    "indicator_key": "range_echo",
+                    "display_name": "Range Echo",
+                    "pane": "signal",
+                    "render_type": "bar",
+                    "value": 0.4,
+                    "warmup": True,
+                    "meta_json": {"source": ["high", "low"]},
+                },
+            ],
+        },
+    )
+
+    message = to_indicator_message(event)
+
+    assert message is not None
+    assert message["snapshot"]["items"][0]["meta"] == {"source": "close"}
+    assert message["snapshot"]["items"][1]["meta"] == {"source": ["high", "low"]}
+    assert message["snapshot"]["items"][1]["warmup"] is True
+    assert message["snapshot"]["indicator_keys"] == ["close_echo", "range_echo"]
+    assert message["snapshot"]["value_by_key"]["range_echo"] == pytest.approx(0.4)

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -8,6 +8,7 @@ from akquant import Bar, Strategy, run_backtest
 from akquant.config import RiskConfig
 from akquant.plot import (
     plot_dashboard,
+    plot_indicators,
     plot_pnl_vs_duration,
     plot_trades_distribution,
 )
@@ -37,6 +38,27 @@ class NoTradeStrategy(Strategy):
     def on_bar(self, bar: Bar) -> None:
         """Do nothing on each bar."""
         _ = bar
+
+
+class IndicatorPlotStrategy(Strategy):
+    """Record a couple of indicators for lightweight plotting checks."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Emit one main-pane line and one sub-pane bar series."""
+        self.record_indicator(
+            name="close_echo",
+            value=bar.close,
+            display_name="Close Echo",
+            pane="main",
+            render_type="line",
+        )
+        self.record_indicator(
+            name="distance_from_ten",
+            value=bar.close - 10.0,
+            display_name="Distance From Ten",
+            pane="signal",
+            render_type="bar",
+        )
 
 
 class MarginLiquidationStrategy(Strategy):
@@ -181,6 +203,7 @@ def test_report_contains_new_analysis_sections(tmp_path: Path) -> None:
     assert "策略风控拒单明细 (Risk Rejections by Strategy)" in html
     assert "暂无策略归属风控拒单聚合数据" in html
     assert "未提供行情数据，已跳过 K 线复盘图" in html
+    assert "自定义指标 (Custom Indicators)" not in html
 
 
 def test_report_includes_trade_kline_with_market_data(tmp_path: Path) -> None:
@@ -422,6 +445,64 @@ def test_report_handles_empty_trade_analysis_blocks(tmp_path: Path) -> None:
     assert "暂无归因数据" in html
 
 
+def test_report_optionally_includes_indicator_panel(tmp_path: Path) -> None:
+    """Report should include indicator section only when explicitly enabled."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=IndicatorPlotStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    report_path = tmp_path / "report_with_indicators.html"
+    result.report(
+        filename=str(report_path),
+        show=False,
+        include_indicators=True,
+        indicator_name="distance_from_ten",
+    )
+    html = report_path.read_text(encoding="utf-8")
+    assert "自定义指标 (Custom Indicators)" in html
+    assert "指标定义明细 (Indicator Definitions)" in html
+    assert "过滤条件: 指标=distance_from_ten" in html
+    assert "Distance From Ten" in html
+    assert "Close Echo" not in html
+    assert "js-plotly-plot" in html
+
+
+def test_report_indicator_panel_handles_empty_indicator_outputs(tmp_path: Path) -> None:
+    """Indicator report section should render an empty-state panel for legacy runs."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=NoTradeStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    report_path = tmp_path / "report_indicator_panel_empty.html"
+    result.report(filename=str(report_path), show=False, include_indicators=True)
+    html = report_path.read_text(encoding="utf-8")
+    assert "自定义指标 (Custom Indicators)" in html
+    assert "暂无指标数据" in html
+    assert "暂无指标定义数据" in html
+
+
 def test_plot_functions_return_figures_for_non_empty_result() -> None:
     """Core plot functions should return figures for non-empty inputs."""
     _skip_if_no_plotly()
@@ -449,6 +530,63 @@ def test_plot_functions_return_figures_for_non_empty_result() -> None:
     assert fig_rolling is not None
     fig_returns = plot_returns_distribution(result.daily_returns)
     assert fig_returns is not None
+
+
+def test_indicator_plot_functions_return_multi_pane_figures() -> None:
+    """Indicator plot helpers should return a lightweight multi-pane figure."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=IndicatorPlotStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    fig = plot_indicators(result, show=False)
+    assert fig is not None
+    assert len(fig.data) == 2
+    assert fig.layout.title.text == "Indicator History"
+    assert {trace.name for trace in fig.data} == {
+        "Close Echo",
+        "Distance From Ten",
+    }
+    assert [annotation.text for annotation in fig.layout.annotations] == [
+        "main",
+        "signal",
+    ]
+
+    filtered_fig = result.plot_indicators(name="distance_from_ten", show=False)
+    assert filtered_fig is not None
+    assert len(filtered_fig.data) == 1
+    assert filtered_fig.data[0].name == "Distance From Ten"
+    assert filtered_fig.data[0].type == "bar"
+
+
+def test_indicator_plot_returns_none_without_indicator_data() -> None:
+    """Indicator plotting should stay lightweight for legacy empty outputs."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=NoTradeStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    assert result.plot_indicators(show=False) is None
 
 
 def test_daily_curve_properties_reduce_intraday_points() -> None:


### PR DESCRIPTION
本提交新增了完整的自定义指标生态功能：
1. 为策略类新增`record_indicator`方法，支持记录标准化指标输出点位
2. 新增`plot_indicators`绘图工具，可生成按面板分组的多子图指标历史图表
3. 提供指标流转换工具函数，将回测流式事件转为前端友好的消息格式
4. 重构引擎事件发送逻辑，优化Python侧的事件调用流程
5. 新增配套示例、测试用例，完善中英文官方文档的指标相关章节
6. 更新项目版本至0.2.34，将`plans/`目录加入`.gitignore`排除列表
7. 补全所有新增API的Python类型声明