### PR TITLE
feat: 新增持仓均价查询功能，完善文档与测试

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.40"
+version = "0.2.41"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/llm.md
+++ b/docs/en/advanced/llm.md
@@ -17,7 +17,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
     *   **Initialization**: Define parameters in `__init__`. Calling `super().__init__()` is optional but recommended.
     *   **Subscription**: Call `self.subscribe(symbol)` in `on_start` to explicitly declare interest. In backtest, it's optional if data is provided.
     *   **Logic**: Implement trading logic in `on_bar(self, bar: Bar)`.
-    *   **Position Helper**: You can use `self.get_position(symbol)` or the `Position` helper class (e.g., `pos = Position(self.ctx, symbol)`).
+    *   **Position Helper**: You can use `self.get_position(symbol)` for numeric quantity, or the `Position` helper class (e.g., `pos = Position(self.ctx, symbol)`) when you also need `size`, `available`, or `entry_price`.
 
 2.  **Data Access**:
     *   **Warmup Period**:
@@ -35,7 +35,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
         *   `self.sell(symbol, quantity, price=None)`: Sell.
         *   `self.order_target_percent(target, symbol)`: Adjust position to target percentage.
         *   `self.order_target_value(target, symbol)`: Adjust position to target value.
-    *   **Position**: `self.get_position(symbol)` returns current holding (float).
+    *   **Position**: `self.get_position(symbol)` returns current holding (float). `self.position.entry_price` or `self.ctx.get_position_entry_price(symbol)` returns runtime average entry price.
     *   **Account**: `self.ctx.cash`, `self.get_portfolio_value()`, `self.get_account()`.
 
 4.  **Indicators**:

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -617,6 +617,18 @@ In addition to `get_position`, you can query more account information:
 *   **`self.get_trades()`**: Get all historical closed trades.
 *   **`self.get_open_orders()`**: Get current open orders.
 *   **`self.get_available_position(symbol)`**: Get available position (considering T+1 rule).
+*   **`self.position.entry_price`**: Get the current symbol's average entry price from the `Position` helper.
+*   **`self.position.avg_price`**: Alias of `entry_price`.
+*   **`self.ctx.get_position_entry_price(symbol)`**: Get average entry price for a specific symbol.
+
+`self.get_position(symbol)` still returns a numeric quantity. If you need average entry price, use the `Position` helper or `self.ctx.get_position_entry_price(symbol)`.
+
+```python
+def on_bar(self, bar):
+    pos = self.position
+    if pos.size > 0 and pos.entry_price > 0:
+        pnl_pct = (bar.close - pos.entry_price) / pos.entry_price
+```
 
 ### 5.6 Instrument Static Metadata Query (Recommended)
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -848,7 +848,13 @@ Note: if you do not pass an explicit `fill_policy` here, the framework defaults 
 
 *   `get_history(count, symbol, field="close") -> np.ndarray`: Get history data array (Zero-Copy). Supports `open/high/low/close/volume` and any numeric extra fields (e.g., `adj_close`, `adj_factor`).
 *   `get_history_df(count, symbol) -> pd.DataFrame`: Get history data DataFrame (OHLCV).
-*   `get_position(symbol) -> float`: Get current position size.
+*   `get_position(symbol) -> float`: Get current position size. This still returns a numeric quantity, not an object.
+*   `get_available_position(symbol) -> float`: Get available position size.
+*   `get_positions() -> Dict[str, float]`: Get all positions by symbol.
+*   `self.position.entry_price -> float`: Get the current symbol's average entry price via the `Position` helper.
+*   `self.position.avg_price -> float`: Alias of `entry_price`.
+*   `ctx.get_position_entry_price(symbol) -> float`: Get the current average entry price for one symbol.
+*   `ctx.get_position_entry_prices() -> Dict[str, float]`: Get current average entry prices for all symbols.
 *   `get_cash() -> float`: Get current available cash.
 *   `get_account() -> Dict[str, float]`: Get an account snapshot. Common fields include `cash`, `equity`, `market_value`, `notional_value`, `frozen_cash`, `margin`, `used_margin`, `unrealized_pnl`, `borrowed_cash`, `short_market_value`, `maintenance_ratio`, `account_mode`, `accrued_interest`, and `daily_interest`.
     *   In cash / spot-style accounts, `market_value` usually represents marked position value.

