### PR TITLE
feat: 发布v0.2.36，重构日志系统并新增DataFeed API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.35"
+version = "0.2.36"
 dependencies = [
  "anyhow",
  "chrono",
@@ -41,12 +41,14 @@ dependencies = [
  "numpy",
  "polars",
  "pyo3",
+ "pyo3-log",
  "pyo3-stub-gen",
  "rayon",
  "rmp-serde",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
+ "serde_json",
  "thiserror",
  "uuid",
 ]
@@ -94,6 +96,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2253,6 +2264,17 @@ checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
 dependencies = [
  "libc",
  "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-log"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.35"
+version = "0.2.36"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"
@@ -29,8 +29,10 @@ csv = "1.3"
 thiserror = "2.0.18"
 rust_decimal_macros = "1.40"
 log = "0.4"
+pyo3-log = "0.13.1"
 crossbeam-channel = "0.5"
 rmp-serde = "1.3.1"
+serde_json = "1.0"
 
 [features]
 default = []

--- a/docs/en/guide/data.md
+++ b/docs/en/guide/data.md
@@ -144,6 +144,38 @@ Parameter semantics:
 *   `align="day"`: Partition by day without `session_windows`; `day_mode` supports `trading/calendar`.
 *   `align="global"`: Aggregate on the full timeline without day partitioning.
 
+### 2.5 Using `DataFeed` Directly
+
+If you want explicit control over how data enters the engine, you can work with `DataFeed` directly instead of normalizing everything into a `DataFrame` first:
+
+```python
+import akquant as aq
+
+feed = aq.DataFeed.from_csv("/data/000001.csv", "000001.SZ")
+
+result = aq.run_backtest(
+    data=feed,
+    strategy=MyStrategy,
+    symbols="000001.SZ",
+    show_progress=False,
+)
+```
+
+For live scenarios, create a writable live feed:
+
+```python
+import akquant as aq
+
+feed = aq.DataFeed.create_live()
+feed.add_tick(aq.Tick(...))
+```
+
+Notes:
+
+*   `DataFeed.from_csv(...)` is a good fit when you want AKQuant to read a CSV-backed event stream directly.
+*   `add_bar(...)`, `add_bars(...)`, and `add_arrays(...)` fit cases where you already have normalized market objects or arrays on the Python side.
+*   If CSV or array inputs contain invalid floating-point values, Rust emits warnings that are forwarded into AKQuant's Python `logging` pipeline instead of failing silently.
+
 ---
 
 ## 3. Multi-Symbol Data

--- a/docs/en/guide/optimization.md
+++ b/docs/en/guide/optimization.md
@@ -201,6 +201,32 @@ When `max_workers > 1`, warning behavior is tied to `forward_worker_logs`:
 *   `forward_worker_logs=True` with active main-process logger handlers: log forwarding is enabled and visibility warning is suppressed.
 *   `forward_worker_logs=True` without active main-process handlers: warns that forwarding was requested but no handler is available.
 
+It is recommended to configure logging explicitly before launching optimization, especially when you want aggregated worker logs in the main process:
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="optimize",
+        level="INFO",
+        console=True,
+        filename="logs/optimize.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=50_000_000,
+        file_backup_count=3,
+    )
+)
+```
+
+Notes:
+
+*   `profile="optimize"` includes process identity in the default format, which helps distinguish worker output.
+*   `forward_worker_logs=True` only forwards worker logs back to the main process; it does not create handlers automatically.
+*   If you only want quick console logging, `akquant.register_logger(level="INFO")` remains valid.
+*   If you want file logs to be easier for external log pipelines to consume, enable `file_json=True`.
+
 ### Persistence & Resume
 
 For scenarios with extremely large parameter sets (e.g., > 10,000 combinations), running on a single machine might take days. AKQuant supports real-time result persistence to SQLite, enabling breakpoint resume.

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -212,6 +212,52 @@ def on_bar(self, bar):
     self.log("Insufficient funds", level=logging.WARNING)
 ```
 
+When log handlers are configured through `akquant.configure_logging(...)` or `akquant.register_logger(...)`, `self.log()` also carries structured context that is useful in `live` profile output and file logs:
+
+* `phase`: current stage such as `strategy`, `order`, or `trade`
+* `strategy_id` / `slot`: strategy identity in multi-strategy runs
+* `symbol`: current instrument
+* `event_time`: strategy event time
+* `order_id` / `client_order_id`: auto-filled inside `on_order` / `on_trade` / `on_reject`
+
+The simplest option remains the compatibility helper:
+
+```python
+import akquant
+
+akquant.register_logger(level="INFO")
+```
+
+For clearer research / optimize / live separation, prefer the structured config API:
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        level="INFO",
+        console=True,
+        filename="logs/strategy.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=10_000_000,
+        file_backup_count=5,
+    )
+)
+```
+
+If you want to ship logs into a log pipeline or collector, you can enable JSON output per handler:
+
+* `console_json=True`: console emits JSON lines
+* `file_json=True`: file emits JSON lines
+
+Practical guidance:
+
+* Use `self.log()` for human-readable strategy debugging
+* Use `run_backtest(..., on_event=...)` when you need a machine-consumable `order/trade/progress/risk` event stream
+* Inside `on_order`, `on_trade`, and `on_reject`, you usually do not need to manually concatenate order ids into the message
+
 ### 3.2 Data Access (Syntactic Sugar)
 
 The `Strategy` class provides properties for quick access to current Bar/Tick data:

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -639,6 +639,101 @@ result = run_backtest(
 *   **UI-Driven Parameter Input**: Declare `PARAM_MODEL` in strategy classes (`akquant.ParamModel`) and use `get_strategy_param_schema` / `validate_strategy_params` for frontend-backend parameter consistency.
 *   **Parameter Tuning**: When using `run_grid_search`, modify the Config object or pass override parameters as needed.
 
+### Logging API
+
+AKQuant stays quiet by default when imported as a library; until explicitly configured, the `akquant` root logger only carries a `NullHandler`.
+
+#### `akquant.LogConfig`
+
+Advanced logging config object used by `configure_logging(...)`.
+
+Core fields:
+
+*   `level`: global fallback level.
+*   `console`: whether to enable the console handler.
+*   `console_level` / `file_level`: per-handler level overrides.
+*   `console_format` / `file_format`: text formatter overrides.
+*   `console_show_context` / `file_show_context`: whether human-readable output should append structured context.
+*   `console_json` / `file_json`: whether the corresponding handler should emit JSON lines.
+*   `filename`: target log file path.
+*   `file_mode`: file open mode, default `a`.
+*   `file_max_bytes` / `file_backup_count`: size-based rotation threshold and retention count.
+*   `profile`: preset profile, one of `research`, `optimize`, or `live`.
+*   `reset_handlers`: whether to reset AKQuant-managed handlers.
+*   `propagate`: whether records should propagate to parent loggers.
+
+#### `akquant.configure_logging`
+
+```python
+def configure_logging(config: LogConfig) -> logging.Logger
+```
+
+Initializes or reconfigures the `akquant` logging system through a structured config.
+
+Recommended example:
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        level="INFO",
+        console=True,
+        console_json=False,
+        filename="logs/live.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=10_000_000,
+        file_backup_count=5,
+    )
+)
+```
+
+Behavior notes:
+
+*   `profile` only fills unspecified fields; explicit config values always win.
+*   `profile="optimize"` uses a process-aware default text format so worker output is easier to distinguish.
+*   `profile="live"` is the natural place to enable structured context and/or JSON output.
+
+#### `akquant.register_logger`
+
+```python
+def register_logger(
+    filename: Optional[str] = None,
+    console: bool = True,
+    level: str = "INFO",
+) -> None
+```
+
+Compatibility helper for quickly enabling logging without exposing advanced fields. Internally this maps to `configure_logging(LogConfig(...))`.
+
+#### `akquant.get_logger`
+
+```python
+def get_logger(name: Optional[str] = None) -> logging.Logger
+```
+
+Fetches a logger under the `akquant` namespace:
+
+*   `get_logger()` -> `akquant`
+*   `get_logger("strategy")` -> `akquant.strategy`
+*   `get_logger("gateway.live")` -> `akquant.gateway.live`
+
+#### `akquant.set_log_level`
+
+```python
+def set_log_level(level: Union[str, int]) -> None
+```
+
+Updates the current `akquant` root logger level.
+
+#### Boundary Guidance
+
+*   `self.log(...)` is the primary human-readable strategy logging path.
+*   `run_backtest(..., on_event=...)` is the machine-consumable event stream and is better suited for realtime UI, alerting, and audit sinks.
+*   Inside `on_order` / `on_trade` / `on_reject`, `self.log(...)` automatically carries structured fields such as `order_id` and `client_order_id`.
+
 ### `akquant.RiskConfig`
 
 Configuration for risk management.
