### PR TITLE
feat(analysis, backtest, docs): 新增结构化基准分析功能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.37"
+version = "0.2.38"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -32,6 +32,45 @@ result.report(
 )
 ```
 
+### Structured Benchmark Analysis
+
+If you need benchmark comparison outputs for a web frontend, notebook workflow, or offline pipeline, use the structured API instead of reading values from the HTML report:
+
+```python
+benchmark_returns = (
+    benchmark_df.set_index("date")["close"].pct_change().fillna(0.0)
+)
+
+benchmark_analysis = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+summary = benchmark_analysis["summary"]
+series = benchmark_analysis["series"]
+
+print(summary["information_ratio"])
+print(series[:2])
+```
+
+The structured benchmark analysis shares the same alignment and calculation logic as `result.report(..., benchmark=...)`, making it suitable as a long-term frontend/API contract:
+
+- `summary`: aggregate relative metrics
+- `series`: aligned daily time series
+- `meta`: sample count and date range
+- `reason`: explanation when the benchmark input is invalid or cannot be aligned
+
+To persist the analysis:
+
+```python
+result.export_benchmark_analysis(
+    path="artifacts/benchmark_analysis.json",
+    benchmark=benchmark_returns,
+    format="json",
+    curve_freq="D",
+)
+```
+
 This generates a consolidated dashboard including:
 
 - **Equity Curve**: Interactive chart of account equity over time.

--- a/docs/en/guide/visualization.md
+++ b/docs/en/guide/visualization.md
@@ -20,3 +20,57 @@ result.report(
 ```
 
 When `benchmark` is provided, the HTML report adds a benchmark comparison section with strategy/benchmark/excess cumulative curves and relative metrics (total excess, annual excess, tracking error, information ratio, beta, alpha).
+
+## Structured Benchmark Analysis
+
+AKQuant now exposes the benchmark comparison logic as a structured analysis payload that can be reused by web frontends, APIs, and offline pipelines instead of relying on HTML parsing.
+
+```python
+benchmark_returns = (
+    benchmark_df.set_index("date")["close"].pct_change().fillna(0.0)
+)
+
+payload = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+print(payload["schema_version"])
+print(payload["summary"]["annual_excess"])
+print(payload["series"][0])
+```
+
+The payload includes:
+
+- `schema_version`: contract version for downstream consumers
+- `available`: whether benchmark analysis is available
+- `reason`: validation or alignment message when analysis is unavailable
+- `benchmark.label`: display label of the selected benchmark
+- `summary`: aggregate metrics such as `total_excess`, `annual_excess`, `tracking_error`, `information_ratio`, `beta`, and `alpha`
+- `series`: aligned daily points with strategy, benchmark, excess, and cumulative series
+- `meta`: sample count, start/end date, and annualization settings
+
+Recommended practice:
+
+- Prepare the benchmark return series on the backend
+- Call `result.benchmark_analysis(...)` once after the backtest
+- Let the frontend render `summary + series + meta`
+- Reuse the same analysis payload for both `result.report(..., benchmark=...)` and the frontend view
+
+## Export for Frontend or Archival
+
+You can persist the benchmark analysis as part of the backtest artifacts:
+
+```python
+result.export_benchmark_analysis(
+    path="artifacts/benchmark_analysis.json",
+    benchmark=benchmark_returns,
+    format="json",
+    curve_freq="D",
+)
+```
+
+`format="parquet"` is also supported and writes:
+
+- `series.parquet`: aligned benchmark time series
+- `metadata.json`: summary metrics and metadata

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -1084,6 +1084,8 @@ Backtest result object.
 *   `exposure_df(freq="D")`: Portfolio exposure decomposition (net/gross/leverage).
 *   `attribution_df(by="symbol", use_net=True, top_n=None)`: Grouped attribution by symbol/tag.
 *   `capacity_df(freq="D")`: Capacity proxy metrics (order count, fill rates, turnover).
+*   `benchmark_analysis(benchmark=None, curve_freq="raw")`: Return a structured benchmark analysis payload for frontends and APIs.
+*   `export_benchmark_analysis(path, benchmark=None, format="json", curve_freq="raw")`: Persist benchmark analysis as JSON or parquet artifacts.
 *   `orders_by_strategy()`: Strategy-ownership order aggregation by `owner_strategy_id`.
 *   `executions_by_strategy()`: Strategy-ownership execution aggregation by `owner_strategy_id`.
 *   `get_event_stats()`: Unified stream summary stats (for example `processed_events`, `dropped_event_count`, `callback_error_count`, `backpressure_policy`, `stream_mode`).
@@ -1092,6 +1094,18 @@ Backtest result object.
 ```python
 orders_by_strategy = result.orders_by_strategy()
 executions_by_strategy = result.executions_by_strategy()
+benchmark_analysis = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+# Common benchmark_analysis fields:
+# - schema_version, available, reason
+# - benchmark.label
+# - summary.total_excess / annual_excess / tracking_error
+# - summary.information_ratio / beta / alpha
+# - series[*].date / strategy_return / benchmark_return / excess_return
+# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return
 
 # Common columns
 # orders_by_strategy:

--- a/docs/en/textbook/10_analysis.md
+++ b/docs/en/textbook/10_analysis.md
@@ -5,6 +5,7 @@ This chapter is currently maintained in Chinese first.
 - Chinese chapter: [第 10 章：策略评价体系与风险指标](../../zh/textbook/10_analysis.md)
 - Textbook home: [Chinese textbook index](../../zh/textbook/index.md)
 - Note: `BacktestResult` now includes `margin_curve` plus daily curve properties (`*_curve_daily`), and `result.report(curve_freq="D")` for faster long-range HTML reports.
+- Note: benchmark comparison is also available as structured data via `result.benchmark_analysis(...)` and `result.export_benchmark_analysis(...)`.
 - Practice links:
   - Primary example: [examples/textbook/ch10_analysis.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch10_analysis.py)
   - Extended example: [examples/33_report_and_analysis_outputs.py](https://github.com/akfamily/akquant/blob/main/examples/33_report_and_analysis_outputs.py)

--- a/docs/en/textbook/13_visualization.md
+++ b/docs/en/textbook/13_visualization.md
@@ -13,3 +13,5 @@ Key update in this chapter:
 
 - `result.report(..., benchmark=...)` now supports benchmark comparison in the built-in HTML report.
 - The report includes cumulative excess return, annual excess return, tracking error, information ratio, beta, and alpha.
+- `result.benchmark_analysis(...)` exposes the same benchmark logic as a structured payload for frontends and APIs.
+- `result.export_benchmark_analysis(...)` can persist benchmark analysis as JSON or parquet artifacts.

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -192,6 +192,45 @@ result.report(
 )
 ```
 
