### PR TITLE
fix(trade): 修正合约乘数PNL计算逻辑并升级版本至0.2.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.39"
+version = "0.2.40"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.39"
+version = "0.2.40"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.39"
+version = "0.2.40"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/account.rs
+++ b/src/account.rs
@@ -106,7 +106,7 @@ pub fn calculate_account_metrics(
         let multiplier = instrument.multiplier();
         let notional = quantity.abs() * price * multiplier;
         if is_futures_margin_account(instrument, risk_config) {
-            let unrealized = trade_tracker.get_unrealized_pnl(symbol, price, multiplier);
+            let unrealized = trade_tracker.get_unrealized_pnl(symbol, price);
             let margin = crate::margin::MarginEngine::position_margin(
                 *quantity,
                 price,

--- a/src/analysis/tests.rs
+++ b/src/analysis/tests.rs
@@ -33,9 +33,17 @@ fn analyze_trades(
     trades: Vec<Trade>,
     current_prices: Option<HashMap<String, Decimal>>,
 ) -> (TradePnL, Vec<ClosedTrade>) {
+    analyze_trades_with_multiplier(trades, current_prices, Decimal::ONE)
+}
+
+fn analyze_trades_with_multiplier(
+    trades: Vec<Trade>,
+    current_prices: Option<HashMap<String, Decimal>>,
+    multiplier: Decimal,
+) -> (TradePnL, Vec<ClosedTrade>) {
     let mut tracker = TradeTracker::new();
     for trade in trades {
-        tracker.process_trade(&trade, None, None, Decimal::ZERO);
+        tracker.process_trade(&trade, multiplier, None, None, Decimal::ZERO);
     }
     (
         tracker.calculate_pnl(current_prices),
@@ -96,6 +104,34 @@ fn test_trade_analyzer_short_loss() {
 }
 
 #[test]
+fn test_trade_analyzer_respects_contract_multiplier_for_closed_trade() {
+    let t1 = create_trade(
+        "RB2310",
+        OrderSide::Buy,
+        Decimal::ONE,
+        Decimal::from(4000),
+        Decimal::ZERO,
+    );
+    let t2 = create_trade(
+        "RB2310",
+        OrderSide::Sell,
+        Decimal::ONE,
+        Decimal::from(4010),
+        Decimal::ZERO,
+    );
+
+    let (pnl, closed_trades) =
+        analyze_trades_with_multiplier(vec![t1, t2], None, Decimal::from(10));
+
+    assert_eq!(pnl.gross_pnl, 100.0);
+    assert_eq!(pnl.net_pnl, 100.0);
+    assert_eq!(closed_trades.len(), 1);
+    assert_eq!(closed_trades[0].pnl, 100.0);
+    assert_eq!(closed_trades[0].net_pnl, 100.0);
+    assert!((closed_trades[0].return_pct - 0.25).abs() < 1e-9);
+}
+
+#[test]
 fn test_trade_analyzer_fifo() {
     // Buy 100 @ 10
     // Buy 100 @ 12
@@ -146,6 +182,25 @@ fn test_unrealized_pnl() {
 
     assert_eq!(pnl.total_closed_trades, 0);
     assert_eq!(pnl.unrealized_pnl, 500.0); // (15-10)*100
+}
+
+#[test]
+fn test_unrealized_pnl_respects_contract_multiplier() {
+    let t1 = create_trade(
+        "RB2310",
+        OrderSide::Buy,
+        Decimal::ONE,
+        Decimal::from(4000),
+        Decimal::ZERO,
+    );
+
+    let mut prices = HashMap::new();
+    prices.insert("RB2310".to_string(), Decimal::from(4010));
+
+    let (pnl, _) = analyze_trades_with_multiplier(vec![t1], Some(prices), Decimal::from(10));
+
+    assert_eq!(pnl.total_closed_trades, 0);
+    assert_eq!(pnl.unrealized_pnl, 100.0);
 }
 
 #[test]

--- a/src/analysis/tracker.rs
+++ b/src/analysis/tracker.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 pub struct TradeEntry {
     pub quantity: Decimal,
     pub price: Decimal,
+    pub multiplier: Decimal,
     pub commission: Decimal,
     pub bar_idx: usize,
     pub timestamp: i64,
@@ -89,21 +90,20 @@ impl TradeTracker {
         &self,
         symbol: &str,
         current_price: Decimal,
-        multiplier: Decimal,
     ) -> Decimal {
         let mut pnl = Decimal::ZERO;
 
         // Long positions: (Price - Entry) * Qty * Multiplier
         if let Some(queue) = self.long_inventory.get(symbol) {
             for entry in queue {
-                pnl += (current_price - entry.price) * entry.quantity * multiplier;
+                pnl += (current_price - entry.price) * entry.quantity * entry.multiplier;
             }
         }
 
         // Short positions: (Entry - Price) * Qty * Multiplier
         if let Some(queue) = self.short_inventory.get(symbol) {
             for entry in queue {
-                pnl += (entry.price - current_price) * entry.quantity * multiplier;
+                pnl += (entry.price - current_price) * entry.quantity * entry.multiplier;
             }
         }
 
@@ -113,6 +113,7 @@ impl TradeTracker {
     pub fn process_trade(
         &mut self,
         trade: &Trade,
+        multiplier: Decimal,
         order_tag: Option<&str>,
         history: Option<&SymbolHistory>,
         portfolio_value: Decimal,
@@ -139,10 +140,12 @@ impl TradeTracker {
                         let covered_qty = remaining_qty.min(match_entry.quantity);
 
                         // Short PnL = (Entry Price - Exit Price) * Qty
-                        let pnl = (match_entry.price - price) * covered_qty;
+                        let pnl =
+                            (match_entry.price - price) * covered_qty * match_entry.multiplier;
                         self.total_pnl += pnl;
 
-                        let entry_val = match_entry.price * covered_qty;
+                        let entry_val =
+                            match_entry.price * covered_qty * match_entry.multiplier;
                         let ret_pct = if !entry_val.is_zero() {
                             pnl / entry_val
                         } else {
@@ -345,6 +348,7 @@ impl TradeTracker {
                         .push_back(TradeEntry {
                             quantity: remaining_qty,
                             price,
+                            multiplier,
                             commission: remaining_comm,
                             bar_idx,
                             timestamp,
@@ -361,10 +365,12 @@ impl TradeTracker {
                         let covered_qty = remaining_qty.min(match_entry.quantity);
 
                         // Long PnL = (Exit Price - Entry Price) * Qty
-                        let pnl = (price - match_entry.price) * covered_qty;
+                        let pnl =
+                            (price - match_entry.price) * covered_qty * match_entry.multiplier;
                         self.total_pnl += pnl;
 
-                        let entry_val = match_entry.price * covered_qty;
+                        let entry_val =
+                            match_entry.price * covered_qty * match_entry.multiplier;
                         let ret_pct = if !entry_val.is_zero() {
                             pnl / entry_val
                         } else {
@@ -560,6 +566,7 @@ impl TradeTracker {
                         .push_back(TradeEntry {
                             quantity: remaining_qty,
                             price,
+                            multiplier,
                             commission: remaining_comm,
                             bar_idx,
                             timestamp,
@@ -605,14 +612,16 @@ impl TradeTracker {
             for (symbol, inventory) in &self.long_inventory {
                 if let Some(price) = prices.get(symbol) {
                     for entry in inventory {
-                        unrealized_pnl += (*price - entry.price) * entry.quantity;
+                        unrealized_pnl +=
+                            (*price - entry.price) * entry.quantity * entry.multiplier;
                     }
                 }
             }
             for (symbol, inventory) in &self.short_inventory {
                 if let Some(price) = prices.get(symbol) {
                     for entry in inventory {
-                        unrealized_pnl += (entry.price - *price) * entry.quantity;
+                        unrealized_pnl +=
+                            (entry.price - *price) * entry.quantity * entry.multiplier;
                     }
                 }
             }

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -128,6 +128,11 @@ mod tests {
             current_time: 123456789,
             portfolio,
             order_manager,
+            last_prices: HashMap::new(),
+            instruments: HashMap::new(),
+            initial_cash: Some(Decimal::from(50000)),
+            margin_accrued_interest: Decimal::ZERO,
+            margin_daily_interest: Decimal::ZERO,
             history_state: Some(HistoryBufferSnapshot {
                 data: HashMap::new(),
                 default_capacity: 3,
@@ -140,6 +145,9 @@ mod tests {
 
         assert_eq!(decoded.current_time, 123456789);
         assert_eq!(decoded.portfolio.cash, Decimal::from(50000));
+        assert_eq!(decoded.initial_cash, Some(Decimal::from(50000)));
+        assert!(decoded.last_prices.is_empty());
+        assert!(decoded.instruments.is_empty());
         assert_eq!(
             decoded
                 .history_state

--- a/src/order_manager.rs
+++ b/src/order_manager.rs
@@ -382,9 +382,9 @@ impl OrderManager {
 
             // 3. Update Portfolio
             portfolio.adjust_cash(-trade.commission);
+            let multiplier = instr_opt.map_or(Decimal::ONE, |instr| instr.multiplier());
 
             if let Some(instr) = instr_opt {
-                let multiplier = instr.multiplier();
                 if is_futures_margin_account(instr, risk_config) {
                     let realized = estimate_futures_realized_pnl(
                         &self.trade_tracker,
@@ -471,7 +471,7 @@ impl OrderManager {
             .equity;
 
             self.trade_tracker
-                .process_trade(&trade, order_tag, symbol_history, portfolio_value);
+                .process_trade(&trade, multiplier, order_tag, symbol_history, portfolio_value);
 
             // 6. Record Trade
             self.trades.push(trade.clone());

--- a/src/settlement/manager.rs
+++ b/src/settlement/manager.rs
@@ -458,7 +458,13 @@ fn apply_liquidation_trade_simulation(
     let portfolio_value =
         calculate_account_metrics(portfolio, prices, instruments, trade_tracker, risk_config)
             .equity;
-    trade_tracker.process_trade(trade, Some("__forced_liquidation__"), None, portfolio_value);
+    trade_tracker.process_trade(
+        trade,
+        multiplier,
+        Some("__forced_liquidation__"),
+        None,
+        portfolio_value,
+    );
 }
 
 impl Default for SettlementManager {

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -131,7 +131,7 @@ impl StatisticsManager {
             let margin_dec = market_value * margin_ratio;
             let margin_f64 = margin_dec.to_f64().unwrap_or(0.0);
 
-            let unrealized_pnl = trade_tracker.get_unrealized_pnl(symbol, price, multiplier);
+            let unrealized_pnl = trade_tracker.get_unrealized_pnl(symbol, price);
             let unrealized_pnl_f64 = unrealized_pnl.to_f64().unwrap_or(0.0);
 
             let entry_price = trade_tracker.get_average_price(symbol);

--- a/tests/test_trades_df.py
+++ b/tests/test_trades_df.py
@@ -1,5 +1,14 @@
 import pandas as pd
-from akquant import Bar, Strategy, run_backtest
+from akquant import (
+    BacktestConfig,
+    Bar,
+    ChinaFuturesConfig,
+    ChinaFuturesInstrumentTemplateConfig,
+    InstrumentConfig,
+    Strategy,
+    StrategyConfig,
+    run_backtest,
+)
 
 
 class TradesTestStrategy(Strategy):
@@ -14,6 +23,23 @@ class TradesTestStrategy(Strategy):
         elif self.position.size > 0:
             # Sell 2 days later to ensure duration > 0
             self.sell(bar.symbol, 100)
+
+
+class FuturesTradesTestStrategy(Strategy):
+    """Strategy for testing futures trades dataframe PnL."""
+
+    def __init__(self) -> None:
+        """Initialize strategy state."""
+        self.entered = False
+
+    def on_bar(self, bar: Bar) -> None:
+        """Open once and close on the following bar."""
+        position = self.get_position(bar.symbol)
+        if not self.entered:
+            self.buy(bar.symbol, 1)
+            self.entered = True
+        elif position > 0:
+            self.close_position(bar.symbol)
 
 
 def test_trades_df() -> None:
@@ -71,3 +97,72 @@ def test_trades_df() -> None:
         # Check duration type
         assert isinstance(trade["duration"], pd.Timedelta)
         print("\nAll expected columns present and duration is Timedelta.")
+
+
+def test_futures_trades_df_respects_contract_multiplier() -> None:
+    """Futures trades_df PnL should include the instrument multiplier."""
+    bars = [
+        Bar(
+            timestamp=pd.Timestamp("2023-01-01 09:00:00", tz="Asia/Shanghai").value,
+            open=4000.0,
+            high=4000.0,
+            low=4000.0,
+            close=4000.0,
+            volume=1000,
+            symbol="RB2310",
+        ),
+        Bar(
+            timestamp=pd.Timestamp("2023-01-01 09:05:00", tz="Asia/Shanghai").value,
+            open=4010.0,
+            high=4010.0,
+            low=4010.0,
+            close=4010.0,
+            volume=1000,
+            symbol="RB2310",
+        ),
+    ]
+
+    result = run_backtest(
+        data=bars,
+        strategy=FuturesTradesTestStrategy,
+        symbols="RB2310",
+        show_progress=False,
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+        config=BacktestConfig(
+            strategy_config=StrategyConfig(
+                initial_cash=500000.0,
+                commission_rate=0.0,
+            ),
+            instruments_config=[
+                InstrumentConfig(
+                    symbol="RB2310",
+                    asset_type="FUTURES",
+                    multiplier=10.0,
+                    margin_ratio=0.1,
+                )
+            ],
+            china_futures=ChinaFuturesConfig(
+                enforce_sessions=False,
+                instrument_templates_by_symbol_prefix=[
+                    ChinaFuturesInstrumentTemplateConfig(
+                        symbol_prefix="RB",
+                        multiplier=10.0,
+                        margin_ratio=0.1,
+                        tick_size=1.0,
+                        lot_size=1.0,
+                        commission_rate=0.0,
+                        enforce_tick_size=False,
+                        enforce_lot_size=True,
+                    )
+                ],
+            ),
+        ),
+    )
+
+    assert len(result.trades_df) == 1
+    trade = result.trades_df.iloc[0]
+    assert trade["symbol"] == "RB2310"
+    assert trade["quantity"] == 1.0
+    assert trade["pnl"] == 100.0
+    assert trade["net_pnl"] == 100.0
+    assert trade["return_pct"] == 0.25


### PR DESCRIPTION
修复TradeTracker中未正确使用合约乘数计算持仓盈亏的问题，将合约乘数字段存入TradeEntry而非每次传入。更新相关方法签名与所有调用点，新增多组测试用例验证期货合约乘数的计算正确性，同步更新所有配置文件的包版本。