@@ -834,6 +929,30 @@ The main entry point for the backtesting engine (usually used implicitly via `ru
 *   `use_simple_market()`: Enable simple market.
 *   `use_china_market()`: Enable China market.
 *   `set_stock_fee_rules(commission, stamp_tax, transfer_fee, min_commission)`: Set fee rules.
+
+### `akquant.DataFeed`
+
+`DataFeed` is the engine-facing event source abstraction. Use it when you want explicit control over how data enters the engine.
+
+**Constructors & factories:**
+
+*   `DataFeed()`: Create an empty historical feed.
+*   `DataFeed.from_csv(path, symbol)`: Create a feed directly from a CSV file; useful when you want Rust-side row iteration to drive the event stream.
+*   `DataFeed.create_live()`: Create a live feed suitable for gateway / market data push scenarios.
+
+**Input methods:**
+
+*   `add_bar(bar)`: Append one `Bar` to the feed.
+*   `add_bars(bars)`: Append a batch of `Bar` objects.
+*   `add_tick(tick)`: Append one `Tick` to a live feed.
+*   `add_arrays(timestamps, opens, highs, lows, closes, volumes, symbol)`: Build bars from arrays and inject them into the feed efficiently.
+*   `sort()`: Sort the current historical feed by event time.
+
+**When to use it:**
+
+*   For normal backtests, prefer `run_backtest(data=...)` with a `DataFrame`, `List[Bar]`, or `DataFeedAdapter`.
+*   Use `DataFeed` when you want to reuse the same feed object, switch explicitly between historical and live modes, or wire data into `Engine.add_data(feed)` yourself.
+*   If `from_csv(...)` or `add_arrays(...)` encounters invalid floating-point values, Rust emits warnings that flow into AKQuant's Python `logging` pipeline, such as `akquant.data.client` and `akquant.data.batch`.
 
 ### `akquant.gateway` Custom Broker Registry
 

--- a/docs/zh/guide/data.md
+++ b/docs/zh/guide/data.md
@@ -144,6 +144,38 @@ result = aq.run_backtest(
 *   `align="day"`：按日分区，不接收 `session_windows`；`day_mode` 支持 `trading/calendar`。
 *   `align="global"`：按全局时间轴聚合，不按交易日切段。
 
+### 2.5 直接使用 `DataFeed`
+
+如果你希望显式控制“数据如何进入引擎”，可以直接使用 `DataFeed`，而不必先转成 `DataFrame`：
+
+```python
+import akquant as aq
+
+feed = aq.DataFeed.from_csv("/data/000001.csv", "000001.SZ")
+
+result = aq.run_backtest(
+    data=feed,
+    strategy=MyStrategy,
+    symbols="000001.SZ",
+    show_progress=False,
+)
+```
+
+实时场景则可以创建可写入的 live feed：
+
+```python
+import akquant as aq
+
+feed = aq.DataFeed.create_live()
+feed.add_tick(aq.Tick(...))
+```
+
+补充说明：
+
+*   `DataFeed.from_csv(...)` 适合让 AKQuant 直接从 CSV 事件流读取数据。
+*   `add_bar(...)` / `add_bars(...)` / `add_arrays(...)` 适合你已经在 Python 侧拿到标准化行情对象或数组。
+*   如果 CSV 或数组里出现非法浮点值，Rust 侧会发出 warning，并通过 AKQuant 的 Python `logging` 输出，而不是静默吞掉。
+
 ---
 
 ## 3. 多标的数据 (Multi-Symbol Data)

--- a/docs/zh/guide/optimization.md
+++ b/docs/zh/guide/optimization.md
@@ -201,6 +201,32 @@ if __name__ == "__main__":
 *   `forward_worker_logs=True` 且主进程存在有效 logger handler：启用日志回传，不再显示“不可见”提示。
 *   `forward_worker_logs=True` 但主进程无有效 logger handler：会提示“请求了日志回传但主进程无可用 handler”。
 
+推荐在运行优化前显式配置一次日志，尤其是你希望查看主进程聚合后的 worker 日志时：
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="optimize",
+        level="INFO",
+        console=True,
+        filename="logs/optimize.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=50_000_000,
+        file_backup_count=3,
+    )
+)
+```
+
+说明：
+
+*   `profile="optimize"` 会在默认格式中带上进程名，便于区分不同 worker。
+*   `forward_worker_logs=True` 只负责“把子进程日志送回主进程”，不负责自动创建 handler。
+*   如果你只想快速打开控制台日志，也可以继续使用 `akquant.register_logger(level="INFO")`。
+*   如果你希望文件日志更方便被日志平台消费，可额外打开 `file_json=True`。
+
 ### 持久化与断点续传 (Persistence & Resume)
 
 对于参数组合极多（如 > 10,000 组）的场景，单机运行可能需要数小时甚至数天。如果中途断电或程序崩溃，重新运行将非常耗时。AKQuant 支持将优化结果实时写入 SQLite 数据库，并支持断点续传。

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -348,6 +348,52 @@ def on_bar(self, bar):
     self.log("资金不足", level=logging.WARNING)
 ```
 
+如果你已经通过 `akquant.configure_logging(...)` 或 `akquant.register_logger(...)` 配置了日志处理器，`self.log()` 还会自动附带结构化上下文，便于在 `live` profile 或文件日志中排障：
+
+* `phase`: 当前日志阶段，例如 `strategy`、`order`、`trade`
+* `strategy_id` / `slot`: 多策略场景下的策略身份
+* `symbol`: 当前标的
+* `event_time`: 策略事件时间
+* `order_id` / `client_order_id`: 在 `on_order` / `on_trade` / `on_reject` 内会自动补齐
+
+最简单的方式仍然是兼容接口：
+
+```python
+import akquant
+
+akquant.register_logger(level="INFO")
+```
+
+如果你想区分 research / optimize / live 场景，推荐使用结构化配置接口：
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        level="INFO",
+        console=True,
+        filename="logs/strategy.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=10_000_000,
+        file_backup_count=5,
+    )
+)
+```
+
+如果你要把日志送到日志平台或采集系统，也可以为控制台或文件单独开启 JSON 输出：
+
+* `console_json=True`: 控制台输出 JSON line
+* `file_json=True`: 文件输出 JSON line
+
+实践建议：
+
+* 人类阅读的调试信息优先用 `self.log()`
+* 需要统一消费 `order/trade/progress/risk` 事件流时，优先用 `run_backtest(..., on_event=...)`
+* 如果你在 `on_order`、`on_trade`、`on_reject` 里写 `self.log()`，通常不需要再手动拼接订单 id
+
 ### 3.2 便捷数据访问 (Data Access)
 
 为了减少代码冗余，`Strategy` 类提供了当前 Bar/Tick 数据的快捷访问属性：

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -694,6 +694,101 @@ result = run_backtest(
 *   **页面化参数输入**: 在策略类中声明 `PARAM_MODEL`（`akquant.ParamModel`），并使用 `get_strategy_param_schema` / `validate_strategy_params` 完成前后端参数联动与校验。
 *   **参数调优**: 使用 `run_grid_search` 时，通常通过修改 Config 对象或传入 override 参数来实现。
 
+### 日志配置 API (Logging)
+
+AKQuant 作为库使用时默认保持静默；未显式配置前，`akquant` 根 logger 仅挂载 `NullHandler`。
+
+#### `akquant.LogConfig`
+
+高级日志配置对象，供 `configure_logging(...)` 使用。
+
+核心字段：
+
+*   `level`: 全局回退等级。
+*   `console`: 是否启用控制台 handler。
+*   `console_level` / `file_level`: handler 级别覆盖。
+*   `console_format` / `file_format`: 文本 formatter 覆盖。
+*   `console_show_context` / `file_show_context`: 文本模式下是否附带结构化上下文。
+*   `console_json` / `file_json`: 是否对对应 handler 启用 JSON line 输出。
+*   `filename`: 文件日志路径。
+*   `file_mode`: 文件模式，默认 `a`。
+*   `file_max_bytes` / `file_backup_count`: 启用按大小轮转时的阈值与保留份数。
+*   `profile`: 预设 profile，支持 `research`、`optimize`、`live`。
+*   `reset_handlers`: 是否重置 AKQuant 自己管理的 handler。
+*   `propagate`: 是否向上游 logger 传播。
+
+#### `akquant.configure_logging`
+
+```python
+def configure_logging(config: LogConfig) -> logging.Logger
+```
+
+使用结构化配置初始化或重配 `akquant` 日志系统。
+
+推荐示例：
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        level="INFO",
+        console=True,
+        console_json=False,
+        filename="logs/live.log",
+        file_level="DEBUG",
+        file_json=True,
+        file_max_bytes=10_000_000,
+        file_backup_count=5,
+    )
+)
+```
+
+行为说明：
+
+*   `profile` 只填充未显式指定的字段，显式参数优先级更高。
+*   `profile="optimize"` 默认文本格式会带 `processName`，便于区分 worker。
+*   `profile="live"` 适合打开结构化上下文或 JSON 输出。
+
+#### `akquant.register_logger`
+
+```python
+def register_logger(
+    filename: Optional[str] = None,
+    console: bool = True,
+    level: str = "INFO",
+) -> None
+```
+
+兼容快捷接口，适合快速打开日志，不暴露高级字段。内部会转成 `configure_logging(LogConfig(...))`。
+
+#### `akquant.get_logger`
+
+```python
+def get_logger(name: Optional[str] = None) -> logging.Logger
+```
+
+获取 `akquant` 命名空间下的 logger：
+
+*   `get_logger()` -> `akquant`
+*   `get_logger("strategy")` -> `akquant.strategy`
+*   `get_logger("gateway.live")` -> `akquant.gateway.live`
+
+#### `akquant.set_log_level`
+
+```python
+def set_log_level(level: Union[str, int]) -> None
+```
+
+修改当前 `akquant` 根 logger 的 level。
+
+#### 使用边界
+
+*   `self.log(...)` 面向人类阅读的策略调试日志。
+*   `run_backtest(..., on_event=...)` 面向机器消费的统一事件流，更适合实时 UI、告警、审计落盘。
+*   在 `on_order` / `on_trade` / `on_reject` 中使用 `self.log(...)` 时，日志会自动携带 `order_id` / `client_order_id` 等结构化字段。
+
 ## 2. 策略开发 (Strategy)
 
 ### `akquant.Strategy`
@@ -889,6 +984,30 @@ runner = LiveRunner(
 
 *   期货费率接口统一使用复数命名 `set_futures_fee_rules*`。
 *   旧单数命名 `set_future_fee_rules*` 已移除，不再对外暴露。
+
+### `akquant.DataFeed`
+
+`DataFeed` 是引擎内部的事件数据源封装，适合在你希望显式控制“数据如何进入引擎”时直接使用。
+
+**构造与工厂方法:**
+
+*   `DataFeed()`: 创建一个空的历史数据源。
+*   `DataFeed.from_csv(path, symbol)`: 直接从 CSV 文件创建数据源；适合由 Rust 侧按行读取并驱动事件流。
+*   `DataFeed.create_live()`: 创建实时数据源，适合供 gateway / 行情推送场景写入事件。
+
+**写入方法:**
+
+*   `add_bar(bar)`: 向数据源追加单个 `Bar`。
+*   `add_bars(bars)`: 向数据源批量追加 `Bar` 列表。
+*   `add_tick(tick)`: 向实时数据源追加单个 `Tick`。
+*   `add_arrays(timestamps, opens, highs, lows, closes, volumes, symbol)`: 通过数组快速批量构建 `Bar` 并注入数据源。
+*   `sort()`: 对当前历史数据源按事件时间排序。
+
+**使用边界:**
+
+*   若你只是做普通回测，优先使用 `run_backtest(data=...)`，直接传 `DataFrame`、`List[Bar]` 或 `DataFeedAdapter` 即可。
+*   若你需要复用同一数据源对象、显式切换历史/实时模式，或直接接入 `Engine.add_data(feed)`，则使用 `DataFeed` 更合适。
+*   `from_csv(...)` / `add_arrays(...)` 中如果遇到非法浮点值，Rust 侧会记录 warning，并通过 AKQuant 的 Python `logging` 体系输出，例如 `akquant.data.client`、`akquant.data.batch`。
 
 ### `akquant.gateway` 自定义 Broker 注册
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.35"
+version = "0.2.36"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -11,6 +11,7 @@ except metadata.PackageNotFoundError:
 __engine_rule_version__ = "1.0.0"  # Increment on behavior-changing updates
 
 from . import akquant as _akquant
+from . import log as _log
 from . import talib
 from .akquant import *  # noqa: F403
 from .akquant import ATR, EMA, MACD, RSI, SMA, BollingerBands
@@ -56,7 +57,6 @@ from .indicator_stream import (
     to_indicator_message,
     to_indicator_messages,
 )
-from .log import get_logger, register_logger
 from .optimize import OptimizationResult, run_grid_search, run_walk_forward
 from .params import (
     BoolParam,
@@ -85,6 +85,19 @@ from .utils import (
     prepare_dataframe,
 )
 
+if typing.TYPE_CHECKING:
+    from .log import LogConfig as LogConfig  # type: ignore[assignment]
+    from .log import configure_logging as configure_logging  # type: ignore[assignment]
+    from .log import get_logger as get_logger
+    from .log import register_logger as register_logger
+    from .log import set_log_level as set_log_level
+else:
+    globals()["LogConfig"] = _log.LogConfig
+    globals()["configure_logging"] = _log.configure_logging
+    globals()["get_logger"] = _log.get_logger
+    globals()["register_logger"] = _log.register_logger
+    globals()["set_log_level"] = _log.set_log_level
+
 __doc__ = _akquant.__doc__
 if hasattr(_akquant, "__all__"):  # noqa: F405
     __all__ = [name for name in _akquant.__all__ if name != "ExecutionMode"] + [  # noqa: F405
@@ -108,8 +121,11 @@ if hasattr(_akquant, "__all__"):  # noqa: F405
         "ParquetFeedAdapter",
         "ResampledFeedAdapter",
         "ReplayFeedAdapter",
+        "LogConfig",
+        "configure_logging",
         "get_logger",
         "register_logger",
+        "set_log_level",
         "strategy_config",
         "ChinaFuturesConfig",
         "ChinaFuturesFeeConfig",
@@ -187,8 +203,11 @@ else:
         "ParquetFeedAdapter",
         "ResampledFeedAdapter",
         "ReplayFeedAdapter",
+        "LogConfig",
+        "configure_logging",
         "get_logger",
         "register_logger",
+        "set_log_level",
         "strategy_config",
         "ChinaOptionsConfig",
         "ChinaOptionsFeeConfig",

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -2,12 +2,61 @@
 # ruff: noqa: E501, F401
 
 import datetime
+import logging
 import typing
 
 import numpy
 import numpy.typing
 
 import akquant
+
+class LogConfig:
+    level: typing.Union[str, int]
+    console: bool
+    console_level: typing.Optional[typing.Union[str, int]]
+    console_format: typing.Optional[str]
+    console_show_context: typing.Optional[bool]
+    console_json: typing.Optional[bool]
+    filename: typing.Optional[str]
+    file_level: typing.Optional[typing.Union[str, int]]
+    file_format: typing.Optional[str]
+    file_show_context: typing.Optional[bool]
+    file_json: typing.Optional[bool]
+    file_mode: str
+    file_max_bytes: typing.Optional[int]
+    file_backup_count: int
+    profile: typing.Optional[str]
+    reset_handlers: bool
+    propagate: bool
+    def __init__(
+        self,
+        level: typing.Union[str, int] = ...,
+        console: bool = ...,
+        console_level: typing.Optional[typing.Union[str, int]] = ...,
+        console_format: typing.Optional[str] = ...,
+        console_show_context: typing.Optional[bool] = ...,
+        console_json: typing.Optional[bool] = ...,
+        filename: typing.Optional[str] = ...,
+        file_level: typing.Optional[typing.Union[str, int]] = ...,
+        file_format: typing.Optional[str] = ...,
+        file_show_context: typing.Optional[bool] = ...,
+        file_json: typing.Optional[bool] = ...,
+        file_mode: str = ...,
+        file_max_bytes: typing.Optional[int] = ...,
+        file_backup_count: int = ...,
+        profile: typing.Optional[str] = ...,
+        reset_handlers: bool = ...,
+        propagate: bool = ...,
+    ) -> None: ...
+
+def get_logger(name: typing.Optional[str] = ...) -> logging.Logger: ...
+def set_log_level(level: typing.Union[str, int]) -> None: ...
+def configure_logging(config: LogConfig) -> logging.Logger: ...
+def register_logger(
+    filename: typing.Optional[str] = ...,
+    console: bool = ...,
+    level: str = ...,
+) -> None: ...
 
 class AssetType:
     Stock: typing.ClassVar["AssetType"]
@@ -447,8 +496,14 @@ class DataFeed:
     支持 CSV 文件读取、数组批量加载和实时数据推送。
     """
 
+    @staticmethod
+    def from_csv(path: str, symbol: str) -> "DataFeed": ...
+    @staticmethod
+    def create_live() -> "DataFeed": ...
     def sort(self) -> None: ...
+    def add_bar(self, bar: Bar) -> None: ...
     def add_bars(self, bars: typing.Sequence[Bar]) -> None: ...
+    def add_tick(self, tick: Tick) -> None: ...
     def add_arrays(
         self,
         timestamps: numpy.ndarray,

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -45,7 +45,7 @@ from ..config import (
 from ..data import ParquetDataCatalog
 from ..feed_adapter import DataFeedAdapter, FeedSlice
 from ..indicator_recording import IndicatorRecorder
-from ..log import get_logger, register_logger
+from ..log import build_log_extra, get_logger, has_configured_handler, register_logger
 from ..risk import apply_risk_config
 from ..strategy import (
     InstrumentAssetTypeName,
@@ -130,6 +130,50 @@ def make_fill_policy(
     if bar_offset is not None:
         policy["bar_offset"] = bar_offset
     return policy
+
+
+def _extract_strategy_log_context(
+    strategy: Any,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Extract stable strategy identity fields for structured logs."""
+    strategy_id = str(getattr(strategy, "_owner_strategy_id", "") or "").strip() or None
+    symbol = None
+    current_bar = getattr(strategy, "current_bar", None)
+    current_tick = getattr(strategy, "current_tick", None)
+    if current_bar is not None:
+        symbol = str(getattr(current_bar, "symbol", "") or "").strip() or None
+    elif current_tick is not None:
+        symbol = str(getattr(current_tick, "symbol", "") or "").strip() or None
+    return strategy_id, strategy_id, symbol
+
+
+def _build_backtest_log_extra(
+    *,
+    phase: str,
+    strategy: Optional[Any] = None,
+    strategy_id: Optional[str] = None,
+    slot: Optional[str] = None,
+    symbol: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build structured logging context for backtest/runtime log records."""
+    if strategy is not None:
+        (
+            strategy_id_from_strategy,
+            slot_from_strategy,
+            symbol_from_strategy,
+        ) = _extract_strategy_log_context(strategy)
+        if strategy_id is None:
+            strategy_id = strategy_id_from_strategy
+        if slot is None:
+            slot = slot_from_strategy
+        if symbol is None:
+            symbol = symbol_from_strategy
+    return build_log_extra(
+        phase=phase,
+        strategy_id=strategy_id,
+        slot=slot,
+        symbol=symbol,
+    )
 
 
 def _prime_framework_pre_open_timers(
@@ -2356,13 +2400,10 @@ def run_backtest(
             history_depth = DEFAULT_HISTORY_DEPTH
 
     # 1. 确保日志已初始化
-    logger = get_logger()
-    has_effective_handler = any(
-        not isinstance(handler, logging.NullHandler) for handler in logger.handlers
-    )
-    if not has_effective_handler:
+    logger = get_logger("backtest")
+    if not has_configured_handler(logger.name):
         register_logger(console=True, level="INFO")
-        logger = get_logger()
+        logger = get_logger("backtest")
     normalized_analyzers = _coerce_analyzer_plugins(analyzer_plugins)
 
     # 1.2 检查 PyCharm 环境下的进度条可见性
@@ -3624,7 +3665,12 @@ def run_backtest(
                 else:
                     logger.warning(
                         "set_options_fee_rules_by_prefix is not available "
-                        "in current engine binary"
+                        "in current engine binary",
+                        extra=_build_backtest_log_extra(
+                            phase="risk",
+                            strategy_id=effective_strategy_id,
+                            slot=effective_strategy_id,
+                        ),
                     )
                     break
         if china_options_config.sessions:
@@ -3673,7 +3719,15 @@ def run_backtest(
                 if hasattr(current_risk_config, k):
                     setattr(current_risk_config, k, v)
                 else:
-                    logger.warning(f"Unknown risk config key: {k}")
+                    logger.warning(
+                        "Unknown risk config key: %s",
+                        k,
+                        extra=_build_backtest_log_extra(
+                            phase="risk",
+                            strategy_id=effective_strategy_id,
+                            slot=effective_strategy_id,
+                        ),
+                    )
 
     # 3. Apply if exists
     if current_risk_config:
@@ -4071,7 +4125,15 @@ def run_backtest(
     try:
         engine_summary = str(engine.run(strategy_instance, show_progress))
     except Exception as e:
-        logger.error(f"Backtest failed: {e}")
+        logger.error(
+            "Backtest failed: %s",
+            e,
+            extra=_build_backtest_log_extra(
+                phase="backtest",
+                strategy_id=effective_strategy_id,
+                slot=effective_strategy_id,
+            ),
+        )
         raise e
     finally:
         if stream_on_event is not None and hasattr(engine, "clear_stream_callback"):
@@ -4083,23 +4145,51 @@ def run_backtest(
             try:
                 strategy_instance._on_stop_internal()
             except Exception as e:
-                logger.error(f"Error in on_stop: {e}")
+                logger.error(
+                    "Error in on_stop: %s",
+                    e,
+                    extra=_build_backtest_log_extra(
+                        phase="strategy",
+                        strategy=strategy_instance,
+                    ),
+                )
         elif hasattr(strategy_instance, "on_stop"):
             try:
                 strategy_instance.on_stop()
             except Exception as e:
-                logger.error(f"Error in on_stop: {e}")
+                logger.error(
+                    "Error in on_stop: %s",
+                    e,
+                    extra=_build_backtest_log_extra(
+                        phase="strategy",
+                        strategy=strategy_instance,
+                    ),
+                )
         for slot_strategy in slot_strategy_instances.values():
             if hasattr(slot_strategy, "_on_stop_internal"):
                 try:
                     slot_strategy._on_stop_internal()
                 except Exception as e:
-                    logger.error(f"Error in slot on_stop: {e}")
+                    logger.error(
+                        "Error in slot on_stop: %s",
+                        e,
+                        extra=_build_backtest_log_extra(
+                            phase="strategy",
+                            strategy=slot_strategy,
+                        ),
+                    )
             elif hasattr(slot_strategy, "on_stop"):
                 try:
                     slot_strategy.on_stop()
                 except Exception as e:
-                    logger.error(f"Error in slot on_stop: {e}")
+                    logger.error(
+                        "Error in slot on_stop: %s",
+                        e,
+                        extra=_build_backtest_log_extra(
+                            phase="strategy",
+                            strategy=slot_strategy,
+                        ),
+                    )
 
     result = BacktestResult(
         engine.get_results(),
@@ -4186,13 +4276,10 @@ def run_warm_start(
 
     from ..checkpoint import warm_start
 
-    logger = get_logger()
-    has_effective_handler = any(
-        not isinstance(handler, logging.NullHandler) for handler in logger.handlers
-    )
-    if not has_effective_handler:
+    logger = get_logger("backtest")
+    if not has_configured_handler(logger.name):
         register_logger(console=True, level="INFO")
-        logger = get_logger()
+        logger = get_logger("backtest")
     strategy_config = config.strategy_config if config is not None else None
     (
         strategy_id,
@@ -5252,7 +5339,15 @@ def run_warm_start(
     try:
         engine_summary = str(engine.run(strategy_instance, show_progress))
     except Exception as e:
-        logger.error(f"Warm start backtest failed: {e}")
+        logger.error(
+            "Warm start backtest failed: %s",
+            e,
+            extra=_build_backtest_log_extra(
+                phase="backtest",
+                strategy_id=effective_strategy_id,
+                slot=effective_strategy_id,
+            ),
+        )
         raise e
     finally:
         if stream_on_event is not None and hasattr(engine, "clear_stream_callback"):
@@ -5264,23 +5359,51 @@ def run_warm_start(
             try:
                 strategy_instance._on_stop_internal()
             except Exception as e:
-                logger.error(f"Error in on_stop: {e}")
+                logger.error(
+                    "Error in on_stop: %s",
+                    e,
+                    extra=_build_backtest_log_extra(
+                        phase="strategy",
+                        strategy=strategy_instance,
+                    ),
+                )
         elif hasattr(strategy_instance, "on_stop"):
             try:
                 strategy_instance.on_stop()
             except Exception as e:
-                logger.error(f"Error in on_stop: {e}")
+                logger.error(
+                    "Error in on_stop: %s",
+                    e,
+                    extra=_build_backtest_log_extra(
+                        phase="strategy",
+                        strategy=strategy_instance,
+                    ),
+                )
         for slot_strategy in slot_strategy_instances.values():
             if hasattr(slot_strategy, "_on_stop_internal"):
                 try:
                     slot_strategy._on_stop_internal()
                 except Exception as e:
-                    logger.error(f"Error in slot on_stop: {e}")
+                    logger.error(
+                        "Error in slot on_stop: %s",
+                        e,
+                        extra=_build_backtest_log_extra(
+                            phase="strategy",
+                            strategy=slot_strategy,
+                        ),
+                    )
             elif hasattr(slot_strategy, "on_stop"):
                 try:
                     slot_strategy.on_stop()
                 except Exception as e:
-                    logger.error(f"Error in slot on_stop: {e}")
+                    logger.error(
+                        "Error in slot on_stop: %s",
+                        e,
+                        extra=_build_backtest_log_extra(
+                            phase="strategy",
+                            strategy=slot_strategy,
+                        ),
+                    )
 
     # 注意：这里的 initial_cash 可能不准确，因为它使用的是当前 cash
     # 但对于 BacktestResult 来说，重要的是 equity curve 的连续性

--- a/python/akquant/data.py
+++ b/python/akquant/data.py
@@ -8,7 +8,7 @@ import pandas as pd
 from .akquant import Bar
 from .utils import load_bar_from_df
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("akquant.data")
 
 
 class ParquetDataCatalog:

--- a/python/akquant/factor/engine.py
+++ b/python/akquant/factor/engine.py
@@ -6,7 +6,7 @@ import polars as pl
 from ..data import ParquetDataCatalog
 from .parser import ExpressionParser
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("akquant.factor")
 
 
 class FactorEngine:

--- a/python/akquant/live.py
+++ b/python/akquant/live.py
@@ -10,9 +10,12 @@ from .gateway.models import (
     UnifiedOrderRequest,
     validate_execution_semantics,
 )
+from .log import build_log_extra, get_logger
 from .strategy import Strategy
 from .strategy_loader import resolve_strategy_input
 from .utils import format_metric_value
+
+logger = get_logger("gateway.live")
 
 
 class _StrategyCallbackFanout:
@@ -862,6 +865,20 @@ class LiveRunner:
             if self.can_submit_client_order(client_order_id):
                 continue
             exc = RuntimeError(f"duplicate active client_order_id: {client_order_id}")
+            owner_strategy_id = (
+                str(getattr(strategy, "_owner_strategy_id", "_default")).strip()
+                or "_default"
+            )
+            logger.warning(
+                "Rejected live submit_order because client_order_id is already active",
+                extra=build_log_extra(
+                    phase="gateway",
+                    strategy_id=owner_strategy_id,
+                    slot=owner_strategy_id if owner_strategy_id != "_default" else None,
+                    symbol=symbol,
+                    client_order_id=client_order_id,
+                ),
+            )
             self._notify_strategy_error(
                 strategy,
                 exc,
@@ -940,18 +957,35 @@ class LiveRunner:
         for event_name, payload in events:
             self._update_broker_state(event_name, payload)
             if self.on_broker_event is not None:
+                owner_strategy_id = self._resolve_owner_strategy_id(payload)
+                payload_dict = self._payload_to_dict(payload)
                 try:
                     self.on_broker_event(
                         {
                             "event_type": event_name,
-                            "owner_strategy_id": self._resolve_owner_strategy_id(
-                                payload
-                            ),
-                            "payload": self._payload_to_dict(payload),
+                            "owner_strategy_id": owner_strategy_id,
+                            "payload": payload_dict,
                         }
                     )
-                except Exception:
-                    pass
+                except Exception as exc:
+                    logger.warning(
+                        "Broker event observer failed",
+                        exc_info=exc,
+                        extra=build_log_extra(
+                            phase="gateway",
+                            strategy_id=owner_strategy_id,
+                            slot=(
+                                owner_strategy_id
+                                if owner_strategy_id != "_default"
+                                else None
+                            ),
+                            symbol=str(payload_dict.get("symbol", "") or "").strip()
+                            or None,
+                            order_id=payload_dict.get("broker_order_id")
+                            or payload_dict.get("order_id"),
+                            client_order_id=payload_dict.get("client_order_id"),
+                        ),
+                    )
             if event_name == "order":
                 self._safe_strategy_callback(strategy, "on_order", payload)
             elif event_name == "trade":
@@ -1292,6 +1326,24 @@ class LiveRunner:
         try:
             callback(payload)
         except Exception as exc:
+            owner_strategy_id = (
+                str(getattr(strategy, "_owner_strategy_id", "_default")).strip()
+                or "_default"
+            )
+            payload_dict = self._payload_to_dict(payload)
+            logger.warning(
+                "Strategy broker callback failed",
+                exc_info=exc,
+                extra=build_log_extra(
+                    phase="gateway",
+                    strategy_id=owner_strategy_id,
+                    slot=owner_strategy_id if owner_strategy_id != "_default" else None,
+                    symbol=str(payload_dict.get("symbol", "") or "").strip() or None,
+                    order_id=payload_dict.get("broker_order_id")
+                    or payload_dict.get("order_id"),
+                    client_order_id=payload_dict.get("client_order_id"),
+                ),
+            )
             on_error = getattr(strategy, "on_error", None)
             if on_error is not None and callback_name != "on_error":
                 on_error(exc, callback_name, payload)

--- a/python/akquant/log.py
+++ b/python/akquant/log.py
@@ -1,10 +1,288 @@
+import json
 import logging
 import sys
-from typing import Optional, Union
+from dataclasses import dataclass
+from logging.handlers import RotatingFileHandler
+from typing import Any, Optional, Union
 
-# Default format: Time | Level | Message
-DEFAULT_FORMAT = "%(asctime)s | %(levelname)s | %(message)s"
+# Default format: Time | Level | Logger | Message
+DEFAULT_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+OPTIMIZE_FORMAT = (
+    "%(asctime)s | %(levelname)s | %(processName)s | %(name)s | %(message)s"
+)
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+ROOT_LOGGER_NAME = "akquant"
+RUST_CONTEXT_MARKER = " [akq_ctx="
+CONTEXT_FIELDS = (
+    "phase",
+    "event_time",
+    "event_time_str",
+    "strategy_id",
+    "slot",
+    "symbol",
+    "order_id",
+    "client_order_id",
+)
+
+
+def _normalize_context_value(value: Any) -> Optional[str]:
+    """Normalize structured logging context values to trimmed strings."""
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _parse_rust_context_message(message: str) -> tuple[str, dict[str, Any] | None]:
+    """Parse an AKQuant Rust log payload appended to the rendered message."""
+    marker_index = message.rfind(RUST_CONTEXT_MARKER)
+    if marker_index < 0 or not message.endswith("]"):
+        return message, None
+    payload_text = message[marker_index + len(RUST_CONTEXT_MARKER) : -1]
+    try:
+        payload = json.loads(payload_text)
+    except json.JSONDecodeError:
+        return message, None
+    if not isinstance(payload, dict):
+        return message, None
+    return message[:marker_index], payload
+
+
+def _extract_rust_context(record: logging.LogRecord) -> None:
+    """Lift AKQuant Rust log context payloads into structured LogRecord fields."""
+    if getattr(record, "_akquant_rust_context_parsed", False):
+        return
+    record._akquant_rust_context_parsed = True
+    if not str(getattr(record, "name", "") or "").startswith(ROOT_LOGGER_NAME):
+        return
+    rendered_message = record.getMessage()
+    stripped_message, payload = _parse_rust_context_message(rendered_message)
+    if payload is None:
+        return
+    record.msg = stripped_message
+    record.args = ()
+    for field_name in CONTEXT_FIELDS:
+        if field_name in payload:
+            value = payload[field_name]
+            if field_name == "event_time":
+                setattr(record, field_name, value)
+            else:
+                setattr(record, field_name, _normalize_context_value(value))
+        elif not hasattr(record, field_name):
+            setattr(record, field_name, None)
+
+
+def _install_log_record_factory() -> None:
+    """Install a LogRecord factory that restores Rust logging context early."""
+    current_factory = logging.getLogRecordFactory()
+    if getattr(current_factory, "_akquant_rust_context_factory", False):
+        return
+
+    def akquant_record_factory(*args: Any, **kwargs: Any) -> logging.LogRecord:
+        record = current_factory(*args, **kwargs)
+        _extract_rust_context(record)
+        return record
+
+    akquant_record_factory._akquant_rust_context_factory = True  # type: ignore[attr-defined]
+    logging.setLogRecordFactory(akquant_record_factory)
+
+
+class AKQuantFormatter(logging.Formatter):
+    """Formatter that can safely render AKQuant logging context."""
+
+    def __init__(
+        self,
+        fmt: str,
+        *,
+        datefmt: str = DATE_FORMAT,
+        include_context: bool = False,
+    ) -> None:
+        """Initialize a formatter with optional AKQuant context rendering."""
+        super().__init__(fmt, datefmt=datefmt)
+        self.include_context = include_context
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a log record and optionally append structured context text."""
+        for field_name in CONTEXT_FIELDS:
+            if not hasattr(record, field_name):
+                setattr(record, field_name, None)
+
+        rendered = super().format(record)
+        if not self.include_context:
+            return rendered
+
+        context_parts: list[str] = []
+        for field_name in (
+            "phase",
+            "strategy_id",
+            "slot",
+            "symbol",
+            "order_id",
+            "client_order_id",
+            "event_time_str",
+        ):
+            value = getattr(record, field_name, None)
+            if value is None or value == "":
+                continue
+            context_parts.append(f"{field_name}={value}")
+        if not context_parts:
+            return rendered
+        return f"{rendered} | {' '.join(context_parts)}"
+
+
+def _ensure_context_fields(record: logging.LogRecord) -> None:
+    """Populate missing AKQuant context fields on a log record."""
+    _extract_rust_context(record)
+    for field_name in CONTEXT_FIELDS:
+        if not hasattr(record, field_name):
+            setattr(record, field_name, None)
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert log values into JSON-safe payloads."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(key): _to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_to_jsonable(item) for item in value]
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        try:
+            return isoformat()
+        except Exception:
+            return str(value)
+    return str(value)
+
+
+class AKQuantJsonFormatter(logging.Formatter):
+    """Formatter that renders AKQuant log records as JSON lines."""
+
+    def __init__(self, *, datefmt: str = DATE_FORMAT) -> None:
+        """Initialize a JSON formatter with the configured timestamp format."""
+        super().__init__(datefmt=datefmt)
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format a log record as one JSON object per line."""
+        _ensure_context_fields(record)
+        payload: dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            "pid": record.process,
+            "process_name": record.processName,
+        }
+        for field_name in CONTEXT_FIELDS:
+            value = getattr(record, field_name, None)
+            if value is None or value == "":
+                continue
+            payload[field_name] = _to_jsonable(value)
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+PROFILE_DEFAULTS: dict[str, dict[str, Any]] = {
+    "research": {
+        "console_format": DEFAULT_FORMAT,
+        "file_format": DEFAULT_FORMAT,
+        "console_show_context": False,
+        "file_show_context": True,
+    },
+    "optimize": {
+        "console_format": OPTIMIZE_FORMAT,
+        "file_format": OPTIMIZE_FORMAT,
+        "console_show_context": False,
+        "file_show_context": True,
+    },
+    "live": {
+        "console_format": DEFAULT_FORMAT,
+        "file_format": DEFAULT_FORMAT,
+        "console_show_context": True,
+        "file_show_context": True,
+    },
+}
+
+
+def _normalize_level(level: Union[str, int]) -> int:
+    """Normalize a logging level into its integer form."""
+    if isinstance(level, int):
+        return level
+    normalized_name = level.strip().upper()
+    if normalized_name == "WARN":
+        normalized_name = "WARNING"
+    normalized = getattr(logging, normalized_name, None)
+    if isinstance(normalized, int):
+        return normalized
+    raise ValueError(f"Unknown log level: {level}")
+
+
+def build_log_extra(
+    *,
+    phase: Optional[str] = None,
+    event_time: Any = None,
+    event_time_str: Optional[str] = None,
+    strategy_id: Optional[str] = None,
+    slot: Optional[str] = None,
+    symbol: Optional[str] = None,
+    order_id: Optional[str] = None,
+    client_order_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Build a normalized AKQuant structured logging payload."""
+    return {
+        "phase": _normalize_context_value(phase),
+        "event_time": event_time,
+        "event_time_str": _normalize_context_value(event_time_str),
+        "strategy_id": _normalize_context_value(strategy_id),
+        "slot": _normalize_context_value(slot),
+        "symbol": _normalize_context_value(symbol),
+        "order_id": _normalize_context_value(order_id),
+        "client_order_id": _normalize_context_value(client_order_id),
+    }
+
+
+_install_log_record_factory()
+
+
+def has_configured_handler(name: Optional[str] = None) -> bool:
+    """Return True when the logger hierarchy has a visible handler configured."""
+    current: Optional[logging.Logger] = logging.getLogger(
+        ROOT_LOGGER_NAME if name is None else name
+    )
+    while current is not None:
+        if any(
+            not isinstance(handler, logging.NullHandler) for handler in current.handlers
+        ):
+            return True
+        if not current.propagate:
+            return False
+        parent = current.parent
+        current = parent if isinstance(parent, logging.Logger) else None
+    return False
+
+
+@dataclass
+class LogConfig:
+    """Advanced logging configuration for AKQuant."""
+
+    level: Union[str, int] = "INFO"
+    console: bool = True
+    console_level: Optional[Union[str, int]] = None
+    console_format: Optional[str] = None
+    console_show_context: Optional[bool] = None
+    console_json: Optional[bool] = None
+    filename: Optional[str] = None
+    file_level: Optional[Union[str, int]] = None
+    file_format: Optional[str] = None
+    file_show_context: Optional[bool] = None
+    file_json: Optional[bool] = None
+    file_mode: str = "a"
+    file_max_bytes: Optional[int] = None
+    file_backup_count: int = 3
+    profile: Optional[str] = None
+    reset_handlers: bool = True
+    propagate: bool = True
 
 
 class Logger:
@@ -18,13 +296,14 @@ class Logger:
 
     def __init__(self) -> None:
         """Initialize the Logger."""
-        self._logger = logging.getLogger("akquant")
+        self._logger = logging.getLogger(ROOT_LOGGER_NAME)
         self._logger.setLevel(logging.INFO)
+        self._logger.propagate = True
         self._handlers: dict[str, logging.Handler] = {}  # key -> handler
 
-        # Add default console handler if not present
+        self._sync_handlers()
         if not self._logger.handlers:
-            self.enable_console()
+            self._ensure_null_handler()
 
     @classmethod
     def get_logger(cls) -> logging.Logger:
@@ -53,31 +332,83 @@ class Logger:
         for key in stale_keys:
             del self._handlers[key]
 
-    def enable_console(self, format_str: str = DEFAULT_FORMAT) -> None:
+    def _ensure_null_handler(self) -> None:
+        """Attach a NullHandler when no other handler is configured."""
+        self._sync_handlers()
+        if self._logger.handlers:
+            return
+        handler = logging.NullHandler()
+        self._logger.addHandler(handler)
+        self._handlers["null"] = handler
+
+    def _remove_handler(self, key: str) -> None:
+        """Remove a managed handler by key if present."""
+        self._sync_handlers()
+        handler = self._handlers.pop(key, None)
+        if handler is None:
+            return
+        self._logger.removeHandler(handler)
+        handler.close()
+
+    def _remove_null_handler(self) -> None:
+        """Remove the fallback NullHandler before enabling visible handlers."""
+        self._remove_handler("null")
+
+    def reset_managed_handlers(self) -> None:
+        """Remove all AKQuant-managed handlers while preserving external ones."""
+        self._sync_handlers()
+        for key in list(self._handlers):
+            self._remove_handler(key)
+
+    def enable_console(
+        self,
+        format_str: str = DEFAULT_FORMAT,
+        level: Optional[Union[str, int]] = None,
+        show_context: bool = False,
+        json_output: bool = False,
+    ) -> None:
         r"""
         启用控制台日志.
 
         :param format_str: 日志格式字符串
         :type format_str: str
+        :param level: 控制台日志等级，为 None 时不修改
+        :type level: str | int, optional
         """
         self._sync_handlers()
-        if "console" in self._handlers:
-            return
-
-        handler = logging.StreamHandler(sys.stdout)
-        handler.setFormatter(logging.Formatter(format_str, datefmt=DATE_FORMAT))
-        self._logger.addHandler(handler)
-        self._handlers["console"] = handler
+        self._remove_null_handler()
+        handler = self._handlers.get("console")
+        if handler is None:
+            handler = logging.StreamHandler(sys.stdout)
+            self._logger.addHandler(handler)
+            self._handlers["console"] = handler
+        handler.setFormatter(
+            AKQuantJsonFormatter(datefmt=DATE_FORMAT)
+            if json_output
+            else AKQuantFormatter(
+                format_str,
+                datefmt=DATE_FORMAT,
+                include_context=show_context,
+            )
+        )
+        if level is not None:
+            handler.setLevel(_normalize_level(level))
 
     def disable_console(self) -> None:
         r"""禁用控制台日志."""
-        self._sync_handlers()
-        if "console" in self._handlers:
-            self._logger.removeHandler(self._handlers["console"])
-            del self._handlers["console"]
+        self._remove_handler("console")
+        self._ensure_null_handler()
 
     def enable_file(
-        self, filename: str, format_str: str = DEFAULT_FORMAT, mode: str = "a"
+        self,
+        filename: str,
+        format_str: str = DEFAULT_FORMAT,
+        mode: str = "a",
+        level: Optional[Union[str, int]] = None,
+        show_context: bool = False,
+        max_bytes: Optional[int] = None,
+        backup_count: int = 3,
+        json_output: bool = False,
     ) -> None:
         r"""
         启用文件日志.
@@ -88,28 +419,158 @@ class Logger:
         :type format_str: str
         :param mode: 文件打开模式 ('a' 追加 或 'w' 覆写)
         :type mode: str
+        :param level: 文件日志等级，为 None 时不修改
+        :type level: str | int, optional
         """
         self._sync_handlers()
-        # Remove existing file handler if path matches (simple check)
+        self._remove_null_handler()
         key = f"file_{filename}"
-        if key in self._handlers:
-            return
+        handler = self._handlers.get(key)
+        max_bytes_value = int(max_bytes) if max_bytes is not None else 0
+        rotation_enabled = max_bytes_value > 0
+        needs_rotating_handler = rotation_enabled
+        if handler is not None and needs_rotating_handler != isinstance(
+            handler, RotatingFileHandler
+        ):
+            self._remove_handler(key)
+            handler = None
+        if handler is None:
+            if rotation_enabled:
+                handler = RotatingFileHandler(
+                    filename=filename,
+                    mode=mode,
+                    maxBytes=max_bytes_value,
+                    backupCount=max(int(backup_count), 1),
+                    encoding="utf-8",
+                )
+            else:
+                handler = logging.FileHandler(filename, mode=mode, encoding="utf-8")
+            self._logger.addHandler(handler)
+            self._handlers[key] = handler
+        handler.setFormatter(
+            AKQuantJsonFormatter(datefmt=DATE_FORMAT)
+            if json_output
+            else AKQuantFormatter(
+                format_str,
+                datefmt=DATE_FORMAT,
+                include_context=show_context,
+            )
+        )
+        if level is not None:
+            handler.setLevel(_normalize_level(level))
 
-        handler = logging.FileHandler(filename, mode=mode, encoding="utf-8")
-        handler.setFormatter(logging.Formatter(format_str, datefmt=DATE_FORMAT))
-        self._logger.addHandler(handler)
-        self._handlers[key] = handler
+    def disable_file(self, filename: Optional[str] = None) -> None:
+        """禁用一个或全部文件日志."""
+        self._sync_handlers()
+        file_keys = [
+            key
+            for key in self._handlers
+            if key.startswith("file_")
+            and (filename is None or key == f"file_{filename}")
+        ]
+        for key in file_keys:
+            self._remove_handler(key)
+        self._ensure_null_handler()
+
+    def apply_config(self, config: LogConfig) -> logging.Logger:
+        """Apply a structured logging configuration to the root logger."""
+        if config.reset_handlers:
+            self.reset_managed_handlers()
+
+        self._logger.propagate = bool(config.propagate)
+        profile_defaults = PROFILE_DEFAULTS.get(str(config.profile or "").strip())
+        console_format = (
+            config.console_format
+            if config.console_format is not None
+            else profile_defaults.get("console_format", DEFAULT_FORMAT)
+            if profile_defaults
+            else DEFAULT_FORMAT
+        )
+        file_format = (
+            config.file_format
+            if config.file_format is not None
+            else profile_defaults.get("file_format", DEFAULT_FORMAT)
+            if profile_defaults
+            else DEFAULT_FORMAT
+        )
+        console_show_context = (
+            config.console_show_context
+            if config.console_show_context is not None
+            else profile_defaults.get("console_show_context", False)
+            if profile_defaults
+            else False
+        )
+        file_show_context = (
+            config.file_show_context
+            if config.file_show_context is not None
+            else profile_defaults.get("file_show_context", True)
+            if profile_defaults
+            else True
+        )
+        console_json = (
+            bool(config.console_json) if config.console_json is not None else False
+        )
+        file_json = bool(config.file_json) if config.file_json is not None else False
+
+        effective_levels: list[int] = []
+        if config.console:
+            console_level = config.console_level or config.level
+            self.enable_console(
+                format_str=console_format,
+                level=console_level,
+                show_context=console_show_context,
+                json_output=console_json,
+            )
+            effective_levels.append(_normalize_level(console_level))
+        else:
+            self.disable_console()
+
+        if config.filename:
+            file_level = config.file_level or config.level
+            self.disable_file()
+            self.enable_file(
+                filename=config.filename,
+                format_str=file_format,
+                mode=config.file_mode,
+                level=file_level,
+                show_context=file_show_context,
+                max_bytes=config.file_max_bytes,
+                backup_count=config.file_backup_count,
+                json_output=file_json,
+            )
+            effective_levels.append(_normalize_level(file_level))
+        else:
+            self.disable_file()
+
+        if effective_levels:
+            self._logger.setLevel(min(effective_levels))
+            self._remove_null_handler()
+        else:
+            self._logger.setLevel(_normalize_level(config.level))
+            self._ensure_null_handler()
+
+        return self._logger
 
 
 # Global helper functions
-def get_logger() -> logging.Logger:
+def get_logger(name: Optional[str] = None) -> logging.Logger:
     r"""
-    获取全局 logger 实例.
+    获取 AKQuant logger 实例.
 
+    :param name: 子 logger 名称；不传时返回根 logger
+    :type name: str, optional
     :return: 已初始化的 logger
     :rtype: logging.Logger
     """
-    return Logger.get_logger()
+    logger = Logger.get_logger()
+    if not name or name == ROOT_LOGGER_NAME:
+        return logger
+    full_name = (
+        name
+        if name.startswith(f"{ROOT_LOGGER_NAME}.")
+        else f"{ROOT_LOGGER_NAME}.{name}"
+    )
+    return logging.getLogger(full_name)
 
 
 def set_log_level(level: Union[str, int]) -> None:
@@ -120,6 +581,13 @@ def set_log_level(level: Union[str, int]) -> None:
     :type level: str | int
     """
     Logger.get_logger().setLevel(level)
+
+
+def configure_logging(config: LogConfig) -> logging.Logger:
+    """Configure the AKQuant root logger via a structured config."""
+    logger_manager = Logger._instance or Logger()
+    Logger._instance = logger_manager
+    return logger_manager.apply_config(config)
 
 
 def register_logger(
@@ -135,15 +603,12 @@ def register_logger(
     :param level: 日志等级 ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
     :type level: str
     """
-    logger_manager = Logger._instance or Logger()
-    Logger._instance = logger_manager
-
-    logger_manager.set_level(level.upper())
-
-    if console:
-        logger_manager.enable_console()
-    else:
-        logger_manager.disable_console()
-
-    if filename:
-        logger_manager.enable_file(filename)
+    configure_logging(
+        LogConfig(
+            level=level.upper(),
+            console=console,
+            filename=filename,
+            file_max_bytes=None,
+            reset_handlers=True,
+        )
+    )

--- a/python/akquant/optimize.py
+++ b/python/akquant/optimize.py
@@ -38,6 +38,7 @@ from .strategy import Strategy
 
 _WORKER_LOG_QUEUE: Any = None
 OptimizationData = Union[pd.DataFrame, Dict[str, pd.DataFrame]]
+logger = logging.getLogger("akquant.optimize")
 
 
 def _normalize_backtest_symbol_kwargs(kwargs: Dict[str, Any]) -> Dict[str, Any]:
@@ -512,7 +513,7 @@ def _save_result_to_db(
             )
             conn.commit()
     except Exception as e:
-        print(f"Failed to save result to DB: {e}")
+        logger.warning("Failed to save result to DB at %s: %s", db_path, e)
 
 
 def run_grid_search(
@@ -581,9 +582,11 @@ def run_grid_search(
         param_combinations = [p for p in param_combinations if constraint(p)]
         filtered_count = len(param_combinations)
         if original_count != filtered_count:
-            print(
-                f"Constraint filtered {original_count - filtered_count} combinations "
-                f"({original_count} -> {filtered_count})"
+            logger.info(
+                "Constraint filtered %s combinations (%s -> %s)",
+                original_count - filtered_count,
+                original_count,
+                filtered_count,
             )
 
     # 1.6 断点续传 (如果有 db_path)
@@ -642,9 +645,9 @@ def run_grid_search(
                         continue
 
                 if existing_results:
-                    print(
-                        f"Found {len(existing_results)} existing results in DB. "
-                        "Resuming..."
+                    logger.info(
+                        "Found %s existing results in DB. Resuming...",
+                        len(existing_results),
                     )
 
                     # 过滤已完成的任务
@@ -662,21 +665,23 @@ def run_grid_search(
                             new_combinations.append(p)
 
                     param_combinations = new_combinations
-                    print(
-                        f"Skipped {skipped_count} completed tasks. "
-                        f"Remaining: {len(param_combinations)}"
+                    logger.info(
+                        "Skipped %s completed tasks. Remaining: %s",
+                        skipped_count,
+                        len(param_combinations),
                     )
 
         except Exception as e:
-            print(f"Warning: Failed to access SQLite DB at {db_path}: {e}")
+            logger.warning("Failed to access SQLite DB at %s: %s", db_path, e)
 
     total_combinations = len(param_combinations)
 
     # 3. 并行执行 (如果有剩余任务)
     new_results = []
     if total_combinations > 0:
-        print(
-            f"Running optimization for {total_combinations} parameter combinations..."
+        logger.info(
+            "Running optimization for %s parameter combinations...",
+            total_combinations,
         )
 
         # 2. 准备任务
@@ -717,10 +722,10 @@ def run_grid_search(
             pool_init_args: tuple[Any, ...] = ()
             worker_log_forwarding_active = False
             if forward_worker_logs:
-                logger = get_logger()
+                root_logger = get_logger()
                 active_handlers = [
                     handler
-                    for handler in logger.handlers
+                    for handler in root_logger.handlers
                     if not isinstance(handler, logging.NullHandler)
                 ]
                 if active_handlers:
@@ -733,15 +738,14 @@ def run_grid_search(
                     pool_init_args = (log_queue,)
                     worker_log_forwarding_active = True
                 else:
-                    print(
-                        "Warning: forward_worker_logs=True but no active logger "
-                        "handler found in main process."
+                    logger.warning(
+                        "forward_worker_logs=True but no active logger handler "
+                        "found in main process."
                     )
             if not worker_log_forwarding_active and not forward_worker_logs:
-                print(
-                    "Warning: max_workers>1 uses subprocess workers. "
-                    "Strategy self.log() output may not be visible in the main "
-                    "process console."
+                logger.warning(
+                    "max_workers>1 uses subprocess workers. Strategy self.log() "
+                    "output may not be visible in the main process console."
                 )
             try:
                 with multiprocessing.Pool(
@@ -759,7 +763,10 @@ def run_grid_search(
                             if db_path:
                                 _save_result_to_db(db_path, strategy.__name__, result)
                     except Exception as e:
-                        print(f"Error during optimization (Worker Crash/OOM?): {e}")
+                        logger.error(
+                            "Error during optimization (Worker Crash/OOM?): %s",
+                            e,
+                        )
                         pass
             finally:
                 if listener is not None:
@@ -768,7 +775,7 @@ def run_grid_search(
                     log_queue.close()
                     log_queue.join_thread()
     else:
-        print("All tasks completed. Returning existing results.")
+        logger.info("All tasks completed. Returning existing results.")
 
     # 合并结果
     results = existing_results + new_results
@@ -779,9 +786,11 @@ def run_grid_search(
         results = [r for r in results if result_filter(r.metrics)]
         filtered_count = len(results)
         if original_count != filtered_count:
-            print(
-                f"Result filter removed {original_count - filtered_count} combinations "
-                f"({original_count} -> {filtered_count})"
+            logger.info(
+                "Result filter removed %s combinations (%s -> %s)",
+                original_count - filtered_count,
+                original_count,
+                filtered_count,
             )
 
     # 5. 排序结果
@@ -878,9 +887,11 @@ def run_walk_forward(
             f"train ({train_period}) + test ({test_period})."
         )
 
-    print(
-        f"Starting Walk-Forward Optimization: Train={train_period}, "
-        f"Test={test_period}, Total Bars={total_len}"
+    logger.info(
+        "Starting Walk-Forward Optimization: Train=%s, Test=%s, Total Bars=%s",
+        train_period,
+        test_period,
+        total_len,
     )
 
     oos_results = []
@@ -908,9 +919,11 @@ def run_walk_forward(
             train_end_exclusive,
         )
 
-        print(
-            f"\n=== Window {i // test_period + 1}: "
-            f"Train [{train_start_time} - {train_end_time}] ==="
+        logger.info(
+            "=== Window %s: Train [%s - %s] ===",
+            i // test_period + 1,
+            train_start_time,
+            train_end_time,
         )
 
         # 2. 样本内优化 (Optimization)
@@ -931,8 +944,8 @@ def run_walk_forward(
         )
 
         if isinstance(opt_results, list) or opt_results.empty:
-            print(
-                "Warning: Optimization failed or returned no results. Skipping window."
+            logger.warning(
+                "Optimization failed or returned no results. Skipping window."
             )
             continue
 
@@ -947,7 +960,7 @@ def run_walk_forward(
         else:
             metric_str = f"{metric}={best_row.get(metric, 0):.4f}"
 
-        print(f"  Best Params: {best_params} ({metric_str})")
+        logger.info("Best Params: %s (%s)", best_params, metric_str)
 
         # 计算实际需要的预热期
         current_warmup = warmup_period
@@ -973,7 +986,12 @@ def run_walk_forward(
         backtest_kwargs["initial_cash"] = initial_cash
         backtest_kwargs["warmup_period"] = current_warmup
 
-        print(f"  Test [{oos_start_time} - {oos_end_time}] (Warmup: {current_warmup})")
+        logger.info(
+            "Test [%s - %s] (Warmup: %s)",
+            oos_start_time,
+            oos_end_time,
+            current_warmup,
+        )
 
         bt_result = run_backtest(
             strategy=strategy, data=test_data_with_warmup, **backtest_kwargs
@@ -983,7 +1001,7 @@ def run_walk_forward(
         equity_curve = bt_result.equity_curve
 
         if equity_curve.empty:
-            print("  Warning: Empty equity curve in OOS.")
+            logger.warning("Empty equity curve in OOS.")
             continue
 
         # 处理时区不匹配问题
@@ -1014,7 +1032,7 @@ def run_walk_forward(
         # 过滤时间段
         valid_equity = equity_curve[equity_curve.index >= oos_start_time]
         if valid_equity.empty:
-            print("  Warning: No equity data in valid OOS period.")
+            logger.warning("No equity data in valid OOS period.")
             continue
 
         # 拼接逻辑
@@ -1062,7 +1080,7 @@ def run_walk_forward(
         oos_results.append(segment_df)
 
     if not oos_results:
-        print("Walk-Forward Optimization produced no results.")
+        logger.warning("Walk-Forward Optimization produced no results.")
         return pd.DataFrame()
 
     # 6. 合并所有片段

--- a/python/akquant/risk.py
+++ b/python/akquant/risk.py
@@ -1,12 +1,18 @@
+import logging
 from typing import TYPE_CHECKING, Optional
 
 from .config import RiskConfig as PyRiskConfig
-from .log import get_logger
+from .log import build_log_extra
 
 if TYPE_CHECKING:
     from .akquant import Engine
 
-logger = get_logger()
+logger = logging.getLogger("akquant.risk")
+
+
+def _build_risk_log_extra() -> dict[str, Optional[str]]:
+    """Build structured context for risk configuration logs."""
+    return build_log_extra(phase="risk")
 
 
 def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
@@ -94,7 +100,8 @@ def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
             rm.add_max_position_percent_rule(config.max_position_pct)
         else:
             logger.warning(
-                "RiskManager does not support add_max_position_percent_rule."
+                "RiskManager does not support add_max_position_percent_rule.",
+                extra=_build_risk_log_extra(),
             )
 
     if config.sector_concentration is not None:
@@ -109,30 +116,41 @@ def apply_risk_config(engine: "Engine", config: Optional[PyRiskConfig]) -> None:
             else:
                 logger.warning(
                     "sector_concentration must be a tuple (limit, sector_map). "
-                    "Rule ignored."
+                    "Rule ignored.",
+                    extra=_build_risk_log_extra(),
                 )
         else:
             logger.warning(
-                "RiskManager does not support add_sector_concentration_rule."
+                "RiskManager does not support add_sector_concentration_rule.",
+                extra=_build_risk_log_extra(),
             )
 
     if config.max_account_drawdown is not None:
         if hasattr(rm, "add_max_drawdown_rule"):
             rm.add_max_drawdown_rule(config.max_account_drawdown)
         else:
-            logger.warning("RiskManager does not support add_max_drawdown_rule.")
+            logger.warning(
+                "RiskManager does not support add_max_drawdown_rule.",
+                extra=_build_risk_log_extra(),
+            )
 
     if config.max_daily_loss is not None:
         if hasattr(rm, "add_max_daily_loss_rule"):
             rm.add_max_daily_loss_rule(config.max_daily_loss)
         else:
-            logger.warning("RiskManager does not support add_max_daily_loss_rule.")
+            logger.warning(
+                "RiskManager does not support add_max_daily_loss_rule.",
+                extra=_build_risk_log_extra(),
+            )
 
     if config.stop_loss_threshold is not None:
         if hasattr(rm, "add_stop_loss_rule"):
             rm.add_stop_loss_rule(config.stop_loss_threshold)
         else:
-            logger.warning("RiskManager does not support add_stop_loss_rule.")
+            logger.warning(
+                "RiskManager does not support add_stop_loss_rule.",
+                extra=_build_risk_log_extra(),
+            )
 
     # Update the engine's risk manager with the new rules
     # This is critical if engine.risk_manager returns a copy/clone

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -347,6 +347,9 @@ class Strategy:
     _framework_use_previous_account_snapshot: bool
     _framework_previous_account_details: Optional[Dict[str, float]]
     _framework_emit_previous_portfolio_snapshot: bool
+    _framework_current_callback: Optional[str]
+    _framework_current_order: Optional[Any]
+    _framework_current_trade: Optional[Any]
     _trading_day_bounds: Dict[str, Tuple[int, int]]
     _oco_groups: Dict[str, set[str]]
     _oco_order_to_group: Dict[str, str]
@@ -465,6 +468,7 @@ class Strategy:
         # lot_size 可以是 int (全局统一) 或 Dict[str, int] (按标的设置)
         # 默认 1，这是最通用的设置（适用于美股、加密货币等）。A股回测请务必设置为 100。
         instance.lot_size = 1
+        instance._owner_strategy_id = None
         instance._framework_last_session = None
         instance._framework_last_local_date = None
         instance._framework_before_trading_done_date = None
@@ -483,6 +487,9 @@ class Strategy:
         instance._framework_use_previous_account_snapshot = False
         instance._framework_previous_account_details = None
         instance._framework_emit_previous_portfolio_snapshot = False
+        instance._framework_current_callback = None
+        instance._framework_current_order = None
+        instance._framework_current_trade = None
         instance._trading_day_bounds = {}
         instance._oco_groups = {}
         instance._oco_order_to_group = {}
@@ -501,7 +508,7 @@ class Strategy:
 
     def __init__(self) -> None:
         """初始化."""
-        pass
+        self._owner_strategy_id: Optional[str] = None
 
     def __getstate__(self) -> Dict[str, Any]:
         """
@@ -534,6 +541,12 @@ class Strategy:
             del state["_framework_stop_flushed"]
         if "_framework_boundary_timers_registered" in state:
             del state["_framework_boundary_timers_registered"]
+        if "_framework_current_callback" in state:
+            del state["_framework_current_callback"]
+        if "_framework_current_order" in state:
+            del state["_framework_current_order"]
+        if "_framework_current_trade" in state:
+            del state["_framework_current_trade"]
         if "_indicator_recorder" in state:
             del state["_indicator_recorder"]
         incremental_indicators = state.get("_incremental_indicators")
@@ -572,6 +585,9 @@ class Strategy:
         self.ctx = None
         self.current_bar = None
         self.current_tick = None
+        self._framework_current_callback = None
+        self._framework_current_order = None
+        self._framework_current_trade = None
         self._is_restored = True  # 标记为已恢复状态
         self._start_initialized = False
         if not hasattr(self, "_seen_trade_keys"):

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -234,6 +234,14 @@ def call_user_callback(
 ) -> Any:
     """调用用户回调，并在异常时转发到 on_error."""
     callback = getattr(strategy, callback_name)
+    previous_callback = getattr(strategy, "_framework_current_callback", None)
+    previous_order = getattr(strategy, "_framework_current_order", None)
+    previous_trade = getattr(strategy, "_framework_current_trade", None)
+    strategy._framework_current_callback = callback_name
+    strategy._framework_current_order = (
+        payload if callback_name in {"on_order", "on_reject"} else None
+    )
+    strategy._framework_current_trade = payload if callback_name == "on_trade" else None
     try:
         return callback(*args)
     except Exception as exc:
@@ -248,6 +256,10 @@ def call_user_callback(
             if not _should_reraise_on_error(strategy):
                 return None
         raise
+    finally:
+        strategy._framework_current_callback = previous_callback
+        strategy._framework_current_order = previous_order
+        strategy._framework_current_trade = previous_trade
 
 
 def dispatch_time_hooks(strategy: Any) -> None:

--- a/python/akquant/strategy_logging.py
+++ b/python/akquant/strategy_logging.py
@@ -1,8 +1,77 @@
 import logging
 from typing import Any
 
-from .log import get_logger
+from .log import build_log_extra, get_logger
 from .strategy_time import now as _now
+
+logger = get_logger("strategy")
+
+
+def _extract_order_log_fields(strategy: Any) -> tuple[str, Any, Any]:
+    """Extract current callback phase plus order/trade payloads."""
+    current_callback = str(
+        getattr(strategy, "_framework_current_callback", "") or ""
+    ).strip()
+    phase = "strategy"
+    if current_callback in {"on_order", "on_reject"}:
+        phase = "order"
+    elif current_callback == "on_trade":
+        phase = "trade"
+    return (
+        phase,
+        getattr(strategy, "_framework_current_order", None),
+        getattr(strategy, "_framework_current_trade", None),
+    )
+
+
+def _extract_symbol(strategy: Any, order_payload: Any, trade_payload: Any) -> Any:
+    """Resolve the most relevant symbol for the current log call."""
+    current_bar = getattr(strategy, "current_bar", None)
+    current_tick = getattr(strategy, "current_tick", None)
+    if current_bar is not None:
+        return str(getattr(current_bar, "symbol", "") or "") or None
+    if current_tick is not None:
+        return str(getattr(current_tick, "symbol", "") or "") or None
+    for payload in (order_payload, trade_payload):
+        symbol = str(getattr(payload, "symbol", "") or "").strip()
+        if symbol:
+            return symbol
+    return None
+
+
+def _build_log_extra(
+    strategy: Any, timestamp_str: str, event_time: Any
+) -> dict[str, Any]:
+    """Build structured logging metadata for strategy-side logs."""
+    strategy_id_raw = getattr(strategy, "_owner_strategy_id", None)
+    strategy_id = (
+        str(strategy_id_raw).strip() if strategy_id_raw is not None else "_default"
+    ) or "_default"
+    phase, order_payload, trade_payload = _extract_order_log_fields(strategy)
+    symbol = _extract_symbol(strategy, order_payload, trade_payload)
+    slot = strategy_id if strategy_id != "_default" else None
+    order_id = None
+    client_order_id = None
+    if order_payload is not None:
+        order_id = getattr(order_payload, "id", None) or getattr(
+            order_payload, "order_id", None
+        )
+        client_order_id = getattr(order_payload, "client_order_id", None)
+    elif trade_payload is not None:
+        order_id = getattr(trade_payload, "order_id", None) or getattr(
+            trade_payload, "id", None
+        )
+        client_order_id = getattr(trade_payload, "client_order_id", None)
+    return build_log_extra(
+        phase=phase,
+        event_time=event_time,
+        event_time_str=timestamp_str or None,
+        strategy_id=strategy_id,
+        slot=slot,
+        symbol=symbol,
+        order_id=order_id,
+        client_order_id=client_order_id,
+    )
 
 
 def log(strategy: Any, msg: str, level: int = logging.INFO) -> None:
@@ -17,4 +86,4 @@ def log(strategy: Any, msg: str, level: int = logging.INFO) -> None:
     else:
         final_msg = msg
 
-    get_logger().log(level, final_msg)
+    logger.log(level, final_msg, extra=_build_log_extra(strategy, timestamp_str, ts))

--- a/python/akquant/strategy_time.py
+++ b/python/akquant/strategy_time.py
@@ -1,3 +1,4 @@
+from numbers import Integral
 from typing import Any, Optional, cast
 
 import pandas as pd
@@ -19,9 +20,13 @@ def now(strategy: Any) -> Optional[pd.Timestamp]:
     ts = None
     ctx = getattr(strategy, "ctx", None)
     if ctx is not None:
-        current_time = int(getattr(ctx, "current_time", 0))
-        if current_time > 0:
-            ts = current_time
+        current_time_raw = getattr(ctx, "current_time", None)
+        if isinstance(current_time_raw, Integral) and not isinstance(
+            current_time_raw, bool
+        ):
+            current_time = int(current_time_raw)
+            if current_time > 0:
+                ts = current_time
 
     if ts is None and strategy.current_bar:
         ts = strategy.current_bar.timestamp

--- a/src/data/batch.rs
+++ b/src/data/batch.rs
@@ -1,3 +1,4 @@
+use crate::log_context::{AkqLogContext, format_event_time_nanos, render_log_message};
 use crate::model::Bar;
 use numpy::PyReadonlyArray1;
 use pyo3::exceptions::PyValueError;
@@ -32,6 +33,19 @@ pub fn from_arrays(
     extra: Option<HashMap<String, Py<PyAny>>>,
     py: Python<'_>,
 ) -> PyResult<Vec<Bar>> {
+    fn warn_invalid_numeric(field_name: &str, value: f64, symbol: &str, timestamp_ns: i64) {
+        log::warn!(
+            "{}",
+            render_log_message(
+                format!("Invalid {field_name} {value}, defaulting to 0.0"),
+                AkqLogContext::new()
+                    .phase("data")
+                    .symbol(symbol)
+                    .event_time_str(format_event_time_nanos(timestamp_ns)),
+            )
+        );
+    }
+
     let timestamps: PyReadonlyArray1<i64> = timestamps.extract()?;
     let opens: PyReadonlyArray1<f64> = opens.extract()?;
     let highs: PyReadonlyArray1<f64> = highs.extract()?;
@@ -120,23 +134,23 @@ pub fn from_arrays(
         bars.push(Bar {
             timestamp: normalized_ts,
             open: Decimal::from_f64(opens[i]).unwrap_or_else(|| {
-                log::warn!("Invalid open price {}, defaulting to 0.0", opens[i]);
+                warn_invalid_numeric("open price", opens[i], sym.as_str(), normalized_ts);
                 Decimal::ZERO
             }),
             high: Decimal::from_f64(highs[i]).unwrap_or_else(|| {
-                log::warn!("Invalid high price {}, defaulting to 0.0", highs[i]);
+                warn_invalid_numeric("high price", highs[i], sym.as_str(), normalized_ts);
                 Decimal::ZERO
             }),
             low: Decimal::from_f64(lows[i]).unwrap_or_else(|| {
-                log::warn!("Invalid low price {}, defaulting to 0.0", lows[i]);
+                warn_invalid_numeric("low price", lows[i], sym.as_str(), normalized_ts);
                 Decimal::ZERO
             }),
             close: Decimal::from_f64(closes[i]).unwrap_or_else(|| {
-                log::warn!("Invalid close price {}, defaulting to 0.0", closes[i]);
+                warn_invalid_numeric("close price", closes[i], sym.as_str(), normalized_ts);
                 Decimal::ZERO
             }),
             volume: Decimal::from_f64(volumes[i]).unwrap_or_else(|| {
-                log::warn!("Invalid volume {}, defaulting to 0.0", volumes[i]);
+                warn_invalid_numeric("volume", volumes[i], sym.as_str(), normalized_ts);
                 Decimal::ZERO
             }),
             symbol: sym,

--- a/src/data/client.rs
+++ b/src/data/client.rs
@@ -1,5 +1,6 @@
 use crate::error::AkQuantError;
 use crate::event::Event;
+use crate::log_context::{AkqLogContext, format_event_time_nanos, render_log_message};
 use crate::model::Bar;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -133,6 +134,19 @@ impl CsvDataClient {
     }
 
     fn read_next(&mut self) -> Option<Event> {
+        fn warn_invalid_numeric(field_name: &str, value: f64, symbol: &str, timestamp_ns: i64) {
+            log::warn!(
+                "{}",
+                render_log_message(
+                    format!("Invalid {field_name} {value}, defaulting to 0.0"),
+                    AkqLogContext::new()
+                        .phase("data")
+                        .symbol(symbol)
+                        .event_time_str(format_event_time_nanos(timestamp_ns)),
+                )
+            );
+        }
+
         // Assume CSV columns: timestamp, open, high, low, close, volume
         // Or using serde with a struct.
         // Let's use string records and parse manually for flexibility or define a struct.
@@ -154,26 +168,52 @@ impl CsvDataClient {
             // Deserialize
             let row: CsvRow = record.deserialize(self.reader.headers().ok()).ok()?;
 
+            let normalized_timestamp = normalize_timestamp(row.timestamp);
             let bar = Bar {
-                timestamp: normalize_timestamp(row.timestamp),
+                timestamp: normalized_timestamp,
                 open: Decimal::from_f64(row.open).unwrap_or_else(|| {
-                    log::warn!("Invalid open price {}, defaulting to 0.0", row.open);
+                    warn_invalid_numeric(
+                        "open price",
+                        row.open,
+                        self.symbol.as_str(),
+                        normalized_timestamp,
+                    );
                     Decimal::ZERO
                 }),
                 high: Decimal::from_f64(row.high).unwrap_or_else(|| {
-                    log::warn!("Invalid high price {}, defaulting to 0.0", row.high);
+                    warn_invalid_numeric(
+                        "high price",
+                        row.high,
+                        self.symbol.as_str(),
+                        normalized_timestamp,
+                    );
                     Decimal::ZERO
                 }),
                 low: Decimal::from_f64(row.low).unwrap_or_else(|| {
-                    log::warn!("Invalid low price {}, defaulting to 0.0", row.low);
+                    warn_invalid_numeric(
+                        "low price",
+                        row.low,
+                        self.symbol.as_str(),
+                        normalized_timestamp,
+                    );
                     Decimal::ZERO
                 }),
                 close: Decimal::from_f64(row.close).unwrap_or_else(|| {
-                    log::warn!("Invalid close price {}, defaulting to 0.0", row.close);
+                    warn_invalid_numeric(
+                        "close price",
+                        row.close,
+                        self.symbol.as_str(),
+                        normalized_timestamp,
+                    );
                     Decimal::ZERO
                 }),
                 volume: Decimal::from_f64(row.volume).unwrap_or_else(|| {
-                    log::warn!("Invalid volume {}, defaulting to 0.0", row.volume);
+                    warn_invalid_numeric(
+                        "volume",
+                        row.volume,
+                        self.symbol.as_str(),
+                        normalized_timestamp,
+                    );
                     Decimal::ZERO
                 }),
                 symbol: self.symbol.clone(),

--- a/src/data/feed.rs
+++ b/src/data/feed.rs
@@ -1,4 +1,5 @@
 use crate::event::Event;
+use crate::log_context::{AkqLogContext, format_event_time_nanos, render_log_message};
 use crate::model::{Bar, Tick};
 use chrono::Utc;
 use pyo3::exceptions::PyValueError;
@@ -12,6 +13,24 @@ use super::batch::from_arrays;
 use super::client::{
     CsvDataClient, DataClient, FeedAction, RealtimeDataClient, SimulatedDataClient,
 };
+
+fn clock_fallback_context(next_timer_ts: Option<i64>) -> AkqLogContext {
+    let mut context = AkqLogContext::new().phase("data");
+    if let Some(timer_ts) = next_timer_ts {
+        context = context.event_time_str(format_event_time_nanos(timer_ts));
+    }
+    context
+}
+
+fn warn_clock_fallback(next_timer_ts: Option<i64>) {
+    log::warn!(
+        "{}",
+        render_log_message(
+            "Failed to get current timestamp, defaulting to 0",
+            clock_fallback_context(next_timer_ts),
+        )
+    );
+}
 
 /// 数据源管理器.
 ///
@@ -206,7 +225,7 @@ impl DataFeed {
         // Calculate timeout
         let timeout = if let Some(timer_ts) = next_timer_timestamp {
             let now = Utc::now().timestamp_nanos_opt().unwrap_or_else(|| {
-                log::warn!("Failed to get current timestamp, defaulting to 0");
+                warn_clock_fallback(next_timer_timestamp);
                 0
             });
             if timer_ts > now {
@@ -254,7 +273,7 @@ impl DataFeed {
             // Live logic
             // Calculate timeout
             let now = Utc::now().timestamp_nanos_opt().unwrap_or_else(|| {
-                log::warn!("Failed to get current timestamp, defaulting to 0");
+                warn_clock_fallback(next_timer_ts);
                 0
             });
             let timeout = if let Some(tt) = next_timer_ts {
@@ -308,5 +327,29 @@ impl DataFeed {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clock_fallback_context_uses_next_timer_timestamp_as_event_time() {
+        let rendered = render_log_message(
+            "clock-fallback",
+            clock_fallback_context(Some(1_000_000_000)),
+        );
+
+        assert!(rendered.contains("\"phase\":\"data\""));
+        assert!(rendered.contains("\"event_time_str\":\"1970-01-01 00:00:01\""));
+    }
+
+    #[test]
+    fn clock_fallback_context_omits_event_time_without_timer() {
+        let rendered = render_log_message("clock-fallback", clock_fallback_context(None));
+
+        assert!(rendered.contains("\"phase\":\"data\""));
+        assert!(!rendered.contains("event_time_str"));
     }
 }

--- a/src/execution/simulated.rs
+++ b/src/execution/simulated.rs
@@ -6,6 +6,7 @@ use crate::event::Event;
 use crate::execution::matcher::{ExecutionMatcher, MatchContext};
 use crate::execution::slippage::{SlippageModel, ZeroSlippage};
 use crate::execution::{ExecutionClient, crypto, forex, futures, option, stock};
+use crate::log_context::{AkqLogContext, format_event_time_nanos, render_log_message};
 use crate::model::{
     AssetType, ExecutionPolicyCore, Order, OrderStatus, PriceBasis, TemporalPolicy,
     TimeInForce, TradingSession,
@@ -34,6 +35,77 @@ pub struct SimulatedExecutionClient {
 }
 
 impl SimulatedExecutionClient {
+    fn order_log_context(order: &Order, event_time: i64) -> AkqLogContext {
+        let mut context = AkqLogContext::new()
+            .phase("execution")
+            .symbol(order.symbol.clone())
+            .order_id(order.id.clone())
+            .event_time_str(format_event_time_nanos(event_time));
+        if let Some(strategy_id) = order
+            .owner_strategy_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            context = context
+                .strategy_id(strategy_id.to_string())
+                .slot(strategy_id.to_string());
+        }
+        context
+    }
+
+    fn insufficient_margin_warning(
+        order: &Order,
+        current_time: i64,
+        total_required: Decimal,
+        current_free_margin: Decimal,
+    ) -> String {
+        render_log_message(
+            format!(
+                "Rejected order due to insufficient margin during execution. Required: {total_required}, Available: {current_free_margin}"
+            ),
+            Self::order_log_context(order, current_time),
+        )
+    }
+
+    fn expired_day_order_warning(order: &Order, event_time: i64) -> String {
+        render_log_message(
+            "Expired day order at session close",
+            Self::order_log_context(order, event_time),
+        )
+    }
+
+    fn ignored_unknown_cancel_warning(order_id: &str) -> String {
+        render_log_message(
+            "Ignored cancel request for unknown order",
+            AkqLogContext::new()
+                .phase("execution")
+                .order_id(order_id.to_string()),
+        )
+    }
+
+    fn ignored_non_cancellable_cancel_warning(order: &Order) -> String {
+        let event_time = if order.updated_at != 0 {
+            order.updated_at
+        } else {
+            order.created_at
+        };
+        render_log_message(
+            format!(
+                "Ignored cancel request because order is not cancellable in status {:?}",
+                order.status
+            ),
+            Self::order_log_context(order, event_time),
+        )
+    }
+
+    fn deferred_same_cycle_order_warning(order: &Order, event_time: i64) -> String {
+        render_log_message(
+            "Deferred same-cycle order until cross-symbol reduce-first orders finish in current slice",
+            Self::order_log_context(order, event_time),
+        )
+    }
+
     fn rebuild_futures_matcher(&mut self) {
         self.matchers.insert(
             AssetType::Futures,
@@ -95,6 +167,14 @@ impl SimulatedExecutionClient {
         match event {
             Event::Bar(bar) => Some(bar.symbol.as_str()),
             Event::Tick(tick) => Some(tick.symbol.as_str()),
+            _ => None,
+        }
+    }
+
+    fn event_timestamp(event: &Event) -> Option<i64> {
+        match event {
+            Event::Bar(bar) => Some(bar.timestamp),
+            Event::Tick(tick) => Some(tick.timestamp),
             _ => None,
         }
     }
@@ -254,10 +334,18 @@ impl SimulatedExecutionClient {
                         .unwrap_or(false);
 
                 if defer_current {
-                    self.deferred_same_cycle_order_ids
+                    let event_time = Self::event_timestamp(event).unwrap_or(ctx.current_time);
+                    let first_defer = self
+                        .deferred_same_cycle_order_ids
                         .insert(order_snapshot.id.clone());
                     self.attempted_same_cycle_order_ids
                         .insert(order_snapshot.id.clone());
+                    if first_defer {
+                        log::warn!(
+                            "{}",
+                            Self::deferred_same_cycle_order_warning(&order_snapshot, event_time)
+                        );
+                    }
                     continue;
                 }
 
@@ -403,6 +491,15 @@ impl SimulatedExecutionClient {
                                         rejected_order.reject_reason = format!(
                                             "Risk: Insufficient margin at execution. Required: {total_required}, Available: {current_free_margin}"
                                         );
+                                        log::warn!(
+                                            "{}",
+                                            Self::insufficient_margin_warning(
+                                                &rejected_order,
+                                                ctx.current_time,
+                                                total_required,
+                                                current_free_margin,
+                                            )
+                                        );
                                         replacement_report =
                                             Some(Event::ExecutionReport(rejected_order, None));
                                     }
@@ -502,7 +599,13 @@ impl ExecutionClient for SimulatedExecutionClient {
 
     fn set_volume_limit(&mut self, limit: f64) {
         self.volume_limit_pct = Decimal::from_f64(limit).unwrap_or_else(|| {
-            log::warn!("Invalid volume limit {}, defaulting to 0.0", limit);
+            log::warn!(
+                "{}",
+                render_log_message(
+                    format!("Invalid volume limit {limit}, defaulting to 0.0"),
+                    AkqLogContext::new().phase("execution"),
+                )
+            );
             Decimal::ZERO
         });
     }
@@ -558,12 +661,20 @@ impl ExecutionClient for SimulatedExecutionClient {
     }
 
     fn on_cancel(&mut self, order_id: &str) {
-        if let Some(order) = self.orders.get_mut(order_id)
-            && (order.status == OrderStatus::Submitted
-                || order.status == OrderStatus::PartiallyFilled
-                || order.status == OrderStatus::New)
-        {
-            order.status = OrderStatus::Cancelled;
+        match self.orders.get_mut(order_id) {
+            Some(order)
+                if order.status == OrderStatus::Submitted
+                    || order.status == OrderStatus::PartiallyFilled
+                    || order.status == OrderStatus::New =>
+            {
+                order.status = OrderStatus::Cancelled;
+            }
+            Some(order) => {
+                log::warn!("{}", Self::ignored_non_cancellable_cancel_warning(order));
+            }
+            None => {
+                log::warn!("{}", Self::ignored_unknown_cancel_warning(order_id));
+            }
         }
     }
 
@@ -588,6 +699,7 @@ impl ExecutionClient for SimulatedExecutionClient {
                         && Self::is_order_active(order)
                         && order.time_in_force == TimeInForce::Day
                     {
+                        log::warn!("{}", Self::expired_day_order_warning(order, timestamp));
                         order.status = OrderStatus::Expired;
                         order.updated_at = timestamp;
                         reports.push(Event::ExecutionReport(order.clone(), None));
@@ -1315,5 +1427,117 @@ mod tests {
             .0
             .reject_reason
             .contains("Insufficient margin at execution"));
+    }
+
+    #[test]
+    fn test_insufficient_margin_warning_includes_order_context() {
+        let mut order = create_test_order(
+            "OPT_P",
+            crate::model::OrderSide::Sell,
+            crate::model::OrderType::Market,
+            Decimal::from(2),
+            None,
+        );
+        order.owner_strategy_id = Some("alpha".to_string());
+
+        let rendered = SimulatedExecutionClient::insufficient_margin_warning(
+            &order,
+            1_000_000_000,
+            Decimal::from(7000),
+            Decimal::from(6000),
+        );
+
+        assert!(rendered.contains("Rejected order due to insufficient margin during execution"));
+        assert!(rendered.contains("\"phase\":\"execution\""));
+        assert!(rendered.contains("\"symbol\":\"OPT_P\""));
+        assert!(rendered.contains(&format!("\"order_id\":\"{}\"", order.id)));
+        assert!(rendered.contains("\"strategy_id\":\"alpha\""));
+        assert!(rendered.contains("\"slot\":\"alpha\""));
+        assert!(rendered.contains("\"event_time_str\":\"1970-01-01 00:00:01\""));
+    }
+
+    #[test]
+    fn test_expired_day_order_warning_includes_order_context() {
+        let mut order = create_test_order(
+            "AAPL",
+            crate::model::OrderSide::Buy,
+            crate::model::OrderType::Limit,
+            Decimal::from(100),
+            Some(Decimal::from(10)),
+        );
+        order.owner_strategy_id = Some("beta".to_string());
+
+        let rendered = SimulatedExecutionClient::expired_day_order_warning(
+            &order,
+            2_000_000_000,
+        );
+
+        assert!(rendered.contains("Expired day order at session close"));
+        assert!(rendered.contains("\"phase\":\"execution\""));
+        assert!(rendered.contains("\"symbol\":\"AAPL\""));
+        assert!(rendered.contains(&format!("\"order_id\":\"{}\"", order.id)));
+        assert!(rendered.contains("\"strategy_id\":\"beta\""));
+        assert!(rendered.contains("\"slot\":\"beta\""));
+        assert!(rendered.contains("\"event_time_str\":\"1970-01-01 00:00:02\""));
+    }
+
+    #[test]
+    fn test_ignored_unknown_cancel_warning_includes_order_id() {
+        let rendered = SimulatedExecutionClient::ignored_unknown_cancel_warning("ghost-order");
+
+        assert!(rendered.contains("Ignored cancel request for unknown order"));
+        assert!(rendered.contains("\"phase\":\"execution\""));
+        assert!(rendered.contains("\"order_id\":\"ghost-order\""));
+    }
+
+    #[test]
+    fn test_ignored_non_cancellable_cancel_warning_includes_order_context() {
+        let mut order = create_test_order(
+            "AAPL",
+            crate::model::OrderSide::Buy,
+            crate::model::OrderType::Limit,
+            Decimal::from(100),
+            Some(Decimal::from(10)),
+        );
+        order.owner_strategy_id = Some("gamma".to_string());
+        order.status = OrderStatus::Filled;
+        order.updated_at = 3_000_000_000;
+
+        let rendered = SimulatedExecutionClient::ignored_non_cancellable_cancel_warning(&order);
+
+        assert!(rendered.contains(
+            "Ignored cancel request because order is not cancellable in status Filled"
+        ));
+        assert!(rendered.contains("\"phase\":\"execution\""));
+        assert!(rendered.contains("\"symbol\":\"AAPL\""));
+        assert!(rendered.contains(&format!("\"order_id\":\"{}\"", order.id)));
+        assert!(rendered.contains("\"strategy_id\":\"gamma\""));
+        assert!(rendered.contains("\"slot\":\"gamma\""));
+        assert!(rendered.contains("\"event_time_str\":\"1970-01-01 00:00:03\""));
+    }
+
+    #[test]
+    fn test_deferred_same_cycle_order_warning_includes_order_context() {
+        let mut order = create_test_order(
+            "MSFT",
+            crate::model::OrderSide::Buy,
+            crate::model::OrderType::Limit,
+            Decimal::from(50),
+            Some(Decimal::from(20)),
+        );
+        order.owner_strategy_id = Some("delta".to_string());
+
+        let rendered =
+            SimulatedExecutionClient::deferred_same_cycle_order_warning(&order, 4_000_000_000);
+
+        assert!(rendered.contains(
+            "Deferred same-cycle order until cross-symbol reduce-first orders finish in current slice"
+        ));
+        assert!(rendered.contains("\"phase\":\"execution\""));
+        assert!(rendered.contains("\"symbol\":\"MSFT\""));
+        assert!(rendered.contains(&format!("\"order_id\":\"{}\"", order.id)));
+        assert!(rendered.contains("\"strategy_id\":\"delta\""));
+        assert!(rendered.contains("\"slot\":\"delta\""));
+        assert!(rendered.contains("\"event_time_str\":\"1970-01-01 00:00:04\""));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod data;
 mod engine;
 mod error;
 mod event;
+mod log_context;
 pub mod event_manager;
 pub mod execution;
 pub mod history;
@@ -39,6 +40,7 @@ use risk::{RiskConfig, RiskManager};
 /// 使用 Rust 实现的 Python 模块
 #[pymodule]
 fn akquant(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let _ = pyo3_log::init();
     m.add_class::<Bar>()?;
     m.add_function(wrap_pyfunction!(from_arrays, m)?)?;
     m.add_class::<Tick>()?;

--- a/src/log_context.rs
+++ b/src/log_context.rs
@@ -1,0 +1,84 @@
+use chrono::{TimeZone, Utc};
+use serde::Serialize;
+
+const RUST_CONTEXT_MARKER: &str = " [akq_ctx=";
+
+#[derive(Default, Serialize)]
+pub struct AkqLogContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    event_time_str: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    strategy_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    slot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    order_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_order_id: Option<String>,
+}
+
+impl AkqLogContext {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn phase(mut self, value: impl Into<String>) -> Self {
+        self.phase = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn event_time_str(mut self, value: impl Into<String>) -> Self {
+        self.event_time_str = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn strategy_id(mut self, value: impl Into<String>) -> Self {
+        self.strategy_id = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn slot(mut self, value: impl Into<String>) -> Self {
+        self.slot = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn symbol(mut self, value: impl Into<String>) -> Self {
+        self.symbol = Some(value.into());
+        self
+    }
+
+    #[must_use]
+    pub fn order_id(mut self, value: impl Into<String>) -> Self {
+        self.order_id = Some(value.into());
+        self
+    }
+}
+
+#[must_use]
+pub fn render_log_message(message: impl Into<String>, context: AkqLogContext) -> String {
+    let message = message.into();
+    let Ok(payload) = serde_json::to_string(&context) else {
+        return message;
+    };
+    if payload == "{}" {
+        return message;
+    }
+    format!("{message}{RUST_CONTEXT_MARKER}{payload}]")
+}
+
+#[must_use]
+pub fn format_event_time_nanos(timestamp_ns: i64) -> String {
+    Utc.timestamp_nanos(timestamp_ns)
+        .format("%Y-%m-%d %H:%M:%S")
+        .to_string()
+}

--- a/src/market/corporate_action.rs
+++ b/src/market/corporate_action.rs
@@ -1,4 +1,5 @@
 use crate::analysis::tracker::TradeTracker;
+use crate::log_context::{AkqLogContext, render_log_message};
 use crate::model::corporate_action::{CorporateAction, CorporateActionType};
 use crate::portfolio::Portfolio;
 use chrono::NaiveDate;
@@ -61,9 +62,18 @@ impl CorporateActionManager {
                         let ratio = action.value.abs();
                         let (min_ratio, max_ratio) = split_ratio_bounds();
                         if ratio <= Decimal::ZERO || ratio < min_ratio || ratio > max_ratio {
-                            eprintln!(
-                                "[{CORP_ACTION_ALERT_PREFIX}] skip split action for {} on {} due to abnormal ratio {}",
-                                action.symbol, action.date, action.value
+                            log::warn!(
+                                "{}",
+                                render_log_message(
+                                    format!(
+                                        "[{CORP_ACTION_ALERT_PREFIX}] skip split action for {} on {} due to abnormal ratio {}",
+                                        action.symbol, action.date, action.value
+                                    ),
+                                    AkqLogContext::new()
+                                        .phase("data")
+                                        .symbol(action.symbol.clone())
+                                        .event_time_str(action.date.to_string()),
+                                )
                             );
                             continue;
                         }

--- a/tests/test_account_risk_rules.py
+++ b/tests/test_account_risk_rules.py
@@ -138,6 +138,30 @@ def test_check_cash_false_can_disable_margin_rejection_for_buy() -> None:
     assert engine.risk_manager.config.check_cash is False
 
 
+def test_apply_risk_config_logs_structured_context_for_invalid_sector_rule(
+    caplog: Any,
+) -> None:
+    """Risk config warnings should include structured phase context."""
+    from akquant.akquant import Engine
+    from akquant.risk import apply_risk_config
+
+    engine = Engine()
+
+    with caplog.at_level("WARNING", logger="akquant"):
+        apply_risk_config(engine, RiskConfig(sector_concentration=0.2))
+
+    warning_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.risk"
+        and "sector_concentration must be a tuple" in record.getMessage()
+    )
+    assert warning_record.phase == "risk"
+    assert warning_record.strategy_id is None
+    assert warning_record.slot is None
+    assert warning_record.symbol is None
+
+
 def test_short_option_margin_is_checked_and_account_margin_updates() -> None:
     """Short option opening orders should trigger margin checks and account margin."""
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,5 @@
+import csv
+import json
 import logging
 import time
 import warnings
@@ -55,6 +57,18 @@ class NoopStrategy(akquant.Strategy):
     def on_bar(self, bar: akquant.Bar) -> None:
         """Handle bar events without generating orders."""
         return
+
+
+class FailingOnStopStrategy(akquant.Strategy):
+    """Strategy that raises during on_stop for logging assertions."""
+
+    def on_bar(self, bar: akquant.Bar) -> None:
+        """Keep the strategy inactive during bar processing."""
+        _ = bar
+
+    def on_stop(self) -> None:
+        """Raise a deterministic failure for log context checks."""
+        raise RuntimeError("boom")
 
 
 class WorkerLogStrategy(akquant.Strategy):
@@ -2315,6 +2329,72 @@ def test_run_backtest_strategy_slot_risk_from_config() -> None:
     assert not any("order quantity" in reason for reason in beta_reject_reasons)
 
 
+def test_run_backtest_unknown_risk_config_key_includes_structured_context(
+    caplog: Any,
+) -> None:
+    """Unknown risk config warnings should expose structured backtest context."""
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        _ = akquant.run_backtest(
+            data=_build_regression_bars("RISK_CONTEXT"),
+            strategy=SingleBuyStrategy,
+            symbols="RISK_CONTEXT",
+            initial_cash=100000.0,
+            commission_rate=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+            min_commission=0.0,
+            fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+            lot_size=1,
+            show_progress=False,
+            strategy_id="alpha",
+            risk_config={"unknown_key": 1},
+        )
+
+    warning_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.backtest"
+        and "Unknown risk config key" in record.getMessage()
+    )
+    assert warning_record.phase == "risk"
+    assert warning_record.strategy_id == "alpha"
+    assert warning_record.slot == "alpha"
+    assert warning_record.symbol is None
+
+
+def test_run_backtest_slot_on_stop_error_includes_structured_context(
+    caplog: Any,
+) -> None:
+    """Slot lifecycle errors should expose slot identity in log records."""
+    with caplog.at_level(logging.ERROR, logger="akquant"):
+        _ = akquant.run_backtest(
+            data=_build_regression_bars("STOP_SLOT"),
+            strategy=NoopStrategy,
+            symbols="STOP_SLOT",
+            initial_cash=100000.0,
+            commission_rate=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+            min_commission=0.0,
+            fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+            lot_size=1,
+            show_progress=False,
+            strategy_id="alpha",
+            strategies_by_slot={"beta": FailingOnStopStrategy},
+        )
+
+    error_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.backtest"
+        and "Error in slot on_stop" in record.getMessage()
+    )
+    assert error_record.phase == "strategy"
+    assert error_record.strategy_id == "beta"
+    assert error_record.slot == "beta"
+    assert error_record.symbol == "STOP_SLOT"
+
+
 def test_run_backtest_explicit_strategy_slot_risk_overrides_config() -> None:
     """Explicit strategy slot risk args should override config values."""
     probe = akquant.Engine()
@@ -4299,22 +4379,574 @@ def test_run_grid_search_strict_params_raises_on_constructor_mismatch() -> None:
         )
 
 
-def test_run_grid_search_parallel_warns_worker_log_visibility(
+def test_configure_logging_supports_mixed_console_and_file_levels(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Console/file handler levels should work together without losing records."""
+    log_file = tmp_path / "mixed_levels.log"
+    akquant.configure_logging(
+        akquant.LogConfig(
+            level="INFO",
+            console=True,
+            filename=str(log_file),
+            file_level="DEBUG",
+        )
+    )
+    logger = akquant.get_logger()
+
+    logger.debug("debug-file-only")
+    logger.info("info-both")
+
+    captured = capsys.readouterr()
+    file_text = log_file.read_text(encoding="utf-8")
+
+    assert logger.level == logging.DEBUG
+    assert "debug-file-only" not in captured.out
+    assert "info-both" in captured.out
+    assert "debug-file-only" in file_text
+    assert "info-both" in file_text
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_configure_logging_optimize_profile_renders_process_name(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Parallel grid search should print worker log visibility warning."""
-    data = _build_benchmark_data(n=20, symbol="OPT_LOG_VISIBILITY")
-    _ = akquant.run_grid_search(
-        strategy=NoopStrategy,
-        param_grid={"dummy": [1, 2]},
-        data=data,
-        symbol="OPT_LOG_VISIBILITY",
-        max_workers=2,
-        return_df=True,
-        show_progress=False,
-    )
+    """Optimize profile should include process name and logger name in output."""
+    akquant.configure_logging(akquant.LogConfig(profile="optimize", level="WARNING"))
+    akquant.get_logger("optimize").warning("optimize-profile-check")
+
     captured = capsys.readouterr()
-    assert "self.log() output may not be visible" in captured.out
+    assert "MainProcess" in captured.out
+    assert "akquant.optimize" in captured.out
+    assert "optimize-profile-check" in captured.out
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_configure_logging_supports_rotating_file_handler(tmp_path: Path) -> None:
+    """File rotation should preserve records across rollover files."""
+    log_file = tmp_path / "rotating.log"
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            filename=str(log_file),
+            file_level="INFO",
+            file_max_bytes=120,
+            file_backup_count=1,
+        )
+    )
+    logger = akquant.get_logger("strategy")
+
+    logger.info("first-message-%s", "A" * 80)
+    logger.info("second-message-%s", "B" * 80)
+
+    rotated_file = log_file.with_name(f"{log_file.name}.1")
+    assert rotated_file.exists()
+
+    combined_text = rotated_file.read_text(encoding="utf-8") + log_file.read_text(
+        encoding="utf-8"
+    )
+    assert "first-message-" in combined_text
+    assert "second-message-" in combined_text
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_configure_logging_supports_json_file_output(tmp_path: Path) -> None:
+    """JSON file logging should emit structured JSON records."""
+    import akquant.log as aklog
+
+    log_file = tmp_path / "json.log"
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            filename=str(log_file),
+            file_json=True,
+            file_level="INFO",
+        )
+    )
+    logger = akquant.get_logger("strategy")
+    logger.info(
+        "json-file-check",
+        extra=aklog.build_log_extra(
+            phase="trade",
+            strategy_id="alpha",
+            slot="alpha",
+            symbol="AAPL",
+            order_id="order-1",
+            client_order_id="coid-1",
+            event_time_str="2023-01-01 09:30:00",
+        ),
+    )
+
+    payload = json.loads(log_file.read_text(encoding="utf-8").strip())
+    assert payload["message"] == "json-file-check"
+    assert payload["logger"] == "akquant.strategy"
+    assert payload["phase"] == "trade"
+    assert payload["strategy_id"] == "alpha"
+    assert payload["symbol"] == "AAPL"
+    assert payload["order_id"] == "order-1"
+    assert payload["client_order_id"] == "coid-1"
+    assert payload["event_time_str"] == "2023-01-01 09:30:00"
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_configure_logging_supports_json_console_output(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON console logging should emit structured JSON records."""
+    import akquant.log as aklog
+
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=True,
+            console_json=True,
+            level="INFO",
+        )
+    )
+    logger = akquant.get_logger("gateway.live")
+    logger.warning(
+        "json-console-check",
+        extra=aklog.build_log_extra(
+            phase="gateway",
+            strategy_id="beta",
+            slot="beta",
+            symbol="IF2406",
+            client_order_id="coid-json-console",
+        ),
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out.strip())
+    assert payload["message"] == "json-console-check"
+    assert payload["logger"] == "akquant.gateway.live"
+    assert payload["phase"] == "gateway"
+    assert payload["strategy_id"] == "beta"
+    assert payload["symbol"] == "IF2406"
+    assert payload["client_order_id"] == "coid-json-console"
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_rust_warnings_bridge_into_python_logging(caplog: Any) -> None:
+    """Rust log::warn! output should flow through the Python logging pipeline."""
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            level="WARNING",
+        )
+    )
+
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        bars = akquant.from_arrays(
+            np.array([1], dtype=np.int64),
+            np.array([np.nan], dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            np.array([1.0], dtype=np.float64),
+            "AAPL",
+            None,
+            None,
+        )
+
+    assert bars[0].open == 0.0
+    matching_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.data.batch"
+        and "Invalid open price NaN, defaulting to 0.0" in record.getMessage()
+    )
+    assert matching_record.phase == "data"
+    assert matching_record.symbol == "AAPL"
+    assert matching_record.event_time_str == "1970-01-01 00:00:00"
+    assert any(
+        record.name == "akquant.data.batch"
+        and "Invalid open price NaN, defaulting to 0.0" in record.getMessage()
+        for record in caplog.records
+    )
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_run_backtest_invalid_volume_limit_bridges_rust_warning(caplog: Any) -> None:
+    """Execution-layer Rust warnings should also enter the Python logging pipeline."""
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            level="WARNING",
+        )
+    )
+
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        result = akquant.run_backtest(
+            strategy=NoopStrategy,
+            data=_build_regression_bars("VOL_LIMIT_WARN"),
+            symbols="VOL_LIMIT_WARN",
+            show_progress=False,
+            commission_rate=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+            min_commission=0.0,
+            volume_limit_pct=float("nan"),
+        )
+
+    assert result is not None
+    matching_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.execution.simulated"
+        and "Invalid volume limit NaN, defaulting to 0.0" in record.getMessage()
+    )
+    assert matching_record.phase == "execution"
+    assert matching_record.symbol is None
+    assert any(
+        record.name == "akquant.execution.simulated"
+        and "Invalid volume limit NaN, defaulting to 0.0" in record.getMessage()
+        for record in caplog.records
+    )
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_engine_csv_feed_bridges_rust_warning(caplog: Any, tmp_path: Path) -> None:
+    """CSV-backed Rust warnings should enter the Python logging pipeline."""
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            level="WARNING",
+        )
+    )
+
+    csv_path = tmp_path / "bars.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["timestamp", "open", "high", "low", "close", "volume"])
+        writer.writerow([1, float("nan"), 10.0, 9.0, 9.5, 100.0])
+
+    feed = akquant.DataFeed.from_csv(str(csv_path), "AAPL")
+    engine = akquant.Engine()
+    engine.add_data(feed)
+
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        summary = engine.run(NoopStrategy(), False)
+
+    assert isinstance(summary, str)
+    matching_record = next(
+        record
+        for record in caplog.records
+        if record.name == "akquant.data.client"
+        and "Invalid open price NaN, defaulting to 0.0" in record.getMessage()
+    )
+    assert matching_record.phase == "data"
+    assert matching_record.symbol == "AAPL"
+    assert matching_record.event_time_str == "1970-01-01 00:00:01"
+    assert any(
+        record.name == "akquant.data.client"
+        and "Invalid open price NaN, defaulting to 0.0" in record.getMessage()
+        for record in caplog.records
+    )
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_rust_warning_json_output_includes_structured_context(tmp_path: Path) -> None:
+    """Rust warnings should populate structured JSON fields after context extraction."""
+    log_file = tmp_path / "rust-warning.json"
+    akquant.configure_logging(
+        akquant.LogConfig(
+            console=False,
+            filename=str(log_file),
+            file_json=True,
+            file_level="WARNING",
+        )
+    )
+
+    _ = akquant.from_arrays(
+        np.array([1], dtype=np.int64),
+        np.array([np.nan], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        "AAPL",
+        None,
+        None,
+    )
+
+    payload = json.loads(log_file.read_text(encoding="utf-8").strip())
+    assert payload["logger"] == "akquant.data.batch"
+    assert payload["message"] == "Invalid open price NaN, defaulting to 0.0"
+    assert payload["phase"] == "data"
+    assert payload["symbol"] == "AAPL"
+    assert payload["event_time_str"] == "1970-01-01 00:00:00"
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_rust_warning_live_profile_renders_structured_context(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Live profile should render Rust warning context in plain text output."""
+    akquant.configure_logging(
+        akquant.LogConfig(profile="live", console=True, level="WARNING")
+    )
+
+    _ = akquant.from_arrays(
+        np.array([1], dtype=np.int64),
+        np.array([np.nan], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        np.array([1.0], dtype=np.float64),
+        "AAPL",
+        None,
+        None,
+    )
+
+    captured = capsys.readouterr()
+    assert "akquant.data.batch" in captured.out
+    assert "Invalid open price NaN, defaulting to 0.0" in captured.out
+    assert "phase=data" in captured.out
+    assert "symbol=AAPL" in captured.out
+    assert "event_time_str=1970-01-01 00:00:00" in captured.out
+
+    akquant.register_logger(console=False, level="INFO")
+
+
+def test_get_logger_uses_null_handler_when_unconfigured() -> None:
+    """The root AKQuant logger should stay quiet until handlers are configured."""
+    import akquant.log as aklog
+
+    logger = logging.getLogger("akquant")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+    aklog.Logger._instance = None
+
+    configured_logger = aklog.get_logger()
+
+    assert configured_logger is logger
+    assert any(isinstance(handler, logging.NullHandler) for handler in logger.handlers)
+    assert not any(
+        isinstance(handler, logging.StreamHandler)
+        and not isinstance(handler, logging.FileHandler | logging.NullHandler)
+        for handler in logger.handlers
+    )
+
+
+def test_rust_context_parser_ignores_malformed_payload() -> None:
+    """Malformed Rust context payloads should not corrupt the rendered message."""
+    import akquant.log as aklog
+
+    message = 'broken-marker [akq_ctx={"phase":"data"'
+
+    stripped, payload = aklog._parse_rust_context_message(message)
+
+    assert stripped == message
+    assert payload is None
+
+
+def test_non_akquant_logger_keeps_literal_rust_context_marker() -> None:
+    """Only AKQuant loggers should decode the embedded Rust context payload."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="thirdparty.lib",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg='raw-message [akq_ctx={"phase":"data","symbol":"AAPL"}]',
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+
+    assert (
+        record.getMessage() == 'raw-message [akq_ctx={"phase":"data","symbol":"AAPL"}]'
+    )
+    assert not hasattr(record, "phase")
+    assert not hasattr(record, "symbol")
+
+
+def test_rust_context_parser_extracts_execution_order_fields() -> None:
+    """AKQuant Rust payloads should restore execution/order business fields."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="akquant.execution.simulated",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=(
+            "Rejected order due to insufficient margin during execution "
+            '[akq_ctx={"phase":"execution","symbol":"OPT_P","order_id":"ord-1",'
+            '"strategy_id":"alpha","slot":"alpha",'
+            '"event_time_str":"1970-01-01 00:00:01"}]'
+        ),
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+    typed_record = cast(Any, record)
+
+    assert (
+        record.getMessage()
+        == "Rejected order due to insufficient margin during execution"
+    )
+    assert typed_record.phase == "execution"
+    assert typed_record.symbol == "OPT_P"
+    assert typed_record.order_id == "ord-1"
+    assert typed_record.strategy_id == "alpha"
+    assert typed_record.slot == "alpha"
+    assert typed_record.event_time_str == "1970-01-01 00:00:01"
+
+
+def test_rust_context_parser_extracts_expired_order_fields() -> None:
+    """Expired-order Rust payloads should restore execution/order business fields."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="akquant.execution.simulated",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=(
+            "Expired day order at session close "
+            '[akq_ctx={"phase":"execution","symbol":"AAPL","order_id":"ord-exp",'
+            '"strategy_id":"beta","slot":"beta",'
+            '"event_time_str":"1970-01-01 00:00:02"}]'
+        ),
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+    typed_record = cast(Any, record)
+
+    assert record.getMessage() == "Expired day order at session close"
+    assert typed_record.phase == "execution"
+    assert typed_record.symbol == "AAPL"
+    assert typed_record.order_id == "ord-exp"
+    assert typed_record.strategy_id == "beta"
+    assert typed_record.slot == "beta"
+    assert typed_record.event_time_str == "1970-01-01 00:00:02"
+
+
+def test_rust_context_parser_extracts_unknown_cancel_fields() -> None:
+    """Unknown-cancel Rust payloads should restore execution/order fields."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="akquant.execution.simulated",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=(
+            "Ignored cancel request for unknown order "
+            '[akq_ctx={"phase":"execution","order_id":"ghost-order"}]'
+        ),
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+    typed_record = cast(Any, record)
+
+    assert record.getMessage() == "Ignored cancel request for unknown order"
+    assert typed_record.phase == "execution"
+    assert typed_record.order_id == "ghost-order"
+    assert typed_record.symbol is None
+
+
+def test_rust_context_parser_extracts_non_cancellable_cancel_fields() -> None:
+    """Non-cancellable cancel Rust payloads should restore full order context."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="akquant.execution.simulated",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=(
+            "Ignored cancel request because order is not cancellable in status Filled "
+            '[akq_ctx={"phase":"execution","symbol":"AAPL","order_id":"ord-cancel",'
+            '"strategy_id":"gamma","slot":"gamma",'
+            '"event_time_str":"1970-01-01 00:00:03"}]'
+        ),
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+    typed_record = cast(Any, record)
+
+    assert (
+        record.getMessage()
+        == "Ignored cancel request because order is not cancellable in status Filled"
+    )
+    assert typed_record.phase == "execution"
+    assert typed_record.symbol == "AAPL"
+    assert typed_record.order_id == "ord-cancel"
+    assert typed_record.strategy_id == "gamma"
+    assert typed_record.slot == "gamma"
+    assert typed_record.event_time_str == "1970-01-01 00:00:03"
+
+
+def test_rust_context_parser_extracts_deferred_same_cycle_order_fields() -> None:
+    """Deferred same-cycle Rust payloads should restore full order context."""
+    import akquant.log as aklog
+
+    record = logging.LogRecord(
+        name="akquant.execution.simulated",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=0,
+        msg=(
+            "Deferred same-cycle order until cross-symbol reduce-first orders "
+            "finish in current slice "
+            '[akq_ctx={"phase":"execution","symbol":"MSFT","order_id":"ord-defer",'
+            '"strategy_id":"delta","slot":"delta",'
+            '"event_time_str":"1970-01-01 00:00:04"}]'
+        ),
+        args=(),
+        exc_info=None,
+    )
+
+    aklog._extract_rust_context(record)
+    typed_record = cast(Any, record)
+
+    assert (
+        record.getMessage()
+        == "Deferred same-cycle order until cross-symbol reduce-first orders "
+        "finish in current slice"
+    )
+    assert typed_record.phase == "execution"
+    assert typed_record.symbol == "MSFT"
+    assert typed_record.order_id == "ord-defer"
+    assert typed_record.strategy_id == "delta"
+    assert typed_record.slot == "delta"
+    assert typed_record.event_time_str == "1970-01-01 00:00:04"
+
+
+def test_run_grid_search_parallel_warns_worker_log_visibility(caplog: Any) -> None:
+    """Parallel grid search should log worker visibility warning once."""
+    data = _build_benchmark_data(n=20, symbol="OPT_LOG_VISIBILITY")
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        _ = akquant.run_grid_search(
+            strategy=NoopStrategy,
+            param_grid={"dummy": [1, 2]},
+            data=data,
+            symbol="OPT_LOG_VISIBILITY",
+            max_workers=2,
+            return_df=True,
+            show_progress=False,
+        )
+    assert "self.log() output may not be visible" in caplog.text
 
 
 def test_run_backtest_warns_on_suspicious_global_slippage(caplog: Any) -> None:
@@ -4333,6 +4965,7 @@ def test_run_backtest_warns_on_suspicious_global_slippage(caplog: Any) -> None:
 
     assert "Global slippage=0.2 uses percent semantics in AKQuant" in caplog.text
     assert "slippage={'type': 'fixed', 'value': 0.2}" in caplog.text
+    assert any(record.name == "akquant.backtest" for record in caplog.records)
 
 
 def test_run_backtest_does_not_warn_on_small_global_slippage(caplog: Any) -> None:
@@ -4352,45 +4985,77 @@ def test_run_backtest_does_not_warn_on_small_global_slippage(caplog: Any) -> Non
     assert "uses percent semantics in AKQuant" not in caplog.text
 
 
-def test_run_grid_search_parallel_forward_worker_logs_suppresses_visibility_warning(
+def test_run_backtest_live_profile_renders_risk_context(
     capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Live profile should render structured context for risk warnings."""
+    akquant.configure_logging(
+        akquant.LogConfig(profile="live", console=True, level="INFO")
+    )
+
+    _ = akquant.run_backtest(
+        data=_build_regression_bars("RISK_CONTEXT_LIVE"),
+        strategy=SingleBuyStrategy,
+        symbols="RISK_CONTEXT_LIVE",
+        initial_cash=100000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+        strategy_id="alpha",
+        risk_config={"unknown_key": 1},
+    )
+
+    captured = capsys.readouterr()
+    assert "akquant.backtest" in captured.out
+    assert "Unknown risk config key: unknown_key" in captured.out
+    assert "phase=risk" in captured.out
+    assert "strategy_id=alpha" in captured.out
+    assert "slot=alpha" in captured.out
+
+
+def test_run_grid_search_parallel_forward_worker_logs_suppresses_visibility_warning(
+    caplog: Any,
 ) -> None:
     """Forwarded worker logs should suppress visibility warning text."""
     akquant.register_logger(console=True, level="INFO")
     data = _build_benchmark_data(n=20, symbol="OPT_LOG_VISIBILITY_FORWARD")
-    _ = akquant.run_grid_search(
-        strategy=NoopStrategy,
-        param_grid={"dummy": [1, 2]},
-        data=data,
-        symbol="OPT_LOG_VISIBILITY_FORWARD",
-        max_workers=2,
-        return_df=True,
-        show_progress=False,
-        forward_worker_logs=True,
-    )
-    captured = capsys.readouterr()
-    assert "self.log() output may not be visible" not in captured.out
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        _ = akquant.run_grid_search(
+            strategy=NoopStrategy,
+            param_grid={"dummy": [1, 2]},
+            data=data,
+            symbol="OPT_LOG_VISIBILITY_FORWARD",
+            max_workers=2,
+            return_df=True,
+            show_progress=False,
+            forward_worker_logs=True,
+        )
+    assert "self.log() output may not be visible" not in caplog.text
 
 
 def test_run_grid_search_parallel_forward_worker_logs_warns_no_handler(
-    capsys: pytest.CaptureFixture[str],
+    caplog: Any,
 ) -> None:
     """Forwarding should warn explicitly when main process has no active handler."""
     akquant.register_logger(console=False, level="INFO")
     data = _build_benchmark_data(n=20, symbol="OPT_LOG_NO_HANDLER")
-    _ = akquant.run_grid_search(
-        strategy=NoopStrategy,
-        param_grid={"dummy": [1, 2]},
-        data=data,
-        symbol="OPT_LOG_NO_HANDLER",
-        max_workers=2,
-        return_df=True,
-        show_progress=False,
-        forward_worker_logs=True,
-    )
-    captured = capsys.readouterr()
-    assert "forward_worker_logs=True but no active logger handler" in captured.out
-    assert "self.log() output may not be visible" not in captured.out
+    with caplog.at_level(logging.WARNING, logger="akquant"):
+        _ = akquant.run_grid_search(
+            strategy=NoopStrategy,
+            param_grid={"dummy": [1, 2]},
+            data=data,
+            symbol="OPT_LOG_NO_HANDLER",
+            max_workers=2,
+            return_df=True,
+            show_progress=False,
+            forward_worker_logs=True,
+        )
+    assert "forward_worker_logs=True but no active logger handler" in caplog.text
+    assert "self.log() output may not be visible" not in caplog.text
     akquant.register_logger(console=True, level="INFO")
 
 

--- a/tests/test_live_runner_broker_bridge.py
+++ b/tests/test_live_runner_broker_bridge.py
@@ -76,7 +76,7 @@ def test_live_runner_broker_bridge_dispatches_events() -> None:
     assert strategy.reports == [{"id": "r1"}]
 
 
-def test_live_runner_broker_bridge_forwards_errors() -> None:
+def test_live_runner_broker_bridge_forwards_errors(caplog: Any) -> None:
     """Forward callback exceptions to strategy on_error."""
 
     class _DummyTraderGateway:
@@ -113,12 +113,23 @@ def test_live_runner_broker_bridge_forwards_errors() -> None:
     strategy = _DummyErrorStrategy()
     runner._bind_broker_callbacks(gateway, cast(Any, strategy))
 
-    gateway.emit_trade({"id": "t2"})
-    time.sleep(0.2)
-    runner._stop_broker_dispatcher()
+    with caplog.at_level("WARNING", logger="akquant.gateway.live"):
+        gateway.emit_trade(
+            {"id": "t2", "symbol": "IF2406", "client_order_id": "coid-t2"}
+        )
+        time.sleep(0.2)
+        runner._stop_broker_dispatcher()
 
     assert strategy.errors
     assert strategy.errors[0][0] == "on_trade"
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Strategy broker callback failed"
+    )
+    assert record.phase == "gateway"
+    assert record.symbol == "IF2406"
+    assert record.client_order_id == "coid-t2"
 
 
 def test_live_runner_broker_bridge_deduplicates_events() -> None:
@@ -500,7 +511,7 @@ def test_live_runner_submitter_checks_idempotency_and_maps() -> None:
     assert runner._resolve_client_order_id("b-coid-1") == "coid-1"
 
 
-def test_live_runner_submitter_forwards_duplicate_error() -> None:
+def test_live_runner_submitter_forwards_duplicate_error(caplog: Any) -> None:
     """Raise and forward error when submitting duplicate active client order id."""
 
     class _DummyTraderGateway:
@@ -524,20 +535,30 @@ def test_live_runner_submitter_forwards_duplicate_error() -> None:
     runner._install_broker_order_submitter(cast(Any, gateway), cast(Any, strategy))
     strategy_any = cast(Any, strategy)
 
-    try:
-        strategy_any.submit_order(
-            symbol="000002.SZ",
-            side="Sell",
-            quantity=5.0,
-            client_order_id="coid-dup",
-        )
-    except RuntimeError as exc:
-        assert "duplicate active client_order_id" in str(exc)
-    else:
-        raise AssertionError("expected RuntimeError for duplicate client_order_id")
+    with caplog.at_level("WARNING", logger="akquant.gateway.live"):
+        try:
+            strategy_any.submit_order(
+                symbol="000002.SZ",
+                side="Sell",
+                quantity=5.0,
+                client_order_id="coid-dup",
+            )
+        except RuntimeError as exc:
+            assert "duplicate active client_order_id" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError for duplicate client_order_id")
 
     assert strategy.errors
     assert strategy.errors[0][0] == "submit_order"
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage()
+        == "Rejected live submit_order because client_order_id is already active"
+    )
+    assert record.phase == "gateway"
+    assert record.symbol == "000002.SZ"
+    assert record.client_order_id == "coid-dup"
 
 
 def test_live_runner_submit_order_supports_buy_and_sell_side() -> None:
@@ -1395,3 +1416,43 @@ def test_live_runner_emits_observable_broker_events_with_owner_strategy_id() -> 
     assert event["event_type"] == "order"
     assert event["owner_strategy_id"] == "beta"
     assert event["payload"]["client_order_id"] == "coid-obs-1"
+
+
+def test_live_runner_logs_broker_event_observer_failures(caplog: Any) -> None:
+    """Observer callback failures should be logged with broker context."""
+
+    def _observer(_: dict[str, Any]) -> None:
+        raise RuntimeError("observer failed")
+
+    class _DummyStrategy:
+        def on_order(self, order: Any) -> None:
+            return None
+
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.broker = "miniqmt"
+    runner._init_broker_bridge_state()
+    runner.on_broker_event = _observer
+    runner._client_to_strategy_ids["coid-obs-2"] = "gamma"
+    strategy = _DummyStrategy()
+    payload = {
+        "client_order_id": "coid-obs-2",
+        "broker_order_id": "b-obs-2",
+        "symbol": "000001.SZ",
+        "status": "Submitted",
+    }
+
+    with caplog.at_level("WARNING", logger="akquant.gateway.live"):
+        runner._queue_broker_event("order", payload)
+        runner._drain_broker_events(cast(Any, strategy))
+
+    record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "Broker event observer failed"
+    )
+    assert record.phase == "gateway"
+    assert record.strategy_id == "gamma"
+    assert record.slot == "gamma"
+    assert record.symbol == "000001.SZ"
+    assert record.order_id == "b-obs-2"
+    assert record.client_order_id == "coid-obs-2"

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -12,7 +12,9 @@ import pytest
 from akquant import (
     BacktestConfig,
     InstrumentConfig,
+    LogConfig,
     StrategyConfig,
+    configure_logging,
     register_logger,
     register_strategy_loader,
     run_backtest,
@@ -62,6 +64,18 @@ class MyStrategy(Strategy):
         self.log(f"Tick {self.symbol} Price: {self.close}")
 
 
+class OrderLoggingStrategy(Strategy):
+    """Strategy used to verify order/trade log context extraction."""
+
+    def on_order(self, order: Any) -> None:
+        """Emit a log from the order callback."""
+        self.log(f"order:{order.id}")
+
+    def on_trade(self, trade: Any) -> None:
+        """Emit a log from the trade callback."""
+        self.log(f"trade:{trade.order_id}")
+
+
 def test_strategy_logging(caplog: Any) -> None:
     """Test logging."""
     strategy = MyStrategy()
@@ -87,6 +101,144 @@ def test_strategy_logging(caplog: Any) -> None:
 
     assert "Bar AAPL Close: 102.0" in caplog.text
     assert "[" in caplog.text and "]" in caplog.text
+    assert any(record.name == "akquant.strategy" for record in caplog.records)
+
+
+def test_strategy_logging_includes_structured_context(caplog: Any) -> None:
+    """Strategy logs should carry structured metadata for later formatting/export."""
+    strategy = MyStrategy()
+    cast(Any, strategy)._owner_strategy_id = "alpha"
+    ctx = MagicMock(spec=StrategyContext)
+    ctx.get_position.return_value = 0.0
+
+    ts = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    bar = Bar(
+        timestamp=ts,
+        open=100.0,
+        high=105.0,
+        low=95.0,
+        close=102.0,
+        volume=1000.0,
+        symbol="AAPL",
+    )
+
+    with caplog.at_level(logging.INFO, logger="akquant"):
+        strategy._on_bar_event(bar, ctx)
+
+    strategy_record = next(
+        record for record in caplog.records if record.name == "akquant.strategy"
+    )
+    assert strategy_record.strategy_id == "alpha"
+    assert strategy_record.slot == "alpha"
+    assert strategy_record.symbol == "AAPL"
+    assert strategy_record.phase == "strategy"
+    assert strategy_record.event_time_str == "2023-01-01 09:30:00"
+    assert str(strategy_record.event_time) == "2023-01-01 09:30:00+08:00"
+
+
+def test_strategy_logging_live_profile_renders_context(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Live profile should render structured context fields in human-readable logs."""
+    configure_logging(LogConfig(profile="live", console=True, level="INFO"))
+    strategy = MyStrategy()
+    cast(Any, strategy)._owner_strategy_id = "alpha"
+    ctx = MagicMock(spec=StrategyContext)
+    ctx.get_position.return_value = 0.0
+
+    ts = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    bar = Bar(
+        timestamp=ts,
+        open=100.0,
+        high=105.0,
+        low=95.0,
+        close=102.0,
+        volume=1000.0,
+        symbol="AAPL",
+    )
+    strategy._on_bar_event(bar, ctx)
+
+    captured = capsys.readouterr()
+    assert "akquant.strategy" in captured.out
+    assert "strategy_id=alpha" in captured.out
+    assert "symbol=AAPL" in captured.out
+    assert "event_time_str=2023-01-01 09:30:00" in captured.out
+
+
+def test_strategy_logging_includes_order_context_during_callbacks(caplog: Any) -> None:
+    """Order/trade callbacks should populate structured order logging fields."""
+    strategy = OrderLoggingStrategy()
+    cast(Any, strategy)._owner_strategy_id = "alpha"
+    ctx = _build_ctx_with_order_and_trade(
+        order_id="order-1",
+        client_order_id="coid-1",
+        symbol="AAPL",
+    )
+
+    ts = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    bar = Bar(
+        timestamp=ts,
+        open=100.0,
+        high=105.0,
+        low=95.0,
+        close=102.0,
+        volume=1000.0,
+        symbol="AAPL",
+    )
+
+    with caplog.at_level(logging.INFO, logger="akquant"):
+        strategy._on_bar_event(bar, ctx)
+
+    order_record = next(
+        record for record in caplog.records if "order:order-1" in record.getMessage()
+    )
+    trade_record = next(
+        record for record in caplog.records if "trade:order-1" in record.getMessage()
+    )
+    assert order_record.phase == "order"
+    assert order_record.strategy_id == "alpha"
+    assert order_record.slot == "alpha"
+    assert order_record.symbol == "AAPL"
+    assert order_record.order_id == "order-1"
+    assert order_record.client_order_id == "coid-1"
+    assert trade_record.phase == "trade"
+    assert trade_record.strategy_id == "alpha"
+    assert trade_record.slot == "alpha"
+    assert trade_record.symbol == "AAPL"
+    assert trade_record.order_id == "order-1"
+    assert trade_record.client_order_id == "coid-1"
+
+
+def test_strategy_logging_live_profile_renders_order_context(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Live profile should render order-related structured fields from callbacks."""
+    configure_logging(LogConfig(profile="live", console=True, level="INFO"))
+    strategy = OrderLoggingStrategy()
+    cast(Any, strategy)._owner_strategy_id = "alpha"
+    ctx = _build_ctx_with_order_and_trade(
+        order_id="order-live-1",
+        client_order_id="coid-live-1",
+        symbol="AAPL",
+    )
+
+    ts = pd.Timestamp("2023-01-01 09:30:00", tz="Asia/Shanghai").value
+    bar = Bar(
+        timestamp=ts,
+        open=100.0,
+        high=105.0,
+        low=95.0,
+        close=102.0,
+        volume=1000.0,
+        symbol="AAPL",
+    )
+    strategy._on_bar_event(bar, ctx)
+
+    captured = capsys.readouterr()
+    assert "order_id=order-live-1" in captured.out
+    assert "client_order_id=coid-live-1" in captured.out
+    assert "phase=order" in captured.out
+    assert "phase=trade" in captured.out
 
 
 def test_strategy_properties() -> None:
@@ -629,6 +781,57 @@ def test_run_backtest_on_reject_fires_once_per_order_id() -> None:
     assert len(rejected_df) == 1
 
 
+class RejectLoggingBacktestStrategy(Strategy):
+    """Strategy used to verify reject callback logging context."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Submit one oversized order to trigger a reject callback."""
+        if self._bar_count == 1:
+            self.buy(symbol=bar.symbol, quantity=10000)
+
+    def on_reject(self, order: Any) -> None:
+        """Emit a strategy log from the reject callback."""
+        self.log(f"reject:{order.id}")
+
+
+def test_run_backtest_reject_logging_includes_order_context(caplog: Any) -> None:
+    """Reject callback logs should include structured order metadata."""
+    bars = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2023-02-01", periods=6, freq="D"),
+            "open": [100.0, 100.2, 100.3, 100.4, 100.5, 100.6],
+            "high": [100.5, 100.7, 100.8, 100.9, 101.0, 101.1],
+            "low": [99.5, 99.7, 99.8, 99.9, 100.0, 100.1],
+            "close": [100.0, 100.1, 100.2, 100.3, 100.4, 100.5],
+            "volume": [1000.0, 1000.0, 1000.0, 1000.0, 1000.0, 1000.0],
+            "symbol": ["STOCK", "STOCK", "STOCK", "STOCK", "STOCK", "STOCK"],
+        }
+    )
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(
+            risk=RiskConfig(safety_margin=0.0001, max_order_value=5000.0)
+        )
+    )
+
+    with caplog.at_level(logging.INFO, logger="akquant"):
+        _ = run_backtest(
+            data=bars,
+            strategy=RejectLoggingBacktestStrategy,
+            symbols=["STOCK"],
+            initial_cash=10000.0,
+            config=config,
+            show_progress=False,
+        )
+
+    reject_record = next(
+        record for record in caplog.records if "reject:" in record.getMessage()
+    )
+    assert reject_record.name == "akquant.strategy"
+    assert reject_record.phase == "order"
+    assert reject_record.symbol == "STOCK"
+    assert reject_record.order_id
+
+
 class SequenceStrategy(Strategy):
     """Strategy for callback sequence assertions."""
 
@@ -657,15 +860,32 @@ class SequenceStrategy(Strategy):
         self.events.append(f"on_trade:{trade.order_id}")
 
 
-def _build_ctx_with_order_and_trade(order_id: str = "o1") -> MagicMock:
+def _build_ctx_with_order_and_trade(
+    order_id: str = "o1",
+    *,
+    client_order_id: str = "coid-1",
+    symbol: str = "AAPL",
+) -> MagicMock:
     """Build a mocked strategy context with one active order and one trade."""
     ctx = MagicMock(spec=StrategyContext)
     ctx.get_position.return_value = 0.0
     ctx.canceled_order_ids = []
     ctx.active_orders = [
-        SimpleNamespace(id=order_id, status="Submitted", filled_quantity=0.0)
+        SimpleNamespace(
+            id=order_id,
+            status="Submitted",
+            filled_quantity=0.0,
+            symbol=symbol,
+            client_order_id=client_order_id,
+        )
     ]
-    ctx.recent_trades = [SimpleNamespace(order_id=order_id)]
+    ctx.recent_trades = [
+        SimpleNamespace(
+            order_id=order_id,
+            symbol=symbol,
+            client_order_id=client_order_id,
+        )
+    ]
     return ctx
 
 


### PR DESCRIPTION
本次提交包含以下核心变更：
1.  版本升级：将项目版本更新至0.2.36，同步更新Cargo.toml、pyproject.toml及Cargo.lock依赖锁文件
2.  日志系统重构：
    - 统一Python侧logger命名为`akquant.<module>`格式，替换原有的`__name__`动态命名
    - 新增Rust侧结构化日志支持，引入`pyo3-log`和`serde_json`依赖，新增`log_context`模块实现日志携带结构化上下文
    - 为策略、风险模块、live运行器等添加结构化日志元数据，支持携带策略ID、标的、订单ID、事件时间等信息
    - 将原有代码中的`eprintln`和`print`输出替换为标准logging日志调用
    - 更新Python侧日志API导出，新增`configure_logging`、`set_log_level`等方法
3.  新增数据源能力：
    - 为`DataFeed`新增`from_csv`、`create_live`、`add_bar`、`add_tick`等API，完善数据源操作
    - 更新中英文文档，补充DataFeed使用指南和日志配置API说明
4.  修复与优化：
    - 修复`strategy_time.py`中的current_time类型检查逻辑，排除bool类型的非法输入
    - 完善策略回调上下文跟踪，在`strategy_framework_hooks`中添加当前回调、订单、交易的状态管理，让`self.log`自动关联对应元数据
    - 新增测试用例验证风险配置日志的结构化上下文输出