### PR TITLE
新功能(回测,引擎): 升级版本至0.2.39, 支持多符号DataFrame热启动并修复回测指标

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.38"
+version = "0.2.39"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.38"
+version = "0.2.39"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -4475,12 +4475,55 @@ def run_warm_start(
         data_map = {}
         # Copied logic from run_backtest for data loading
         if isinstance(data, pd.DataFrame):
-            if len(symbols) == 1:
-                data_map = {symbols[0]: data}
+            df_input = data
+            if not isinstance(df_input.index, pd.DatetimeIndex):
+                found_date = False
+                for col in ["date", "timestamp", "datetime", "Date", "Timestamp"]:
+                    if col in df_input.columns:
+                        df_input = df_input.set_index(col)
+                        found_date = True
+                        break
+
+                if not found_date:
+                    try:
+                        df_input.index = pd.to_datetime(df_input.index)
+                    except Exception:
+                        pass
+
+            if df_input.index.dtype == "object":
+                try:
+                    df_input.index = pd.to_datetime(df_input.index)
+                except Exception:
+                    pass
+
+            if isinstance(df_input.index, pd.DatetimeIndex):
+                df_input = _filter_datetime_index_frame_by_runtime_window(
+                    df_input,
+                    kwargs.get("start_time"),
+                    kwargs.get("end_time"),
+                    timezone_name,
+                )
+
+            df_prepared = prepare_dataframe(df_input)
+            if "symbol" in df_prepared.columns:
+                df_prepared = df_prepared.copy()
+                df_prepared["symbol"] = df_prepared["symbol"].astype(str)
+                filter_symbols = bool(symbols and "BENCHMARK" not in symbols)
+                if filter_symbols:
+                    df_prepared = df_prepared[df_prepared["symbol"].isin(symbols)]
+                if not df_prepared.empty:
+                    grouped = df_prepared.groupby("symbol", sort=False)
+                    data_map = {
+                        str(grouped_symbol): grouped_df.copy()
+                        for grouped_symbol, grouped_df in grouped
+                    }
+            elif len(symbols) == 1:
+                data_map = {symbols[0]: df_prepared}
             else:
-                # Multi-index or strict format required?
-                # For simplicity, assume single symbol if passed as DF
-                data_map = {symbols[0]: data}
+                raise ValueError(
+                    "Warm start multi-symbol DataFrame input must contain "
+                    "a 'symbol' column"
+                )
         elif isinstance(data, list) and data and isinstance(data[0], Bar):
             # Convert List[Bar] to DataFrame for indicators
             # We assume all bars are for the same symbol (or single symbol context)
@@ -5336,6 +5379,16 @@ def run_warm_start(
     if hasattr(engine, "set_stock_fee_rules"):
         engine.set_stock_fee_rules(commission, stamp_tax, transfer_fee, min_commission)
         logger.info(f"Re-configured market fees: comm={commission}, stamp={stamp_tax}")
+    restored_initial_market_value = float(restored_cash)
+    if hasattr(engine, "get_account_metrics"):
+        try:
+            account_metrics = cast(Any, engine).get_account_metrics()
+            if isinstance(account_metrics, tuple) and len(account_metrics) >= 1:
+                restored_initial_market_value = float(account_metrics[0])
+        except Exception:
+            restored_initial_market_value = float(restored_cash)
+    if hasattr(engine, "set_initial_cash_reference"):
+        cast(Any, engine).set_initial_cash_reference(restored_initial_market_value)
     resolved_policy_warm_start: Optional[ResolvedExecutionPolicy] = None
     if has_fill_policy_override:
         resolved_policy_warm_start = _resolve_execution_policy(
@@ -5473,9 +5526,6 @@ def run_warm_start(
                         ),
                     )
 
-    # 注意：这里的 initial_cash 可能不准确，因为它使用的是当前 cash
-    # 但对于 BacktestResult 来说，重要的是 equity curve 的连续性
-    # 我们使用之前捕获的 restored_cash 作为 reference
     result = BacktestResult(
         engine.get_results(),
         timezone=timezone_name,
@@ -5484,6 +5534,10 @@ def run_warm_start(
         engine=engine,
         indicator_outputs=indicator_recorder.build_payload(),
     )
+    try:
+        result.initial_cash = float(result.metrics.initial_market_value)
+    except Exception:
+        pass
     _attach_result_runtime_metadata(
         result=result,
         engine_summary=engine_summary,

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -247,15 +247,6 @@ class BacktestResult:
                 self._initial_cash = initial_cash
 
             def __getattr__(self, name: str) -> Any:
-                # Override initial_market_value if we have a valid initial_cash
-                if name == "initial_market_value" and self._initial_cash > 0:
-                    return self._initial_cash
-
-                # Recalculate total_return based on corrected initial_market_value
-                if name == "total_return" and self._initial_cash > 0:
-                    end_val = getattr(self._raw, "end_market_value")
-                    return (end_val - self._initial_cash) / self._initial_cash
-
                 val = getattr(self._raw, name)
                 if name in ["start_time", "end_time"]:
                     # Convert ns timestamp to datetime

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -592,6 +592,11 @@ impl Engine {
             current_time: self.clock.timestamp().unwrap_or(0),
             portfolio: self.state.portfolio.clone(),
             order_manager: self.state.order_manager.clone(),
+            last_prices: self.last_prices.clone(),
+            instruments: self.instruments.clone(),
+            initial_cash: Some(self.initial_cash),
+            margin_accrued_interest: self.margin_accrued_interest,
+            margin_daily_interest: self.margin_daily_interest,
             history_state,
             strategy_risk_state: crate::engine::state::StrategyRiskStateSnapshot {
                 default_strategy_id: self.default_strategy_id.clone(),
@@ -639,6 +644,11 @@ impl Engine {
 
         self.state.portfolio = snapshot.portfolio;
         self.state.order_manager = snapshot.order_manager;
+        self.last_prices = snapshot.last_prices;
+        self.instruments = snapshot.instruments;
+        self.initial_cash = snapshot.initial_cash.unwrap_or(self.state.portfolio.cash);
+        self.margin_accrued_interest = snapshot.margin_accrued_interest;
+        self.margin_daily_interest = snapshot.margin_daily_interest;
         let history_buffer = snapshot
             .history_state
             .map(crate::history::HistoryBuffer::from);
@@ -1049,6 +1059,14 @@ impl Engine {
         let val = Decimal::from_f64(cash).unwrap_or(Decimal::ZERO);
         self.state.portfolio.cash = val;
         self.initial_cash = val;
+    }
+
+    /// 设置绩效统计使用的初始基线资金，不修改当前组合现金
+    ///
+    /// :param cash: 作为绩效基线的初始权益
+    /// :type cash: float
+    pub fn set_initial_cash_reference(&mut self, cash: f64) {
+        self.initial_cash = Decimal::from_f64(cash).unwrap_or(Decimal::ZERO);
     }
 
     /// 添加数据源

--- a/src/engine/state.rs
+++ b/src/engine/state.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::data::DataFeed;
 use crate::history::HistoryBufferSnapshot;
+use crate::model::Instrument;
 use crate::order_manager::OrderManager;
 use crate::portfolio::Portfolio;
 
@@ -35,6 +36,16 @@ pub struct EngineSnapshot {
     pub current_time: i64,
     pub portfolio: Portfolio,
     pub order_manager: OrderManager,
+    #[serde(default)]
+    pub last_prices: HashMap<String, Decimal>,
+    #[serde(default)]
+    pub instruments: HashMap<String, Instrument>,
+    #[serde(default)]
+    pub initial_cash: Option<Decimal>,
+    #[serde(default)]
+    pub margin_accrued_interest: Decimal,
+    #[serde(default)]
+    pub margin_daily_interest: Decimal,
     #[serde(default)]
     pub history_state: Option<HistoryBufferSnapshot>,
     #[serde(default)]

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -2854,6 +2854,29 @@ class WarmStartMultiSymbolStrategy(Strategy):
         self.by_symbol[bar.symbol] = self.by_symbol.get(bar.symbol, 0) + 1
 
 
+class WarmStartMultiSymbolDataFrameStrategy(Strategy):
+    """Strategy for multi-symbol dataframe warm-start regression tests."""
+
+    def __init__(self) -> None:
+        """Initialize deterministic event capture."""
+        self.set_history_depth(2)
+        self.records: list[tuple[int, str, str, float | None, float | None]] = []
+
+    def on_bar(self, bar: Bar) -> None:
+        """Capture symbol resolution and per-symbol close history."""
+        aaa_last = float(self.get_history(1, symbol="AAA", field="close")[-1])
+        bbb_last = float(self.get_history(1, symbol="BBB", field="close")[-1])
+        self.records.append(
+            (
+                int(bar.timestamp),
+                str(bar.symbol),
+                str(self.symbol),
+                None if np.isnan(aaa_last) else aaa_last,
+                None if np.isnan(bbb_last) else bbb_last,
+            )
+        )
+
+
 def _make_symbol_df(
     symbol: str,
     start: str,
@@ -2873,6 +2896,16 @@ def _make_symbol_df(
             "volume": [1000.0 + float(i) for i in range(periods)],
             "symbol": [symbol] * periods,
         }
+    )
+
+
+def _combine_symbol_frames(*frames: pd.DataFrame) -> pd.DataFrame:
+    """Combine symbol frames into one timestamp-sorted long dataframe."""
+    return cast(
+        pd.DataFrame,
+        pd.concat(list(frames), ignore_index=True)
+        .sort_values(["timestamp", "symbol"])
+        .reset_index(drop=True),
     )
 
 
@@ -2913,6 +2946,115 @@ def test_run_warm_start_multi_symbol_continuity(tmp_path: Path) -> None:
     resume_idx = strategy.events.index("on_resume")
     assert strategy.events[resume_idx + 1] == "on_start"
     assert result2.metrics.initial_market_value == result1.metrics.end_market_value
+
+
+def test_run_warm_start_multi_symbol_dataframe_continuity(tmp_path: Path) -> None:
+    """Warm start should preserve symbol routing for multi-symbol dataframe input."""
+    checkpoint = tmp_path / "snapshot_multi_dataframe.pkl"
+    phase1_aaa = _make_symbol_df("AAA", "2023-01-01", 3, 100.0)
+    phase1_bbb = _make_symbol_df("BBB", "2023-01-01", 3, 200.0)
+    phase2_aaa = _make_symbol_df("AAA", "2023-01-04", 2, 103.0)
+    phase2_bbb = _make_symbol_df("BBB", "2023-01-04", 2, 203.0)
+    phase1 = _combine_symbol_frames(phase1_aaa, phase1_bbb)
+    phase2 = _combine_symbol_frames(phase2_aaa, phase2_bbb)
+    full = _combine_symbol_frames(phase1, phase2)
+
+    full_result = run_backtest(
+        data=full,
+        strategy=WarmStartMultiSymbolDataFrameStrategy,
+        symbols=["AAA", "BBB"],
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    result1 = run_backtest(
+        data=phase1,
+        strategy=WarmStartMultiSymbolDataFrameStrategy,
+        symbols=["AAA", "BBB"],
+        initial_cash=100000.0,
+        show_progress=False,
+    )
+    save_snapshot(result1.engine, result1.strategy, str(checkpoint))  # type: ignore[arg-type]
+
+    warm_result = run_warm_start(
+        checkpoint_path=str(checkpoint),
+        data=phase2,
+        symbols=["AAA", "BBB"],
+        show_progress=False,
+    )
+
+    full_strategy = full_result.strategy
+    warm_strategy = warm_result.strategy
+    assert full_strategy is not None
+    assert warm_strategy is not None
+    assert warm_strategy.records == full_strategy.records
+    assert all(
+        bar_symbol == self_symbol
+        for _, bar_symbol, self_symbol, _, _ in warm_strategy.records
+    )
+
+
+class WarmStartOpenPositionMetricsStrategy(Strategy):
+    """Strategy for open-position warm-start metric continuity tests."""
+
+    def __init__(self) -> None:
+        """Initialize deterministic trading state."""
+        self.submitted = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Open one futures position and keep it across warm start."""
+        if not self.submitted:
+            self.buy(symbol="FUT", quantity=1.0)
+            self.submitted = True
+
+
+def test_run_warm_start_open_position_preserves_initial_market_value(
+    tmp_path: Path,
+) -> None:
+    """Warm start should use prior end equity as the new initial market value."""
+    checkpoint = tmp_path / "snapshot_open_position.pkl"
+    phase1 = _make_bars("2023-01-01", 3, symbol="FUT", start_price=100.0)
+    phase2 = _make_bars("2023-01-04", 2, symbol="FUT", start_price=103.0)
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(exit_on_last_bar=False),
+        instruments_config=[
+            InstrumentConfig(
+                symbol="FUT",
+                asset_type="FUTURES",
+                multiplier=10.0,
+                margin_ratio=0.1,
+                tick_size=0.2,
+            )
+        ],
+    )
+
+    result1 = run_backtest(
+        data=phase1,
+        strategy=WarmStartOpenPositionMetricsStrategy,
+        symbols="FUT",
+        initial_cash=100000.0,
+        show_progress=False,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        config=config,
+    )
+    save_snapshot(result1.engine, result1.strategy, str(checkpoint))  # type: ignore[arg-type]
+
+    result2 = run_warm_start(
+        checkpoint_path=str(checkpoint),
+        data=phase2,
+        symbols="FUT",
+        show_progress=False,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        config=config,
+    )
+
+    assert result1.metrics.end_market_value > result1.strategy.get_account()["cash"]  # type: ignore[union-attr]
+    assert result2.metrics.initial_market_value == pytest.approx(
+        result1.metrics.end_market_value
+    )
+    assert result2.metrics.total_return == pytest.approx(
+        (result2.metrics.end_market_value - result2.metrics.initial_market_value)
+        / result2.metrics.initial_market_value
+    )
 
 
 class WarmStartEventIdempotencyStrategy(Strategy):


### PR DESCRIPTION
- 将包版本从0.2.38升级至0.2.39
- 为引擎快照新增last_prices、instruments、初始现金及保证金利息相关字段
- 新增set_initial_cash_reference方法用于设置绩效统计的参考初始资金
- 完善热启动流程的多符号DataFrame输入处理,自动解析日期索引并按符号分组
- 修正BacktestResult的初始市值与总收益率计算逻辑,移除旧的属性重载代码
- 新增多符号DataFrame热启动与持仓热启动指标连续性的测试用例
- 修复热启动时初始参考资金的恢复与设置逻辑