### PR TITLE
fix(engine): 修复同周期终端订单成交事件未触发回调的问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.34"
+version = "0.2.35"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.34"
+version = "0.2.35"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.34"
+version = "0.2.35"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -29,6 +29,9 @@ from .akquant import (
 from .indicator_recording import IndicatorRecorder
 from .sizer import FixedSize, Sizer
 from .strategy_events import (
+    flush_pending_order_events as _flush_pending_order_events_impl,
+)
+from .strategy_events import (
     on_bar_event as _on_bar_event_impl,
 )
 from .strategy_events import (
@@ -1461,6 +1464,9 @@ class Strategy:
 
     def _on_timer_event(self, payload: str, ctx: StrategyContext) -> None:
         _on_timer_event_impl(self, payload, ctx)
+
+    def _flush_pending_order_events(self, ctx: StrategyContext) -> None:
+        _flush_pending_order_events_impl(self, ctx)
 
     def on_bar(self, bar: Bar) -> None:
         """

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -205,3 +205,10 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
 
     call_user_callback(strategy, "on_timer", payload, payload=payload)
     _flush_indicator_snapshots(strategy)
+
+
+def flush_pending_order_events(strategy: Any, ctx: StrategyContext) -> None:
+    """Flush pending order/trade callbacks without invoking a user market callback."""
+    ensure_framework_state(strategy)
+    strategy.ctx = ctx
+    strategy._check_order_events()

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -1211,6 +1211,55 @@ impl Engine {
         }
     }
 
+    pub(crate) fn flush_terminal_pending_order_events(
+        &mut self,
+        py: Python<'_>,
+        strategy: &Bound<'_, PyAny>,
+    ) -> PyResult<()> {
+        if self.state.order_manager.current_step_trades.is_empty()
+            && self.state.order_manager.current_step_rejected_orders.is_empty()
+        {
+            return Ok(());
+        }
+
+        self.ensure_strategy_slot_exists();
+        self.ensure_strategy_context_capacity();
+        let slot_count = self.strategy_slots.len();
+        let active_orders = Arc::new(self.state.order_manager.active_orders.clone());
+        let step_trades = self.state.order_manager.current_step_trades.clone();
+        let step_rejected_orders = self.state.order_manager.current_step_rejected_orders.clone();
+        let previous_cash = self.state.portfolio.cash;
+        let previous_account_metrics = self.current_account_metrics();
+
+        for slot_index in 0..slot_count {
+            self.active_strategy_slot = slot_index;
+            let py_ctx = self.get_or_create_strategy_context(
+                slot_index,
+                active_orders.clone(),
+                step_trades.clone(),
+                step_rejected_orders.clone(),
+                previous_cash,
+                previous_account_metrics,
+            )?;
+            let slot_strategy = self
+                .strategy_slot_strategies
+                .get(slot_index)
+                .and_then(|slot| slot.as_ref())
+                .map(|slot| slot.clone_ref(py));
+            if let Some(ref slot_py) = slot_strategy {
+                slot_py
+                    .bind(py)
+                    .call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))?;
+            } else {
+                strategy.call_method1("_flush_pending_order_events", (py_ctx,))?;
+            }
+        }
+
+        self.state.order_manager.current_step_trades.clear();
+        self.state.order_manager.current_step_rejected_orders.clear();
+        Ok(())
+    }
+
     pub(crate) fn build_pipeline(&self) -> PipelineRunner {
         let mut pipeline = PipelineRunner::new();
         // 1. Process events from previous iteration (or init)

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -1134,6 +1134,8 @@ impl Engine {
             return Err(e);
         }
 
+        self.flush_terminal_pending_order_events(py, strategy)?;
+
         // Final cleanup
         self.state.order_manager.cleanup_finished_orders();
 

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -548,6 +548,46 @@ class SellThenBuySameCycleStrategy(Strategy):
         self.step += 1
 
 
+class DailyRebalanceSellThenBuySameCycleStrategy(Strategy):
+    """Validate day-rebalance callbacks also observe terminal same-cycle fills."""
+
+    def __init__(self) -> None:
+        """Initialize staged rebalance state and callback logs."""
+        super().__init__()
+        self.step = 0
+        self.order_events: list[tuple[str, str, str]] = []
+        self.trade_events: list[tuple[str, str]] = []
+
+    def on_daily_rebalance(self, trading_date: object, timestamp: int) -> None:
+        """Rotate from AAA to BBB during the framework rebalance hook."""
+        _ = (trading_date, timestamp)
+        if self.step == 1:
+            self.order_target_percent(symbol="AAA", target_percent=0.95)
+        elif self.step == 2:
+            self.order_target_percent(symbol="AAA", target_percent=0.0)
+            self.order_target_percent(symbol="BBB", target_percent=0.95)
+        self.step += 1
+
+    def on_order(self, order: Any) -> None:
+        """Record observable order callbacks."""
+        self.order_events.append(
+            (
+                str(order.symbol),
+                str(order.side).split(".")[-1].lower(),
+                str(order.status).split(".")[-1].lower(),
+            )
+        )
+
+    def on_trade(self, trade: Any) -> None:
+        """Record observable trade callbacks."""
+        self.trade_events.append(
+            (
+                str(trade.symbol),
+                str(trade.side).split(".")[-1].lower(),
+            )
+        )
+
+
 class TargetPositionsLongShortRotationStrategy(Strategy):
     """Exercise multi-symbol signed target positions through one advanced API call."""
 
@@ -615,3 +655,38 @@ def test_same_cycle_sell_then_buy_uses_post_sell_cash_for_sizing() -> None:
     final_positions = result.positions.iloc[-1]
     assert float(final_positions.get("AAA", 0.0)) == 0.0
     assert float(final_positions.get("BBB", 0.0)) >= 499.0
+
+
+def test_daily_rebalance_same_cycle_terminal_fill_emits_callbacks() -> None:
+    """Last-timestamp same-cycle fills should still reach order/trade callbacks."""
+    timestamps = [
+        pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai"),
+    ]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [10.0, 10.0, 10.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [10.0, 10.0, 10.0]),
+    }
+
+    strategy = DailyRebalanceSellThenBuySameCycleStrategy()
+    result = run_backtest(
+        data=data_map,
+        strategy=strategy,
+        symbols=["AAA", "BBB"],
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        show_progress=False,
+    )
+
+    orders_df = result.orders_df.sort_values("created_at").reset_index(drop=True)
+    bbb_buys = orders_df[(orders_df["symbol"] == "BBB") & (orders_df["side"] == "buy")]
+    assert not bbb_buys.empty
+    assert set(bbb_buys["status"].astype(str).str.lower()) == {"filled"}
+    assert ("BBB", "buy", "filled") in strategy.order_events
+    assert ("BBB", "buy") in strategy.trade_events


### PR DESCRIPTION
新增Rust与Python层的待处理订单事件刷新逻辑，在引擎收尾清理前调用该逻辑以确保同周期终端成交能触发对应回调。新增测试用例验证日调仓场景下的回调触发正确性，同步升级包版本至0.2.35。