--- a/docs/zh/advanced/llm.md
+++ b/docs/zh/advanced/llm.md
@@ -17,7 +17,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
     *   **Initialization**: Define parameters in `__init__`. Calling `super().__init__()` is optional but recommended.
     *   **Subscription**: Call `self.subscribe(symbol)` in `on_start` to explicitly declare interest. In backtest, it's optional if data is provided.
     *   **Logic**: Implement trading logic in `on_bar(self, bar: Bar)`.
-    *   **Position Helper**: You can use `self.get_position(symbol)` or the `Position` helper class (e.g., `pos = Position(self.ctx, symbol)`).
+    *   **Position Helper**: You can use `self.get_position(symbol)` for numeric quantity, or the `Position` helper class (e.g., `pos = Position(self.ctx, symbol)`) when you also need `size`, `available`, or `entry_price`.
 
 2.  **Data Access**:
     *   **Warmup Period**:
@@ -36,7 +36,7 @@ Your task is to write trading strategies or backtest scripts based on user requi
         *   `self.order_target_percent(target, symbol)`: Adjust position to target percentage.
         *   `self.order_target_value(target, symbol)`: Adjust position to target value.
         *   在 `fill_policy={"price_basis":"close","bar_offset":0}` 下，同一事件周期中若同时存在卖单与买单，撮合采用先卖后买语义：先处理卖单成交并结算资金，再进行买单风控与下单数量计算。
-    *   **Position**: `self.get_position(symbol)` returns current holding (float).
+    *   **Position**: `self.get_position(symbol)` returns current holding (float). `self.position.entry_price` or `self.ctx.get_position_entry_price(symbol)` returns runtime average entry price.
     *   **Account**: `self.ctx.cash`, `self.get_portfolio_value()`, `self.get_account()`.
 
 4.  **Indicators**:

--- a/docs/zh/advanced/timezone.md
+++ b/docs/zh/advanced/timezone.md
@@ -161,7 +161,7 @@ A: 因为这些字段现在统一表示 UTC 时间。北京时间 09:31 对应 U
 A: 请检查你的输入数据是否是 Naive Datetime（无时区）。如果是 Naive 的，AKQuant 会默认当作北京时间处理，导致转换到 UTC 时出错。请在传入数据前使用 `.tz_localize("US/Eastern")` 处理数据索引。
 
 **Q: `AttributeError: 'float' object has no attribute 'quantity'` 是什么？**