+### 结构化 Benchmark Analysis
+
+如果你除了 HTML 报告之外，还需要把基准对比结果给前端、Notebook 或离线任务，推荐直接使用结构化接口：
+
+```python
+benchmark_returns = (
+    benchmark_df.set_index("date")["close"].pct_change().fillna(0.0)
+)
+
+benchmark_analysis = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+summary = benchmark_analysis["summary"]
+series = benchmark_analysis["series"]
+
+print(summary["information_ratio"])
+print(series[:2])
+```
+
+结构化 benchmark analysis 与 `result.report(..., benchmark=...)` 共用同一套对齐和计算逻辑，因此适合作为长期数据契约：
+
+- `summary`: 汇总指标
+- `series`: 逐日对齐序列
+- `meta`: 样本数与日期范围
+- `reason`: 输入无效或无重叠区间时的说明
+
+如果你需要把这份结果落盘：
+
+```python
+result.export_benchmark_analysis(
+    path="artifacts/benchmark_analysis.json",
+    benchmark=benchmark_returns,
+    format="json",
+    curve_freq="D",
+)
+```
+
 ### 组合归因与容量分析 (Attribution & Capacity)
 
 `BacktestResult` 提供了可直接用于二次分析的结构化结果：

--- a/docs/zh/guide/visualization.md
+++ b/docs/zh/guide/visualization.md
@@ -20,3 +20,56 @@ result.report(
 ```
 
 报告会新增“基准对比 (Benchmark Comparison)”区块，提供累计超额收益、年化超额收益、跟踪误差、信息比率、Beta、Alpha 等指标，并展示策略/基准/超额三条累计收益曲线。
+
+## 结构化 Benchmark Analysis
+
+从当前版本开始，AKQuant 不再只有 HTML 报告里的基准对比区块，还提供可直接给前端、API 或离线分析复用的结构化 benchmark analysis：
+
+```python
+benchmark_returns = (
+    benchmark_df.set_index("date")["close"].pct_change().fillna(0.0)
+)
+
+payload = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+print(payload["schema_version"])
+print(payload["summary"]["annual_excess"])
+print(payload["series"][0])
+```
+
+返回 payload 主要包含：
+
+- `schema_version`: 数据契约版本
+- `available`: 当前 benchmark analysis 是否可用
+- `reason`: 当 benchmark 无法对齐或输入非法时的原因
+- `benchmark.label`: 基准显示名称
+- `summary`: 汇总指标，如 `total_excess`、`annual_excess`、`tracking_error`、`information_ratio`、`beta`、`alpha`
+- `series`: 对齐后的逐日序列，包含策略收益、基准收益、超额收益及三条累计收益曲线
+- `meta`: 对齐样本数、起止日期、年化因子等元信息
+
+推荐实践：
+
+- 后端负责准备 benchmark 收益率序列并调用 `result.benchmark_analysis(...)`
+- 前端直接消费 `summary + series + meta`
+- `result.report(..., benchmark=...)` 与前端页面应复用同一份 benchmark analysis 逻辑，而不是各自重新计算
+
+## 导出给前端或归档
+
+如果需要把 benchmark analysis 固化为回测产物，可以直接导出：
+
+```python
+result.export_benchmark_analysis(
+    path="artifacts/benchmark_analysis.json",
+    benchmark=benchmark_returns,
+    format="json",
+    curve_freq="D",
+)
+```
+
+也支持 `format="parquet"`，会输出：
+
+- `series.parquet`: 逐点时间序列
+- `metadata.json`: 汇总指标与元信息

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -1160,6 +1160,8 @@ class RiskConfig:
 *   `exposure_df(freq="D")`: 组合暴露分解（净暴露、总暴露、杠杆）。
 *   `attribution_df(by="symbol", use_net=True, top_n=None)`: 按 symbol/tag 做归因汇总。
 *   `capacity_df(freq="D")`: 容量代理指标（订单数、成交率、换手）。
+*   `benchmark_analysis(benchmark=None, curve_freq="raw")`: 返回结构化 benchmark analysis，可直接供前端/API 使用。
+*   `export_benchmark_analysis(path, benchmark=None, format="json", curve_freq="raw")`: 将 benchmark analysis 导出为 JSON 或 parquet 产物。
 *   `orders_by_strategy()`: 按 `owner_strategy_id` 聚合订单统计。
 *   `executions_by_strategy()`: 按 `owner_strategy_id` 聚合成交流水统计。
 *   `get_event_stats()`: 返回流式事件统计摘要（如 `processed_events`、`dropped_event_count`、`callback_error_count`、`backpressure_policy`、`stream_mode`）。
@@ -1168,6 +1170,18 @@ class RiskConfig:
 ```python
 orders_by_strategy = result.orders_by_strategy()
 executions_by_strategy = result.executions_by_strategy()
+benchmark_analysis = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+# benchmark_analysis 常用字段:
+# - schema_version, available, reason
+# - benchmark.label
+# - summary.total_excess / annual_excess / tracking_error
+# - summary.information_ratio / beta / alpha
+# - series[*].date / strategy_return / benchmark_return / excess_return
+# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return
 
 # 常用字段示例
 # orders_by_strategy:

--- a/docs/zh/textbook/10_analysis.md
+++ b/docs/zh/textbook/10_analysis.md
@@ -155,7 +155,15 @@ margin_daily = result.margin_curve_daily
 
 # 报告可选使用日频曲线
 result.report(filename="report_daily.html", curve_freq="D")
+
+# benchmark analysis 也可复用同一频率配置
+benchmark_analysis = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
 ```
+
+当你需要把“策略 vs 沪深300”之类的超额收益结果提供给前端或研究流水线时，优先使用 `result.benchmark_analysis(...)` 或 `result.export_benchmark_analysis(...)`，而不是从 HTML 报告中反向提取数据。
 
 ### 10.5.4 代码示例
 

--- a/docs/zh/textbook/13_visualization.md
+++ b/docs/zh/textbook/13_visualization.md
@@ -109,7 +109,44 @@ result.report(
 - 信息比率 (Information Ratio)
 - Beta / Alpha
 
-### 13.3.3 信用账户强平审计视图
+### 13.3.3 结构化 Benchmark Analysis 与前端复用
+
+长期项目里，更推荐把 benchmark analysis 当成结构化分析资产，而不是只存在于 HTML 报告中。
+
+```python
+benchmark_returns = (
+    benchmark_df.set_index("date")["close"].pct_change().fillna(0.0)
+)
+
+payload = result.benchmark_analysis(
+    benchmark=benchmark_returns,
+    curve_freq="D",
+)
+
+print(payload["summary"])
+print(payload["series"][:2])
+```
+
+推荐做法：
+
+1. 回测结束后由后端调用 `result.benchmark_analysis(...)`
+2. 将 `summary + series + meta` 直接返回给前端
+3. `result.report(..., benchmark=...)` 与前端页面复用同一套 benchmark analysis 逻辑
+
+这样可以避免前端再次计算超额收益、IR、Beta、Alpha，减少口径漂移。
+
+如需把 benchmark analysis 作为回测产物保存：
+
+```python
+result.export_benchmark_analysis(
+    path="artifacts/benchmark_analysis.json",
+    benchmark=benchmark_returns,
+    format="json",
+    curve_freq="D",
+)
+```
+
+### 13.3.4 信用账户强平审计视图
 
 在融资/融券回测中，如果发生维持担保比例触发的强平，`BacktestResult` 会产出结构化审计表：
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.37"
+version = "0.2.38"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/analysis/__init__.py
+++ b/python/akquant/analysis/__init__.py
@@ -1,0 +1,23 @@
+"""Structured analysis helpers for AKQuant results."""
+
+from .benchmark import (
+    benchmark_analysis_from_result,
+    build_benchmark_analysis,
+    build_daily_returns_from_equity,
+    normalize_curve_freq,
+    normalize_returns_series,
+    normalize_returns_series_with_reason,
+    resolve_benchmark_returns,
+    resolve_equity_curve,
+)
+
+__all__ = [
+    "benchmark_analysis_from_result",
+    "build_benchmark_analysis",
+    "build_daily_returns_from_equity",
+    "normalize_curve_freq",
+    "normalize_returns_series",
+    "normalize_returns_series_with_reason",
+    "resolve_benchmark_returns",
+    "resolve_equity_curve",
+]

--- a/python/akquant/analysis/benchmark.py
+++ b/python/akquant/analysis/benchmark.py
@@ -1,0 +1,277 @@
+"""Benchmark analysis helpers shared by reports, exports, and APIs."""
+
+from typing import Any, Optional, Union, cast
+
+import pandas as pd
+
+
+def normalize_curve_freq(curve_freq: str) -> str:
+    """Normalize curve frequency option."""
+    value = str(curve_freq).strip()
+    if value.lower() == "raw":
+        return "raw"
+    if value.upper() == "D":
+        return "D"
+    raise ValueError("curve_freq must be 'raw' or 'D'")
+
+
+def resolve_equity_curve(result: Any, curve_freq: str) -> pd.Series:
+    """Resolve equity curve for analysis rendering."""
+    normalized_curve_freq = normalize_curve_freq(curve_freq)
+    if normalized_curve_freq == "D" and hasattr(result, "equity_curve_daily"):
+        series = cast(pd.Series, result.equity_curve_daily)
+        if not series.empty:
+            return series
+    return cast(pd.Series, result.equity_curve)
+
+
+def build_daily_returns_from_equity(equity_curve: pd.Series) -> pd.Series:
+    """Build daily returns from an equity curve."""
+    if equity_curve.empty:
+        return pd.Series(dtype=float)
+    daily_equity = equity_curve.resample("D").last().ffill()
+    returns = daily_equity.pct_change().fillna(0.0)
+    return cast(pd.Series, returns)
+
+
+def normalize_returns_series_with_reason(
+    series: pd.Series, series_label: str = "收益序列"
+) -> tuple[pd.Series, Optional[str]]:
+    """Normalize returns to a daily index and report validation errors."""
+    cleaned = series.copy()
+    cleaned = pd.to_numeric(cleaned, errors="coerce")
+    cleaned = cast(pd.Series, cleaned.dropna())
+    if cleaned.empty:
+        return cast(pd.Series, cleaned), f"{series_label}为空"
+
+    raw_index = cleaned.index
+    if isinstance(raw_index, pd.RangeIndex):
+        return (
+            pd.Series(dtype=float),
+            f"{series_label}索引必须为日期索引，当前为 RangeIndex",
+        )
+    if not isinstance(raw_index, pd.DatetimeIndex) and pd.api.types.is_numeric_dtype(
+        raw_index.dtype
+    ):
+        return (
+            pd.Series(dtype=float),
+            f"{series_label}索引必须为 DatetimeIndex 或可解析的日期索引",
+        )
+
+    if isinstance(raw_index, pd.DatetimeIndex):
+        dt_index = raw_index
+    else:
+        dt_index = pd.DatetimeIndex(pd.to_datetime(raw_index, errors="coerce"))
+
+    valid_mask = ~pd.isna(dt_index)
+    if not bool(valid_mask.any()):
+        return pd.Series(dtype=float), f"{series_label}索引无法解析为日期"
+
+    cleaned = cleaned.loc[valid_mask].copy()
+    dt_index = dt_index[valid_mask]
+    if dt_index.empty:
+        return pd.Series(dtype=float), f"{series_label}索引无法解析为日期"
+
+    if dt_index.tz is not None:
+        # Preserve the local trading day before dropping timezone info.
+        dt_index = dt_index.tz_localize(None)
+    cleaned.index = dt_index.normalize()
+    cleaned = cast(pd.Series, cleaned.groupby(cleaned.index).last())
+    cleaned = cast(pd.Series, cleaned.sort_index().astype(float))
+    return cleaned, None
+
+
+def normalize_returns_series(series: pd.Series) -> pd.Series:
+    """Normalize return series index to a timezone-naive daily index."""
+    normalized, _ = normalize_returns_series_with_reason(series)
+    return normalized
+
+
+def resolve_benchmark_returns(
+    benchmark: Optional[Union[str, pd.Series]], strategy_returns: pd.Series
+) -> tuple[Optional[pd.Series], str]:
+    """Resolve benchmark input into an aligned return series and label."""
+    if benchmark is None:
+        return None, "未提供基准"
+    if isinstance(benchmark, str):
+        return None, f"暂不支持自动拉取基准: {benchmark}"
+    if not isinstance(benchmark, pd.Series):
+        return None, "基准类型错误，需为 pd.Series 或 str"
+    benchmark_label = (
+        str(benchmark.name)
+        if benchmark.name is not None and str(benchmark.name).strip()
+        else "Benchmark"
+    )
+    benchmark_series, benchmark_reason = normalize_returns_series_with_reason(
+        benchmark, f"基准序列 {benchmark_label}"
+    )
+    if benchmark_reason is not None:
+        return None, benchmark_reason
+    quantile_95 = float(benchmark_series.abs().quantile(0.95))
+    if quantile_95 > 2.0:
+        benchmark_series = cast(pd.Series, benchmark_series.pct_change().fillna(0.0))
+    strategy_series, strategy_reason = normalize_returns_series_with_reason(
+        strategy_returns, "策略收益序列"
+    )
+    if strategy_reason is not None:
+        return None, f"{strategy_reason}，无法对齐基准: {benchmark_label}"
+    if strategy_series.index.intersection(benchmark_series.index).empty:
+        return None, f"策略与基准无重叠区间: {benchmark_label}"
+    return benchmark_series, benchmark_label
+
+
+def _json_value(value: float) -> Optional[float]:
+    """Convert pandas/NaN values to JSON-friendly numbers."""
+    if pd.isna(value):
+        return None
+    return float(value)
+
+
+def _empty_benchmark_analysis(reason: str, benchmark_label: str) -> dict[str, Any]:
+    """Build an empty structured benchmark analysis payload."""
+    return {
+        "schema_version": "1.0",
+        "available": False,
+        "reason": reason,
+        "benchmark": {"label": benchmark_label},
+        "summary": {
+            "total_excess": None,
+            "annual_excess": None,
+            "tracking_error": None,
+            "information_ratio": None,
+            "beta": None,
+            "alpha": None,
+        },
+        "series": [],
+        "meta": {
+            "aligned_points": 0,
+            "start_date": None,
+            "end_date": None,
+            "annual_factor": 252.0,
+        },
+    }
+
+
+def build_benchmark_analysis(
+    strategy_returns: pd.Series,
+    benchmark: Optional[Union[str, pd.Series]],
+    annual_factor: float = 252.0,
+) -> dict[str, Any]:
+    """Build a structured benchmark analysis payload."""
+    benchmark_returns, benchmark_label = resolve_benchmark_returns(
+        benchmark, strategy_returns
+    )
+    if benchmark_returns is None:
+        reason = (
+            "未提供可用基准数据，已跳过相对收益分析。"
+            if benchmark is None
+            else f"未生成基准对比: {benchmark_label}"
+        )
+        return _empty_benchmark_analysis(reason, benchmark_label)
+
+    strategy_series = normalize_returns_series(strategy_returns)
+    aligned = pd.concat(
+        [strategy_series.rename("strategy"), benchmark_returns.rename("benchmark")],
+        axis=1,
+        join="inner",
+    ).dropna()
+    if aligned.empty:
+        return _empty_benchmark_analysis(
+            "策略与基准收益率无可用重叠样本，已跳过对比。",
+            benchmark_label,
+        )
+
+    strategy_aligned = cast(pd.Series, aligned["strategy"].astype(float))
+    benchmark_aligned = cast(pd.Series, aligned["benchmark"].astype(float))
+    excess = cast(pd.Series, strategy_aligned - benchmark_aligned)
+
+    annual_excess = float(excess.mean() * annual_factor)
+    tracking_error = float(excess.std(ddof=0) * (annual_factor**0.5))
+    info_ratio = annual_excess / tracking_error if tracking_error > 0 else float("nan")
+
+    strategy_total = float((1.0 + strategy_aligned).to_numpy(dtype=float).prod())
+    benchmark_total = float((1.0 + benchmark_aligned).to_numpy(dtype=float).prod())
+    total_excess = (
+        strategy_total / benchmark_total - 1.0 if benchmark_total > 0 else float("nan")
+    )
+
+    mean_strategy = float(strategy_aligned.mean())
+    mean_benchmark = float(benchmark_aligned.mean())
+    variance_benchmark = float(benchmark_aligned.var(ddof=0))
+    beta = float("nan")
+    alpha = float("nan")
+    if variance_benchmark > 0:
+        covariance = float(
+            (
+                (strategy_aligned - mean_strategy)
+                * (benchmark_aligned - mean_benchmark)
+            ).mean()
+        )
+        beta = covariance / variance_benchmark
+        alpha = (mean_strategy - beta * mean_benchmark) * annual_factor
+
+    cumulative_strategy = cast(pd.Series, (1.0 + strategy_aligned).cumprod() - 1.0)
+    cumulative_benchmark = cast(pd.Series, (1.0 + benchmark_aligned).cumprod() - 1.0)
+    cumulative_excess = cast(pd.Series, cumulative_strategy - cumulative_benchmark)
+
+    series_records = []
+    series_frame = pd.DataFrame(
+        {
+            "strategy_return": strategy_aligned,
+            "benchmark_return": benchmark_aligned,
+            "excess_return": excess,
+            "strategy_cum_return": cumulative_strategy,
+            "benchmark_cum_return": cumulative_benchmark,
+            "excess_cum_return": cumulative_excess,
+        }
+    )
+    for dt, row in series_frame.iterrows():
+        series_records.append(
+            {
+                "date": cast(pd.Timestamp, dt).strftime("%Y-%m-%d"),
+                "strategy_return": float(row["strategy_return"]),
+                "benchmark_return": float(row["benchmark_return"]),
+                "excess_return": float(row["excess_return"]),
+                "strategy_cum_return": float(row["strategy_cum_return"]),
+                "benchmark_cum_return": float(row["benchmark_cum_return"]),
+                "excess_cum_return": float(row["excess_cum_return"]),
+            }
+        )
+
+    return {
+        "schema_version": "1.0",
+        "available": True,
+        "reason": None,
+        "benchmark": {"label": benchmark_label},
+        "summary": {
+            "total_excess": _json_value(total_excess),
+            "annual_excess": _json_value(annual_excess),
+            "tracking_error": _json_value(tracking_error),
+            "information_ratio": _json_value(info_ratio),
+            "beta": _json_value(beta),
+            "alpha": _json_value(alpha),
+        },
+        "series": series_records,
+        "meta": {
+            "aligned_points": int(len(aligned)),
+            "start_date": cast(pd.Timestamp, aligned.index[0]).strftime("%Y-%m-%d"),
+            "end_date": cast(pd.Timestamp, aligned.index[-1]).strftime("%Y-%m-%d"),
+            "annual_factor": float(annual_factor),
+        },
+    }
+
+
+def benchmark_analysis_from_result(
+    result: Any,
+    benchmark: Optional[Union[str, pd.Series]],
+    curve_freq: str = "raw",
+    annual_factor: float = 252.0,
+) -> dict[str, Any]:
+    """Build structured benchmark analysis directly from a backtest-like result."""
+    equity_curve = resolve_equity_curve(result, curve_freq)
+    strategy_returns = build_daily_returns_from_equity(equity_curve)
+    return build_benchmark_analysis(
+        strategy_returns=strategy_returns,
+        benchmark=benchmark,
+        annual_factor=annual_factor,
+    )

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -1545,6 +1545,57 @@ class BacktestResult:
             return
         raise ValueError("format must be 'json' or 'parquet'")
 
+    def benchmark_analysis(
+        self,
+        benchmark: Optional[Union[str, pd.Series]] = None,
+        curve_freq: str = "raw",
+    ) -> Dict[str, Any]:
+        """Build a structured benchmark analysis payload for APIs and reports."""
+        from ..analysis.benchmark import benchmark_analysis_from_result
+
+        return cast(
+            Dict[str, Any],
+            benchmark_analysis_from_result(
+                result=self,
+                benchmark=benchmark,
+                curve_freq=curve_freq,
+            ),
+        )
+
+    def export_benchmark_analysis(
+        self,
+        path: str,
+        benchmark: Optional[Union[str, pd.Series]] = None,
+        format: str = "json",
+        curve_freq: str = "raw",
+    ) -> None:
+        """Export structured benchmark analysis to json or a parquet bundle."""
+        output_format = str(format).strip().lower()
+        output_path = Path(path)
+        payload = self.benchmark_analysis(
+            benchmark=benchmark,
+            curve_freq=curve_freq,
+        )
+        if output_format == "json":
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(
+                json.dumps(payload, ensure_ascii=True, indent=2),
+                encoding="utf-8",
+            )
+            return
+        if output_format == "parquet":
+            output_path.mkdir(parents=True, exist_ok=True)
+            series_frame = pd.DataFrame(payload.get("series", []))
+            series_frame.to_parquet(output_path / "series.parquet")
+            metadata = dict(payload)
+            metadata.pop("series", None)
+            (output_path / "metadata.json").write_text(
+                json.dumps(metadata, ensure_ascii=True, indent=2),
+                encoding="utf-8",
+            )
+            return
+        raise ValueError("format must be 'json' or 'parquet'")
+
     @staticmethod
     def _json_ready_records(frame: pd.DataFrame) -> List[Dict[str, Any]]:
         records: List[Dict[str, Any]] = []

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -6,6 +6,18 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import pandas as pd
 
+from ..analysis.benchmark import (
+    build_benchmark_analysis as _build_benchmark_analysis,
+)
+from ..analysis.benchmark import (
+    build_daily_returns_from_equity as _build_daily_returns_from_equity,
+)
+from ..analysis.benchmark import (
+    normalize_curve_freq as _normalize_curve_freq,
+)
+from ..analysis.benchmark import (
+    resolve_equity_curve as _resolve_equity_curve,
+)
 from ..utils import format_metric_value
 from .analysis import (
     plot_pnl_vs_duration,
@@ -562,185 +574,27 @@ def _rename_table_columns(df: pd.DataFrame, mapping: dict[str, str]) -> pd.DataF
     return cast(pd.DataFrame, renamed)
 
 
-def _normalize_curve_freq(curve_freq: str) -> str:
-    """Normalize curve frequency option."""
-    value = str(curve_freq).strip()
-    if value.lower() == "raw":
-        return "raw"
-    if value.upper() == "D":
-        return "D"
-    raise ValueError("curve_freq must be 'raw' or 'D'")
-
-
-def _resolve_equity_curve(result: Any, curve_freq: str) -> pd.Series:
-    """Resolve equity curve for report rendering."""
-    if curve_freq == "D" and hasattr(result, "equity_curve_daily"):
-        series = cast(pd.Series, result.equity_curve_daily)
-        if not series.empty:
-            return series
-    return cast(pd.Series, result.equity_curve)
-
-
-def _build_daily_returns_from_equity(equity_curve: pd.Series) -> pd.Series:
-    """Build daily returns from equity curve."""
-    if equity_curve.empty:
-        return pd.Series(dtype=float)
-    daily_equity = equity_curve.resample("D").last().ffill()
-    returns = daily_equity.pct_change().fillna(0.0)
-    return cast(pd.Series, returns)
-
-
-def _normalize_returns_series_with_reason(
-    series: pd.Series, series_label: str = "收益序列"
-) -> tuple[pd.Series, Optional[str]]:
-    """Normalize returns to a daily index and report validation errors."""
-    cleaned = series.copy()
-    cleaned = pd.to_numeric(cleaned, errors="coerce")
-    cleaned = cast(pd.Series, cleaned.dropna())
-    if cleaned.empty:
-        return cast(pd.Series, cleaned), f"{series_label}为空"
-
-    raw_index = cleaned.index
-    if isinstance(raw_index, pd.RangeIndex):
-        return (
-            pd.Series(dtype=float),
-            f"{series_label}索引必须为日期索引，当前为 RangeIndex",
-        )
-    if not isinstance(raw_index, pd.DatetimeIndex) and pd.api.types.is_numeric_dtype(
-        raw_index.dtype
-    ):
-        return (
-            pd.Series(dtype=float),
-            f"{series_label}索引必须为 DatetimeIndex 或可解析的日期索引",
-        )
-
-    if isinstance(raw_index, pd.DatetimeIndex):
-        dt_index = raw_index
-    else:
-        dt_index = pd.DatetimeIndex(pd.to_datetime(raw_index, errors="coerce"))
-
-    valid_mask = ~pd.isna(dt_index)
-    if not bool(valid_mask.any()):
-        return pd.Series(dtype=float), f"{series_label}索引无法解析为日期"
-
-    cleaned = cleaned.loc[valid_mask].copy()
-    dt_index = dt_index[valid_mask]
-    if dt_index.empty:
-        return pd.Series(dtype=float), f"{series_label}索引无法解析为日期"
-
-    if dt_index.tz is not None:
-        # Drop timezone while preserving the local calendar day for daily alignment.
-        dt_index = dt_index.tz_localize(None)
-    cleaned.index = dt_index.normalize()
-    cleaned = cast(pd.Series, cleaned.groupby(cleaned.index).last())
-    cleaned = cast(pd.Series, cleaned.sort_index().astype(float))
-    return cleaned, None
-
-
-def _normalize_returns_series(series: pd.Series) -> pd.Series:
-    """Normalize return series index to timezone-naive daily datetime index."""
-    normalized, _ = _normalize_returns_series_with_reason(series)
-    return normalized
-
-
-def _resolve_benchmark_returns(
-    benchmark: Optional[Union[str, pd.Series]], strategy_returns: pd.Series
-) -> tuple[Optional[pd.Series], str]:
-    """Resolve benchmark input into aligned return series and display label."""
-    if benchmark is None:
-        return None, "未提供基准"
-    if isinstance(benchmark, str):
-        return None, f"暂不支持自动拉取基准: {benchmark}"
-    if not isinstance(benchmark, pd.Series):
-        return None, "基准类型错误，需为 pd.Series 或 str"
-    benchmark_label = (
-        str(benchmark.name)
-        if benchmark.name is not None and str(benchmark.name).strip()
-        else "Benchmark"
-    )
-    benchmark_series, benchmark_reason = _normalize_returns_series_with_reason(
-        benchmark, f"基准序列 {benchmark_label}"
-    )
-    if benchmark_reason is not None:
-        return None, benchmark_reason
-    quantile_95 = float(benchmark_series.abs().quantile(0.95))
-    if quantile_95 > 2.0:
-        benchmark_series = cast(pd.Series, benchmark_series.pct_change().fillna(0.0))
-    strategy_series, strategy_reason = _normalize_returns_series_with_reason(
-        strategy_returns, "策略收益序列"
-    )
-    if strategy_reason is not None:
-        return None, f"{strategy_reason}，无法对齐基准: {benchmark_label}"
-    if strategy_series.index.intersection(benchmark_series.index).empty:
-        return None, f"策略与基准无重叠区间: {benchmark_label}"
-    return benchmark_series, benchmark_label
-
-
 def _build_benchmark_sections(
     strategy_returns: pd.Series,
     benchmark: Optional[Union[str, pd.Series]],
     config: dict[str, Any],
 ) -> dict[str, str]:
     """Build benchmark comparison metrics and chart sections."""
-    benchmark_returns, benchmark_label = _resolve_benchmark_returns(
-        benchmark, strategy_returns
+    payload = _build_benchmark_analysis(
+        strategy_returns=strategy_returns, benchmark=benchmark
     )
-    if benchmark_returns is None:
-        reason = (
-            "未提供可用基准数据，已跳过相对收益分析。"
-            if benchmark is None
-            else f"未生成基准对比: {benchmark_label}"
-        )
-        empty_html = f'<div class="empty-panel">{reason}</div>'
+    if not bool(payload["available"]):
+        empty_html = f'<div class="empty-panel">{payload["reason"]}</div>'
         return {
             "benchmark_metrics_html": empty_html,
             "benchmark_chart_html": empty_html,
         }
-    strategy_series = _normalize_returns_series(strategy_returns)
-    aligned = pd.concat(
-        [strategy_series.rename("strategy"), benchmark_returns.rename("benchmark")],
-        axis=1,
-        join="inner",
-    ).dropna()
-    if aligned.empty:
-        empty_html = (
-            '<div class="empty-panel">'
-            "策略与基准收益率无可用重叠样本，已跳过对比。"
-            "</div>"
-        )
-        return {
-            "benchmark_metrics_html": empty_html,
-            "benchmark_chart_html": empty_html,
-        }
-    strategy_aligned = cast(pd.Series, aligned["strategy"].astype(float))
-    benchmark_aligned = cast(pd.Series, aligned["benchmark"].astype(float))
-    excess = cast(pd.Series, strategy_aligned - benchmark_aligned)
-    annual_factor = 252.0
-    annual_excess = float(excess.mean() * annual_factor)
-    tracking_error = float(excess.std(ddof=0) * (annual_factor**0.5))
-    info_ratio = annual_excess / tracking_error if tracking_error > 0 else float("nan")
-    strategy_total = float((1.0 + strategy_aligned).to_numpy(dtype=float).prod())
-    benchmark_total = float((1.0 + benchmark_aligned).to_numpy(dtype=float).prod())
-    total_excess = (
-        strategy_total / benchmark_total - 1.0 if benchmark_total > 0 else float("nan")
-    )
-    mean_strategy = float(strategy_aligned.mean())
-    mean_benchmark = float(benchmark_aligned.mean())
-    variance_benchmark = float(benchmark_aligned.var(ddof=0))
-    beta = float("nan")
-    alpha = float("nan")
-    if variance_benchmark > 0:
-        covariance = float(
-            (
-                (strategy_aligned - mean_strategy)
-                * (benchmark_aligned - mean_benchmark)
-            ).mean()
-        )
-        beta = covariance / variance_benchmark
-        alpha = (mean_strategy - beta * mean_benchmark) * annual_factor
+    benchmark_label = str(payload["benchmark"]["label"])
+    summary = cast(dict[str, Optional[float]], payload["summary"])
+    series_frame = pd.DataFrame(payload["series"])
 
-    def metric_color(value: float) -> str:
-        if pd.isna(value):
+    def metric_color(value: Optional[float]) -> str:
+        if value is None or pd.isna(value):
             return ""
         if value > 0:
             return "positive"
@@ -748,8 +602,8 @@ def _build_benchmark_sections(
             return "negative"
         return ""
 
-    def metric_fmt(value: float, kind: str) -> str:
-        if pd.isna(value):
+    def metric_fmt(value: Optional[float], kind: str) -> str:
+        if value is None or pd.isna(value):
             return "N/A"
         if kind == "pct":
             return f"{value * 100:.2f}%"
@@ -759,33 +613,35 @@ def _build_benchmark_sections(
         ("基准名称 (Benchmark)", benchmark_label, ""),
         (
             "累计超额收益 (Total Excess)",
-            metric_fmt(total_excess, "pct"),
-            metric_color(total_excess),
+            metric_fmt(summary["total_excess"], "pct"),
+            metric_color(summary["total_excess"]),
         ),
         (
             "年化超额收益 (Annual Excess)",
-            metric_fmt(annual_excess, "pct"),
-            metric_color(annual_excess),
+            metric_fmt(summary["annual_excess"], "pct"),
+            metric_color(summary["annual_excess"]),
         ),
         (
             "跟踪误差 (Tracking Error)",
-            metric_fmt(tracking_error, "pct"),
+            metric_fmt(summary["tracking_error"], "pct"),
             "",
         ),
         (
             "信息比率 (Information Ratio)",
-            metric_fmt(info_ratio, "ratio"),
-            metric_color(info_ratio),
+            metric_fmt(summary["information_ratio"], "ratio"),
+            metric_color(summary["information_ratio"]),
         ),
         (
             "Beta",
-            metric_fmt(beta, "ratio"),
-            metric_color(beta - 1.0 if not pd.isna(beta) else beta),
+            metric_fmt(summary["beta"], "ratio"),
+            metric_color(
+                None if summary["beta"] is None else cast(float, summary["beta"]) - 1.0
+            ),
         ),
         (
             "Alpha (Annual)",
-            metric_fmt(alpha, "pct"),
-            metric_color(alpha),
+            metric_fmt(summary["alpha"], "pct"),
+            metric_color(summary["alpha"]),
         ),
     ]
     metrics_html = ""
@@ -794,15 +650,12 @@ def _build_benchmark_sections(
             f'<div class="metric-card"><div class="metric-value {color_cls}">{value}'
             f'</div><div class="metric-label">{label}</div></div>'
         )
-    cumulative_strategy = cast(pd.Series, (1.0 + strategy_aligned).cumprod() - 1.0)
-    cumulative_benchmark = cast(pd.Series, (1.0 + benchmark_aligned).cumprod() - 1.0)
-    cumulative_excess = cast(pd.Series, cumulative_strategy - cumulative_benchmark)
     go = __import__("plotly.graph_objects", fromlist=["Figure"])
     fig = go.Figure()
     fig.add_trace(
         go.Scatter(
-            x=cumulative_strategy.index,
-            y=cumulative_strategy,
+            x=series_frame["date"],
+            y=series_frame["strategy_cum_return"],
             mode="lines",
             name="策略累计收益",
             line=dict(color="#1f77b4", width=2),
@@ -810,8 +663,8 @@ def _build_benchmark_sections(
     )
     fig.add_trace(
         go.Scatter(
-            x=cumulative_benchmark.index,
-            y=cumulative_benchmark,
+            x=series_frame["date"],
+            y=series_frame["benchmark_cum_return"],
             mode="lines",
             name=f"基准累计收益 ({benchmark_label})",
             line=dict(color="#7f8c8d", width=2, dash="dash"),
@@ -819,8 +672,8 @@ def _build_benchmark_sections(
     )
     fig.add_trace(
         go.Scatter(
-            x=cumulative_excess.index,
-            y=cumulative_excess,
+            x=series_frame["date"],
+            y=series_frame["excess_cum_return"],
             mode="lines",
             name="累计超额收益",
             line=dict(color="#c0392b", width=2),

--- a/tests/test_report_helpers.py
+++ b/tests/test_report_helpers.py
@@ -1,10 +1,14 @@
 import pandas as pd
+from akquant.analysis.benchmark import (
+    benchmark_analysis_from_result,
+    build_benchmark_analysis,
+    normalize_returns_series,
+    resolve_benchmark_returns,
+)
 from akquant.plot.report import (
     _build_analysis_table_sections,
     _build_metrics_html,
     _build_summary_context,
-    _normalize_returns_series,
-    _resolve_benchmark_returns,
 )
 from akquant.utils import format_metric_value
 
@@ -213,7 +217,7 @@ def test_normalize_returns_series_preserves_local_calendar_day() -> None:
     idx = pd.date_range("2023-01-01", periods=3, freq="D", tz="Asia/Shanghai")
     series = pd.Series([0.0, 0.01, -0.02], index=idx)
 
-    normalized = _normalize_returns_series(series)
+    normalized = normalize_returns_series(series)
 
     expected_idx = pd.date_range("2023-01-01", periods=3, freq="D")
     pd.testing.assert_index_equal(normalized.index, expected_idx)
@@ -225,8 +229,47 @@ def test_resolve_benchmark_returns_rejects_range_index() -> None:
     strategy_returns = pd.Series([0.0, 0.01, -0.02], index=strategy_idx)
     benchmark_returns = pd.Series([0.0, 0.005, -0.001], name="RANGE_BENCH")
 
-    resolved, reason = _resolve_benchmark_returns(benchmark_returns, strategy_returns)
+    resolved, reason = resolve_benchmark_returns(benchmark_returns, strategy_returns)
 
     assert resolved is None
     assert "RangeIndex" in reason
     assert "日期索引" in reason
+
+
+def test_build_benchmark_analysis_returns_structured_payload() -> None:
+    """Structured benchmark analysis should expose summary and aligned series."""
+    strategy_idx = pd.date_range("2023-01-01", periods=3, freq="D", tz="Asia/Shanghai")
+    strategy_returns = pd.Series([0.0, 0.01, -0.02], index=strategy_idx)
+    benchmark_returns = pd.Series(
+        [0.0, 0.005, -0.01],
+        index=pd.date_range("2023-01-01", periods=3, freq="D"),
+        name="CSI300",
+    )
+
+    payload = build_benchmark_analysis(strategy_returns, benchmark_returns)
+
+    assert payload["schema_version"] == "1.0"
+    assert payload["available"] is True
+    assert payload["benchmark"]["label"] == "CSI300"
+    assert payload["meta"]["aligned_points"] == 3
+    assert payload["meta"]["start_date"] == "2023-01-01"
+    assert payload["meta"]["end_date"] == "2023-01-03"
+    assert payload["summary"]["tracking_error"] is not None
+    assert payload["series"][0]["date"] == "2023-01-01"
+    assert payload["series"][-1]["excess_cum_return"] is not None
+
+
+def test_benchmark_analysis_from_result_uses_equity_curve() -> None:
+    """Benchmark analysis from result should derive returns from the equity curve."""
+    result = DummyResult(with_data=True)
+    benchmark_returns = pd.Series(
+        [0.0, 0.005],
+        index=pd.date_range("2023-01-01", periods=2, freq="D"),
+        name="CSI300",
+    )
+
+    payload = benchmark_analysis_from_result(result, benchmark_returns)
+
+    assert payload["available"] is True
+    assert payload["benchmark"]["label"] == "CSI300"
+    assert payload["meta"]["aligned_points"] == 2

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -387,6 +387,37 @@ def test_report_aligns_naive_benchmark_dates_without_notice(tmp_path: Path) -> N
     assert "基准序列 NAIVE_BENCH 索引必须为日期索引" not in html
 
 
+def test_backtest_result_exposes_structured_benchmark_analysis() -> None:
+    """BacktestResult should expose benchmark analysis for non-HTML consumers."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=RoundTripStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+    benchmark_returns = pd.Series(
+        [0.0, 0.001, -0.0005, 0.0008, 0.0],
+        index=pd.date_range("2023-01-01", periods=5, freq="D"),
+        name="CSI300",
+    )
+
+    payload = result.benchmark_analysis(benchmark=benchmark_returns, curve_freq="D")
+
+    assert payload["schema_version"] == "1.0"
+    assert payload["available"] is True
+    assert payload["benchmark"]["label"] == "CSI300"
+    assert payload["summary"]["information_ratio"] is not None
+    assert payload["meta"]["aligned_points"] > 0
+    assert payload["series"][0]["date"] == "2023-01-01"
+
+
 def test_report_shows_notice_for_range_index_benchmark(tmp_path: Path) -> None:
     """RangeIndex benchmark input should render a clear validation notice."""
     _skip_if_no_plotly()


### PR DESCRIPTION
新增标准化的基准收益分析能力，无需从HTML报告中提取数据：
- 创建`akquant.analysis.benchmark`模块，封装收益对齐、指标计算、结构化输出等核心逻辑
- 为`BacktestResult`类新增`benchmark_analysis`和`export_benchmark_analysis`方法，支持直接获取结构化基准分析结果，以及导出为JSON/Parquet格式的归档文件
- 重构原`plot.report`模块中的基准分析代码，复用新的共享分析逻辑以消除重复实现
- 更新全量中英文文档，包括教程、API参考、使用指南，新增结构化基准分析的使用说明与示例
- 新增配套测试用例，验证功能的正确性与边界情况处理