### PR TITLE
Feature/per handler log levels

### DIFF
--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -212,6 +212,19 @@ def on_bar(self, bar):
     self.log("Insufficient funds", level=logging.WARNING)
 ```
 
+To configure separate log levels for console and file output, call `register_logger()` at startup:
+
+```python
+from akquant import register_logger
+
+# Console shows only WARNING+, file records DEBUG+ details
+register_logger(
+    filename="strategy.log",
+    console_level="WARNING",
+    file_level="DEBUG",
+)
+```
+
 ### 3.2 Data Access (Syntactic Sugar)
 
 The `Strategy` class provides properties for quick access to current Bar/Tick data:

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -348,6 +348,19 @@ def on_bar(self, bar):
     self.log("资金不足", level=logging.WARNING)
 ```
 
+如需分别配置控制台与文件的日志级别，可在启动时调用 `register_logger()`：
+
+```python
+from akquant import register_logger
+
+# 控制台仅显示 WARNING 及以上，文件记录 DEBUG 及以上的详细信号
+register_logger(
+    filename="strategy.log",
+    console_level="WARNING",
+    file_level="DEBUG",
+)
+```
+
 ### 3.2 便捷数据访问 (Data Access)
 
 为了减少代码冗余，`Strategy` 类提供了当前 Bar/Tick 数据的快捷访问属性：

--- a/python/akquant/log.py
+++ b/python/akquant/log.py
@@ -43,7 +43,7 @@ class Logger:
         self._logger.setLevel(level)
 
     def _sync_handlers(self) -> None:
-        """同步内部 handler 索引，移除已脱离 logger 的引用."""
+        """同步内部 handler 索引，移除已脱离 logger 的引用"""
         active_handlers = set(self._logger.handlers)
         stale_keys = [
             key
@@ -53,31 +53,51 @@ class Logger:
         for key in stale_keys:
             del self._handlers[key]
 
-    def enable_console(self, format_str: str = DEFAULT_FORMAT) -> None:
+    def _sync_logger_level(self) -> None:
+        """Set logger level to the minimum of all handler levels with explicit settings."""
+        explicit_levels = [
+            h.level for h in self._logger.handlers if h.level != logging.NOTSET
+        ]
+        if explicit_levels:
+            self._logger.setLevel(min(explicit_levels))
+
+    def enable_console(
+        self, format_str: str = DEFAULT_FORMAT, level: Optional[Union[str, int]] = None
+    ) -> None:
         r"""
-        启用控制台日志.
+        启用控制台日志
 
         :param format_str: 日志格式字符串
         :type format_str: str
+        :param level: 控制台独立的日志等级，为 None 时继承 logger 全局级别
+        :type level: str | int, optional
         """
         self._sync_handlers()
         if "console" in self._handlers:
+            if level is not None:
+                self._handlers["console"].setLevel(level)
             return
 
         handler = logging.StreamHandler(sys.stdout)
         handler.setFormatter(logging.Formatter(format_str, datefmt=DATE_FORMAT))
+        if level is not None:
+            handler.setLevel(level)
         self._logger.addHandler(handler)
         self._handlers["console"] = handler
 
     def disable_console(self) -> None:
-        r"""禁用控制台日志."""
+        r"""禁用控制台日志"""
         self._sync_handlers()
         if "console" in self._handlers:
             self._logger.removeHandler(self._handlers["console"])
             del self._handlers["console"]
 
     def enable_file(
-        self, filename: str, format_str: str = DEFAULT_FORMAT, mode: str = "a"
+        self,
+        filename: str,
+        format_str: str = DEFAULT_FORMAT,
+        mode: str = "a",
+        level: Optional[Union[str, int]] = None,
     ) -> None:
         r"""
         启用文件日志.
@@ -86,17 +106,22 @@ class Logger:
         :type filename: str
         :param format_str: 日志格式字符串
         :type format_str: str
-        :param mode: 文件打开模式 ('a' 追加 或 'w' 覆写)
+        :param mode: 文件打开模式 (''"'"'a''"'"' 追加 或 ''"'"'w''"'"' 覆盖)
         :type mode: str
+        :param level: 文件独立的日志等级，为 None 时继承 logger 全局级别
+        :type level: str | int, optional
         """
         self._sync_handlers()
-        # Remove existing file handler if path matches (simple check)
         key = f"file_{filename}"
         if key in self._handlers:
+            if level is not None:
+                self._handlers[key].setLevel(level)
             return
 
         handler = logging.FileHandler(filename, mode=mode, encoding="utf-8")
         handler.setFormatter(logging.Formatter(format_str, datefmt=DATE_FORMAT))
+        if level is not None:
+            handler.setLevel(level)
         self._logger.addHandler(handler)
         self._handlers[key] = handler
 
@@ -123,7 +148,11 @@ def set_log_level(level: Union[str, int]) -> None:
 
 
 def register_logger(
-    filename: Optional[str] = None, console: bool = True, level: str = "INFO"
+    filename: Optional[str] = None,
+    console: bool = True,
+    level: str = "INFO",
+    console_level: Optional[Union[str, int]] = None,
+    file_level: Optional[Union[str, int]] = None,
 ) -> None:
     r"""
     日志一体化配置.
@@ -134,16 +163,24 @@ def register_logger(
     :type console: bool
     :param level: 日志等级 ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
     :type level: str
+    :param console_level: 控制台独立日志等级，为 None 时使用 level
+    :type console_level: str | int, optional
+    :param file_level: 文件独立日志等级，为 None 时使用 level
+    :type file_level: str | int, optional
     """
     logger_manager = Logger._instance or Logger()
     Logger._instance = logger_manager
 
-    logger_manager.set_level(level.upper())
-
     if console:
-        logger_manager.enable_console()
+        logger_manager.enable_console(level=console_level)
     else:
         logger_manager.disable_console()
 
     if filename:
-        logger_manager.enable_file(filename)
+        logger_manager.enable_file(filename, level=file_level)
+
+    # Sync logger level to minimum of all explicitly-set handler levels.
+    # If no handler has an explicit level, use the global level parameter.
+    logger_manager._sync_logger_level()
+    if not any(h.level != logging.NOTSET for h in logger_manager._logger.handlers):
+        logger_manager.set_level(level.upper())

--- a/python/akquant/log.py
+++ b/python/akquant/log.py
@@ -54,7 +54,7 @@ class Logger:
             del self._handlers[key]
 
     def _sync_logger_level(self) -> None:
-        """Set logger level to the minimum of all handler levels with explicit settings."""
+        """Set logger level to the minimum of all explicitly-set handler levels."""
         explicit_levels = [
             h.level for h in self._logger.handlers if h.level != logging.NOTSET
         ]


### PR DESCRIPTION
原因：现在大家都是AI写代码，控制台只显示重要信息可以节省TOKEN，策略与实际思路不一致、信号未出现、拒绝订单过多等等情况下，才去文件看详细级别的日志查看问题。也可能反过来，控制台想显示详细信息，但希望文件记录重要信息防止磁盘爆炸。
做出的修改：日志级别配置，用户可以设置控制台看什么级别日志，文件记录什么级别日志。
代码和文档几乎是AI帮改，已通过测试。只修改了python端和文档