-A: 这通常是在访问持仓时发生的错误。`self.ctx.get_position(symbol)` 返回的是持仓数量（float），而不是一个对象。请直接使用返回值作为数量。
+A: 这通常是在访问持仓时发生的错误。`self.ctx.get_position(symbol)` 返回的是持仓数量（float），而不是一个对象。请直接使用返回值作为数量。如果你需要持仓均价，请改用 `self.position.entry_price` 或 `self.ctx.get_position_entry_price(symbol)`。
 
 **Q: 混合频率回测时，日线和分钟线怎么对齐？**
 A: AKQuant 是事件驱动的，按时间戳顺序处理 Bar。

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -869,7 +869,11 @@ akquant.run_backtest(
     > pos = self.position  # 获取当前 symbol 的 Position 对象
     > print(pos.size)      # 总持仓
     > print(pos.available) # 可用持仓
+    > print(pos.entry_price)  # 持仓均价
+    > print(pos.avg_price)    # entry_price 的别名
     > ```
+    >
+    > `self.get_position(symbol)` 的返回值仍然是 `float` 数量；如果你需要持仓均价，请使用 `Position` helper 或 `self.ctx.get_position_entry_price(symbol)`。
 
 **示例代码**：
 
@@ -881,6 +885,10 @@ def on_bar(self, bar: Bar):
     # 卖出逻辑：必须检查可用持仓
     if signal_sell and pos.available > 0:
         self.sell(bar.symbol, pos.available)
+
+    # 成本线判断：直接读取运行态持仓均价
+    if pos.size > 0 and pos.entry_price > 0:
+        pnl_pct = (bar.close - pos.entry_price) / pos.entry_price
 ```
 
 > **注意**：如果你在 T+1 模式下尝试卖出超过 `available` 的数量，订单会被风控模块（Risk Manager）**拒绝 (Rejected)**，并提示 "Insufficient available position"。

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -871,9 +871,13 @@ def on_pre_open(self, event: Dict[str, Any]) -> None:
 *   `get_history_map(count, symbols, field="close") -> Dict[str, np.ndarray]`: 批量获取多个标的历史数据。
 *   `rebalance_to_topn(scores, top_n, weight_mode="equal", ...) -> List[str]`: 根据打分选取 TopN 并执行调仓，支持等权或按分数归一化。
 *   `get_history_df(count, symbol) -> pd.DataFrame`: 获取历史数据 DataFrame (OHLCV)。
-*   `get_position(symbol) -> float`: 获取当前持仓量。
+*   `get_position(symbol) -> float`: 获取当前持仓量。返回值仍为数量，不返回对象。
 *   `get_available_position(symbol) -> float`: 获取可用持仓量。
 *   `get_positions() -> Dict[str, float]`: 获取所有标的持仓。
+*   `self.position.entry_price -> float`: 通过 `Position` helper 获取当前标的持仓均价。
+*   `self.position.avg_price -> float`: `entry_price` 的别名。
+*   `ctx.get_position_entry_price(symbol) -> float`: 获取指定标的当前持仓均价。
+*   `ctx.get_position_entry_prices() -> Dict[str, float]`: 获取所有标的当前持仓均价。
 *   `hold_bar(symbol) -> int`: 获取当前持仓持有的 Bar 数量。
 *   `get_cash() -> float`: 获取当前可用资金。
 *   `get_account() -> Dict[str, float]`: 获取账户详情快照。常见字段包括 `cash`、`equity`、`market_value`、`notional_value`、`frozen_cash`、`margin`、`used_margin`、`unrealized_pnl`、`borrowed_cash`、`short_market_value`、`maintenance_ratio`、`account_mode`、`accrued_interest`、`daily_interest`。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.40"
+version = "0.2.41"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -2703,6 +2703,23 @@ class StrategyContext:
         """
         ...
 
+    def get_position_entry_prices(self) -> dict[str, float]:
+        r"""
+        获取当前所有持仓均价.
+
+        :return: 持仓均价字典 {symbol: entry_price}
+        """
+        ...
+
+    def get_position_entry_price(self, symbol: str) -> float:
+        r"""
+        获取当前持仓均价.
+
+        :param symbol: 标的代码
+        :return: 持仓均价
+        """
+        ...
+
 class ExpiryEvent:
     symbol: str
     asset_type: akquant.AssetType

--- a/python/akquant/strategy_position.py
+++ b/python/akquant/strategy_position.py
@@ -28,6 +28,19 @@ class Position:
         """可用持仓数量."""
         return self._ctx.get_available_position(self._symbol)
 
+    @property
+    def entry_price(self) -> float:
+        """持仓均价."""
+        return self._ctx.get_position_entry_price(self._symbol)
+
+    @property
+    def avg_price(self) -> float:
+        """持仓均价别名."""
+        return self.entry_price
+
     def __repr__(self) -> str:
         """返回持仓信息的字符串表示."""
-        return f"Position(symbol={self._symbol}, size={self.size})"
+        return (
+            f"Position(symbol={self._symbol}, size={self.size}, "
+            f"available={self.available}, entry_price={self.entry_price})"
+        )

--- a/src/context.rs
+++ b/src/context.rs
@@ -43,6 +43,7 @@ pub struct ContextInit {
     pub previous_cash: Decimal,
     pub positions: Arc<HashMap<String, Decimal>>,
     pub available_positions: Arc<HashMap<String, Decimal>>,
+    pub position_entry_prices: Arc<HashMap<String, Decimal>>,
     pub session: TradingSession,
     pub current_time: i64,
     pub active_orders: Arc<Vec<Order>>,
@@ -75,6 +76,7 @@ pub struct ContextUpdate {
     pub previous_cash: Decimal,
     pub positions: Arc<HashMap<String, Decimal>>,
     pub available_positions: Arc<HashMap<String, Decimal>>,
+    pub position_entry_prices: Arc<HashMap<String, Decimal>>,
     pub session: TradingSession,
     pub current_time: i64,
     pub active_orders: Arc<Vec<Order>>,
@@ -287,6 +289,7 @@ impl StrategyContext {
         self.previous_cash = update.previous_cash;
         self.positions = update.positions;
         self.available_positions = update.available_positions;
+        self.position_entry_prices = update.position_entry_prices;
         self.session = update.session;
         self.current_time = update.current_time;
         self.active_orders_arc = update.active_orders.clone();
@@ -375,6 +378,7 @@ pub struct StrategyContext {
     pub previous_cash: Decimal,
     pub positions: Arc<HashMap<String, Decimal>>,
     pub available_positions: Arc<HashMap<String, Decimal>>,
+    pub position_entry_prices: Arc<HashMap<String, Decimal>>,
     #[pyo3(get)]
     pub session: TradingSession,
     #[pyo3(get)]
@@ -443,6 +447,7 @@ impl StrategyContext {
             previous_cash: init.previous_cash,
             positions: init.positions,
             available_positions: init.available_positions,
+            position_entry_prices: init.position_entry_prices,
             session: init.session,
             current_time: init.current_time,
             closed_trades: init.closed_trades,
@@ -479,6 +484,7 @@ impl StrategyContext {
     /// :param cash: 初始资金
     /// :param positions: 初始持仓 {symbol: quantity}
     /// :param available_positions: 初始可用持仓 {symbol: quantity}
+    /// :param position_entry_prices: 初始持仓均价 {symbol: entry_price}
     /// :param session: 当前交易时段
     /// :param current_time: 当前时间戳 (纳秒)
     /// :param active_orders: 当前活跃订单列表
@@ -493,6 +499,7 @@ impl StrategyContext {
         previous_cash: Option<&Bound<'_, PyAny>>,
         positions: HashMap<String, f64>,
         available_positions: HashMap<String, f64>,
+        position_entry_prices: Option<HashMap<String, f64>>,
         session: Option<TradingSession>,
         current_time: Option<i64>,
         active_orders: Option<Vec<Order>>,
@@ -524,6 +531,11 @@ impl StrategyContext {
             .into_iter()
             .map(|(k, v)| (k, Decimal::from_f64(v).unwrap_or(Decimal::ZERO)))
             .collect();
+        let entry_price_dec: HashMap<String, Decimal> = position_entry_prices
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| (k, Decimal::from_f64(v).unwrap_or(Decimal::ZERO)))
+            .collect();
 
         Ok(StrategyContext {
             orders: Vec::new(),
@@ -538,6 +550,7 @@ impl StrategyContext {
             previous_cash: extract_decimal(previous_cash.unwrap_or(cash))?,
             positions: Arc::new(pos_dec),
             available_positions: Arc::new(avail_dec),
+            position_entry_prices: Arc::new(entry_price_dec),
             session: session.unwrap_or(TradingSession::Continuous),
             current_time: current_time.unwrap_or(0),
             closed_trades: Arc::new(closed_trades.unwrap_or_default()),
@@ -668,6 +681,14 @@ impl StrategyContext {
         self.available_positions
             .iter()
             .filter(|(_, v)| !v.is_zero())
+            .map(|(k, v)| (k.clone(), v.to_f64().unwrap_or_default()))
+            .collect()
+    }
+
+    #[getter]
+    fn get_position_entry_prices(&self) -> HashMap<String, f64> {
+        self.position_entry_prices
+            .iter()
             .map(|(k, v)| (k.clone(), v.to_f64().unwrap_or_default()))
             .collect()
     }
@@ -945,6 +966,18 @@ impl StrategyContext {
     /// :return: 可用持仓数量
     fn get_available_position(&self, symbol: String) -> f64 {
         self.available_positions
+            .get(&symbol)
+            .unwrap_or(&Decimal::ZERO)
+            .to_f64()
+            .unwrap_or_default()
+    }
+
+    /// 获取当前持仓均价.
+    ///
+    /// :param symbol: 标的代码
+    /// :return: 持仓均价
+    fn get_position_entry_price(&self, symbol: String) -> f64 {
+        self.position_entry_prices
             .get(&symbol)
             .unwrap_or(&Decimal::ZERO)
             .to_f64()

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -146,6 +146,22 @@ impl Engine {
         )
     }
 
+    fn build_position_entry_prices(&self) -> Arc<HashMap<String, Decimal>> {
+        let mut entry_prices = HashMap::new();
+        for (symbol, quantity) in self.state.portfolio.positions.iter() {
+            if quantity.is_zero() {
+                continue;
+            }
+            let average_price = self
+                .state
+                .order_manager
+                .trade_tracker
+                .get_average_price(symbol);
+            entry_prices.insert(symbol.clone(), average_price);
+        }
+        Arc::new(entry_prices)
+    }
+
     pub(crate) fn is_active_timestamp(&self, timestamp: i64) -> bool {
         self.active_start_time_ns
             .is_none_or(|start_ns| timestamp >= start_ns)
@@ -602,6 +618,7 @@ impl Engine {
     ) -> PyResult<Py<StrategyContext>> {
         self.ensure_strategy_context_capacity();
         let account_metrics = self.current_account_metrics();
+        let position_entry_prices = self.build_position_entry_prices();
         if let Some(existing_ctx) = self
             .strategy_contexts
             .get(slot_index)
@@ -616,6 +633,7 @@ impl Engine {
                         previous_cash,
                         positions: self.state.portfolio.positions.clone(),
                         available_positions: self.state.portfolio.available_positions.clone(),
+                        position_entry_prices,
                         session: self.clock.session,
                         current_time: self.clock.timestamp().unwrap_or(0),
                         active_orders,
@@ -999,12 +1017,14 @@ impl Engine {
         previous_account_metrics: AccountMetrics,
     ) -> StrategyContext {
         let account_metrics = self.current_account_metrics();
+        let position_entry_prices = self.build_position_entry_prices();
         // Create a temporary context for the strategy to use
         StrategyContext::new(crate::context::ContextInit {
             cash: self.state.portfolio.cash,
             previous_cash,
             positions: self.state.portfolio.positions.clone(),
             available_positions: self.state.portfolio.available_positions.clone(),
+            position_entry_prices,
             session: self.clock.session,
             current_time: self.clock.timestamp().unwrap_or(0),
             active_orders,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -159,6 +159,42 @@ class BuyBuySellBuyStrategy(akquant.Strategy):
         self._step += 1
 
 
+class PositionEntryPriceCaptureStrategy(akquant.Strategy):
+    """Capture runtime position helper state across buy/sell transitions."""
+
+    def __init__(self) -> None:
+        """Initialize step counter and capture buffer."""
+        super().__init__()
+        self._step = 0
+        self.snapshots: list[dict[str, float | str]] = []
+
+    def on_bar(self, bar: akquant.Bar) -> None:
+        """Record helper values before submitting deterministic orders."""
+        pos = self.position
+        ctx_entry_price = 0.0
+        if self.ctx is not None:
+            ctx_entry_price = float(self.ctx.get_position_entry_price(bar.symbol))
+        self.snapshots.append(
+            {
+                "size": float(pos.size),
+                "available": float(pos.available),
+                "entry_price": float(pos.entry_price),
+                "avg_price": float(pos.avg_price),
+                "ctx_entry_price": ctx_entry_price,
+                "repr": repr(pos),
+            }
+        )
+        if self._step == 0:
+            self.buy(symbol=bar.symbol, quantity=10)
+        elif self._step == 1:
+            self.buy(symbol=bar.symbol, quantity=10)
+        elif self._step == 2:
+            self.sell(symbol=bar.symbol, quantity=5)
+        elif self._step == 3:
+            self.sell(symbol=bar.symbol, quantity=15)
+        self._step += 1
+
+
 class ContinuousBuyStrategy(akquant.Strategy):
     """Submit a buy order on every bar."""
 
@@ -381,6 +417,22 @@ def _build_daily_loss_bars(symbol: str) -> list[akquant.Bar]:
         akquant.Bar(day1, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
         akquant.Bar(day2, 8.0, 8.0, 8.0, 8.0, 1000.0, symbol),
         akquant.Bar(day3, 8.0, 8.0, 8.0, 8.0, 1000.0, symbol),
+    ]
+
+
+def _build_position_entry_price_bars(symbol: str) -> list[akquant.Bar]:
+    """Build bars for weighted-average position entry price checks."""
+    day1 = _ns(datetime(2023, 2, 1, 15, 0, tzinfo=timezone.utc))
+    day2 = _ns(datetime(2023, 2, 2, 15, 0, tzinfo=timezone.utc))
+    day3 = _ns(datetime(2023, 2, 3, 15, 0, tzinfo=timezone.utc))
+    day4 = _ns(datetime(2023, 2, 4, 15, 0, tzinfo=timezone.utc))
+    day5 = _ns(datetime(2023, 2, 5, 15, 0, tzinfo=timezone.utc))
+    return [
+        akquant.Bar(day1, 10.0, 10.0, 10.0, 10.0, 1000.0, symbol),
+        akquant.Bar(day2, 12.0, 12.0, 12.0, 12.0, 1000.0, symbol),
+        akquant.Bar(day3, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
+        akquant.Bar(day4, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
+        akquant.Bar(day5, 11.0, 11.0, 11.0, 11.0, 1000.0, symbol),
     ]
 
 
@@ -1781,6 +1833,56 @@ def test_engine_set_fill_policy_roundtrip() -> None:
     assert basis == "close"
     assert int(bar_offset) == 1
     assert temporal == "next_event"
+
+
+def test_position_helper_exposes_runtime_entry_price() -> None:
+    """Position helper should expose weighted-average runtime entry price."""
+    symbol = "POS_HELPER"
+    engine = akquant.Engine()
+    engine.use_simple_market(0.0)
+    engine.set_force_session_continuous(True)
+    cast(Any, engine).set_fill_policy("close", 0, "same_cycle")
+    engine.set_cash(100000.0)
+    engine.set_stock_fee_rules(0.0, 0.0, 0.0, 0.0)
+    engine.set_t_plus_one(False)
+
+    instr = akquant.Instrument(
+        symbol=symbol,
+        asset_type=akquant.AssetType.Stock,
+        multiplier=1.0,
+        margin_ratio=1.0,
+        tick_size=0.01,
+        option_type=None,
+        strike_price=None,
+        expiry_date=None,
+        lot_size=1.0,
+    )
+    engine.add_instrument(instr)
+    engine.add_bars(_build_position_entry_price_bars(symbol))
+
+    strategy = PositionEntryPriceCaptureStrategy()
+    engine.run(strategy, show_progress=False)
+
+    assert len(strategy.snapshots) == 5
+    assert strategy.snapshots[0]["size"] == pytest.approx(0.0, rel=1e-9)
+    assert strategy.snapshots[0]["entry_price"] == pytest.approx(0.0, rel=1e-9)
+    assert strategy.snapshots[1]["size"] == pytest.approx(10.0, rel=1e-9)
+    assert strategy.snapshots[1]["available"] == pytest.approx(10.0, rel=1e-9)
+    assert strategy.snapshots[1]["entry_price"] == pytest.approx(10.0, rel=1e-9)
+    assert strategy.snapshots[1]["avg_price"] == pytest.approx(10.0, rel=1e-9)
+    assert strategy.snapshots[1]["ctx_entry_price"] == pytest.approx(10.0, rel=1e-9)
+    assert strategy.snapshots[2]["size"] == pytest.approx(20.0, rel=1e-9)
+    assert strategy.snapshots[2]["entry_price"] == pytest.approx(11.0, rel=1e-9)
+    assert strategy.snapshots[3]["size"] == pytest.approx(15.0, rel=1e-9)
+    assert strategy.snapshots[3]["entry_price"] == pytest.approx(34.0 / 3.0, rel=1e-9)
+    assert strategy.snapshots[3]["avg_price"] == pytest.approx(34.0 / 3.0, rel=1e-9)
+    assert strategy.snapshots[3]["ctx_entry_price"] == pytest.approx(
+        34.0 / 3.0, rel=1e-9
+    )
+    assert strategy.snapshots[4]["size"] == pytest.approx(0.0, rel=1e-9)
+    assert strategy.snapshots[4]["available"] == pytest.approx(0.0, rel=1e-9)
+    assert strategy.snapshots[4]["entry_price"] == pytest.approx(0.0, rel=1e-9)
+    assert "entry_price=0.0" in cast(str, strategy.snapshots[4]["repr"])
 
 
 def test_engine_set_fill_policy_invalid_combo() -> None:


### PR DESCRIPTION
为 StrategyContext 新增 get_position_entry_price 和 get_position_entry_prices 方法 为 Position 辅助类新增 entry_price 与 avg_price 属性
更新全量中英文API文档与策略指南
新增测试用例验证持仓均价计算逻辑
更新FAQ中关于持仓均价获取的错误提示