### PR TITLE
feat(backtest,strategy,engine): 实现每日调仓对齐完整价格切片，修复跨标的调仓问题

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.2.41"
+version = "0.2.42"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.2.41"
+version = "0.2.42"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -60,6 +60,9 @@ from ..strategy_framework_hooks import (
     collect_boundary_timer_entries as _collect_boundary_timer_entries_impl,
 )
 from ..strategy_framework_hooks import (
+    collect_daily_rebalance_timer_entries as _collect_daily_rebalance_entries_impl,
+)
+from ..strategy_framework_hooks import (
     collect_pre_open_timer_entries as _collect_pre_open_timer_entries_impl,
 )
 from ..strategy_loader import resolve_strategy_input
@@ -213,6 +216,29 @@ def _prime_framework_boundary_timers(
         entries = _collect_boundary_timer_entries_impl(current_strategy)
         if entries:
             current_strategy._framework_boundary_timers_registered = True
+        for timestamp_ns, payload in entries:
+            unique_timers[payload] = int(timestamp_ns)
+
+    for payload, timestamp_ns in sorted(
+        unique_timers.items(),
+        key=lambda item: (int(item[1]), item[0]),
+    ):
+        add_timer(timestamp_ns, payload)
+
+
+def _prime_framework_daily_rebalance_timers(
+    strategies: Sequence[Strategy], engine: Any
+) -> None:
+    """Prime daily rebalance timers before the event loop starts."""
+    add_timer = getattr(engine, "add_timer", None)
+    if not callable(add_timer):
+        return
+
+    unique_timers: dict[str, int] = {}
+    for current_strategy in strategies:
+        entries = _collect_daily_rebalance_entries_impl(current_strategy)
+        if entries:
+            current_strategy._framework_daily_rebalance_timers_registered = True
         for timestamp_ns, payload in entries:
             unique_timers[payload] = int(timestamp_ns)
 
@@ -467,12 +493,14 @@ def _filter_datetime_index_frame_by_runtime_window(
 
 def _build_trading_day_metadata(
     data_map_for_indicators: Dict[str, pd.DataFrame], timezone: str
-) -> Tuple[List[pd.Timestamp], Dict[str, Tuple[int, int]]]:
-    """Build sorted trading days and per-day nanosecond bounds."""
+) -> Tuple[List[pd.Timestamp], Dict[str, Tuple[int, int]], Dict[str, int]]:
+    """Build sorted trading days, per-day bounds, and rebalance timestamps."""
     all_dates: set[pd.Timestamp] = set()
     day_bounds: Dict[str, Tuple[int, int]] = {}
+    day_symbols: Dict[str, set[str]] = {}
+    day_timestamp_symbol_count: Dict[str, Dict[int, int]] = {}
 
-    for df in data_map_for_indicators.values():
+    for symbol, df in data_map_for_indicators.items():
         if df.empty or not isinstance(df.index, pd.DatetimeIndex):
             continue
 
@@ -487,6 +515,15 @@ def _build_trading_day_metadata(
             day_key = pd.Timestamp(day_ts).date().isoformat()
             start_ns = int(day_df.index.min().value)
             end_ns = int(day_df.index.max().value)
+            day_symbols.setdefault(day_key, set()).add(str(symbol))
+            seen_timestamps = {
+                int(ts.value) for ts in cast(pd.DatetimeIndex, day_df.index).unique()
+            }
+            timestamp_counts = day_timestamp_symbol_count.setdefault(day_key, {})
+            for timestamp_ns in seen_timestamps:
+                timestamp_counts[timestamp_ns] = (
+                    timestamp_counts.get(timestamp_ns, 0) + 1
+                )
             if day_key in day_bounds:
                 prev_start, prev_end = day_bounds[day_key]
                 day_bounds[day_key] = (
@@ -496,7 +533,23 @@ def _build_trading_day_metadata(
             else:
                 day_bounds[day_key] = (start_ns, end_ns)
 
-    return sorted(all_dates), day_bounds
+    day_rebalance_timestamps: Dict[str, int] = {}
+    for day_key, timestamp_counts in day_timestamp_symbol_count.items():
+        symbol_count = len(day_symbols.get(day_key, set()))
+        if symbol_count <= 0:
+            continue
+        first_complete_timestamp = min(
+            (
+                timestamp_ns
+                for timestamp_ns, count in timestamp_counts.items()
+                if int(count) >= symbol_count
+            ),
+            default=None,
+        )
+        if first_complete_timestamp is not None:
+            day_rebalance_timestamps[day_key] = int(first_complete_timestamp)
+
+    return sorted(all_dates), day_bounds, day_rebalance_timestamps
 
 
 BacktestDataInput = Union[
@@ -3164,7 +3217,7 @@ def run_backtest(
     # Inject trading days to strategy (for add_daily_timer)
     all_strategy_instances = [strategy_instance, *slot_strategy_instances.values()]
     if data_map_for_indicators:
-        all_dates, day_bounds = _build_trading_day_metadata(
+        all_dates, day_bounds, day_rebalance_timestamps = _build_trading_day_metadata(
             data_map_for_indicators, timezone
         )
 
@@ -3173,6 +3226,10 @@ def run_backtest(
                 current_strategy._trading_days = all_dates
             if hasattr(current_strategy, "_trading_day_bounds"):
                 current_strategy._trading_day_bounds = day_bounds
+            if hasattr(current_strategy, "_trading_day_rebalance_timestamps"):
+                current_strategy._trading_day_rebalance_timestamps = (
+                    day_rebalance_timestamps
+                )
 
     # 4. 配置引擎
     engine = Engine()
@@ -3180,6 +3237,7 @@ def run_backtest(
     for current_strategy in all_strategy_instances:
         setattr(current_strategy, "_engine", engine)
     _prime_framework_boundary_timers(all_strategy_instances, engine)
+    _prime_framework_daily_rebalance_timers(all_strategy_instances, engine)
     _prime_framework_pre_open_timers(all_strategy_instances, engine)
     if analyzer_manager.plugins:
         try:
@@ -4975,7 +5033,7 @@ def run_warm_start(
         warnings.warn(warning_message, RuntimeWarning, stacklevel=2)
         logger.warning(warning_message)
     if data_map_for_indicators:
-        all_dates, day_bounds = _build_trading_day_metadata(
+        all_dates, day_bounds, day_rebalance_timestamps = _build_trading_day_metadata(
             data_map_for_indicators, timezone_name
         )
 
@@ -4984,6 +5042,10 @@ def run_warm_start(
                 current_strategy._trading_days = all_dates
             if hasattr(current_strategy, "_trading_day_bounds"):
                 current_strategy._trading_day_bounds = day_bounds
+            if hasattr(current_strategy, "_trading_day_rebalance_timestamps"):
+                current_strategy._trading_day_rebalance_timestamps = (
+                    day_rebalance_timestamps
+                )
             setattr(current_strategy, "_engine", engine)
 
     # Capture restored cash BEFORE running (for correct initial_market_value in result)
@@ -5417,6 +5479,7 @@ def run_warm_start(
             stream_mode,
         )
     _prime_framework_boundary_timers(all_strategy_instances, engine)
+    _prime_framework_daily_rebalance_timers(all_strategy_instances, engine)
     _prime_framework_pre_open_timers(all_strategy_instances, engine)
 
     if hasattr(strategy_instance, "_on_start_internal"):

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -350,7 +350,9 @@ class Strategy:
     _framework_current_callback: Optional[str]
     _framework_current_order: Optional[Any]
     _framework_current_trade: Optional[Any]
+    _framework_daily_rebalance_timers_registered: bool
     _trading_day_bounds: Dict[str, Tuple[int, int]]
+    _trading_day_rebalance_timestamps: Dict[str, int]
     _oco_groups: Dict[str, set[str]]
     _oco_order_to_group: Dict[str, str]
     _use_engine_oco: bool
@@ -490,7 +492,9 @@ class Strategy:
         instance._framework_current_callback = None
         instance._framework_current_order = None
         instance._framework_current_trade = None
+        instance._framework_daily_rebalance_timers_registered = False
         instance._trading_day_bounds = {}
+        instance._trading_day_rebalance_timestamps = {}
         instance._oco_groups = {}
         instance._oco_order_to_group = {}
         instance._use_engine_oco = False

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -15,6 +15,7 @@ from .strategy_framework_hooks import (
     ensure_framework_state,
     mark_portfolio_dirty,
     register_boundary_timers,
+    register_daily_rebalance_timers,
     register_pre_open_timers,
 )
 from .strategy_ml import (
@@ -49,6 +50,7 @@ def on_bar_event(strategy: Any, bar: Bar, ctx: StrategyContext) -> None:
     strategy.ctx = ctx
     flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
+    register_daily_rebalance_timers(strategy)
     register_pre_open_timers(strategy)
     strategy._last_event_type = "bar"
 
@@ -132,6 +134,7 @@ def on_tick_event(strategy: Any, tick: Tick, ctx: StrategyContext) -> None:
     strategy.ctx = ctx
     flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
+    register_daily_rebalance_timers(strategy)
     register_pre_open_timers(strategy)
     strategy._last_event_type = "tick"
     strategy._check_order_events()
@@ -160,6 +163,7 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
     strategy.ctx = ctx
     flush_pending_schedules(strategy)
     register_boundary_timers(strategy)
+    register_daily_rebalance_timers(strategy)
     register_pre_open_timers(strategy)
     strategy._check_order_events()
 

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -137,6 +137,40 @@ def collect_boundary_timer_entries(strategy: Any) -> List[Tuple[int, str]]:
     return entries
 
 
+def collect_daily_rebalance_timer_entries(strategy: Any) -> List[Tuple[int, str]]:
+    """Collect framework daily rebalance timers aligned to complete price slices."""
+    if not _strategy_overrides_callback(strategy, "on_daily_rebalance"):
+        return []
+
+    rebalance_timestamps = getattr(strategy, "_trading_day_rebalance_timestamps", None)
+    if not rebalance_timestamps:
+        return []
+
+    entries: List[Tuple[int, str]] = []
+    for day_key, source_timestamp in rebalance_timestamps.items():
+        try:
+            source_ts = int(source_timestamp)
+        except (TypeError, ValueError):
+            continue
+        if source_ts <= 0:
+            continue
+        entries.append(
+            (source_ts + 1, f"__framework_rebalance__|{day_key}|{source_ts}")
+        )
+    return entries
+
+
+def _has_timer_driven_daily_rebalance(strategy: Any, trading_date: Any) -> bool:
+    rebalance_timestamps = getattr(strategy, "_trading_day_rebalance_timestamps", None)
+    if not isinstance(rebalance_timestamps, dict) or not rebalance_timestamps:
+        return False
+    if hasattr(trading_date, "isoformat"):
+        day_key = trading_date.isoformat()
+    else:
+        day_key = str(trading_date)
+    return day_key in rebalance_timestamps
+
+
 def _should_reraise_on_error(strategy: Any) -> bool:
     mode = str(_runtime_option(strategy, "error_mode")).strip().lower()
     if mode == "raise":
@@ -336,6 +370,7 @@ def dispatch_time_hooks(strategy: Any) -> None:
         and _is_normal_session(current_session)
         and getattr(strategy, "_framework_daily_rebalance_done_date", None)
         != current_date
+        and not _has_timer_driven_daily_rebalance(strategy, current_date)
     ):
         _dispatch_daily_rebalance_if_needed(strategy, current_date, current_time)
 
@@ -398,6 +433,27 @@ def register_boundary_timers(strategy: Any) -> None:
     strategy._framework_boundary_timers_registered = True
 
 
+def register_daily_rebalance_timers(strategy: Any) -> None:
+    """注册框架级每日调仓定时器，在完整时间片结束后触发."""
+    if strategy.ctx is None:
+        return
+    if getattr(strategy, "_framework_daily_rebalance_timers_registered", False):
+        return
+
+    entries = collect_daily_rebalance_timer_entries(strategy)
+    if not entries:
+        strategy._framework_daily_rebalance_timers_registered = True
+        return
+
+    current_time = int(getattr(strategy.ctx, "current_time", 0))
+    for trigger_ts, payload in entries:
+        if current_time > 0 and trigger_ts <= current_time:
+            continue
+        strategy.ctx.schedule(trigger_ts, payload)
+
+    strategy._framework_daily_rebalance_timers_registered = True
+
+
 def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
     """处理框架级边界定时器，返回是否已消费该 payload."""
     if strategy.ctx is None:
@@ -430,7 +486,9 @@ def dispatch_boundary_timer(strategy: Any, payload: str) -> bool:
                 payload={"trading_date": day, "timestamp": current_time},
             )
             strategy._framework_before_trading_done_date = day
-        if getattr(strategy, "_framework_daily_rebalance_done_date", None) != day:
+        if getattr(
+            strategy, "_framework_daily_rebalance_done_date", None
+        ) != day and not _has_timer_driven_daily_rebalance(strategy, day):
             _run_in_framework_phase(
                 strategy,
                 "daily_rebalance",
@@ -696,3 +754,7 @@ def ensure_framework_state(strategy: Any) -> None:
         strategy._framework_boundary_timers_registered = False
     if not hasattr(strategy, "_trading_day_bounds"):
         strategy._trading_day_bounds = {}
+    if not hasattr(strategy, "_trading_day_rebalance_timestamps"):
+        strategy._trading_day_rebalance_timestamps = {}
+    if not hasattr(strategy, "_framework_daily_rebalance_timers_registered"):
+        strategy._framework_daily_rebalance_timers_registered = False

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -203,6 +203,12 @@ impl Engine {
         }
     }
 
+    pub(crate) fn context_timestamp(&self) -> i64 {
+        self.terminal_result_timestamp()
+            .or_else(|| self.clock.timestamp())
+            .unwrap_or(0)
+    }
+
     pub(crate) fn execution_policy_core(&self) -> ExecutionPolicyCore {
         self.execution_policy_core_state
     }
@@ -635,7 +641,7 @@ impl Engine {
                         available_positions: self.state.portfolio.available_positions.clone(),
                         position_entry_prices,
                         session: self.clock.session,
-                        current_time: self.clock.timestamp().unwrap_or(0),
+                        current_time: self.context_timestamp(),
                         active_orders,
                         closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
                         recent_trades: step_trades,
@@ -1026,7 +1032,7 @@ impl Engine {
             available_positions: self.state.portfolio.available_positions.clone(),
             position_entry_prices,
             session: self.clock.session,
-            current_time: self.clock.timestamp().unwrap_or(0),
+            current_time: self.context_timestamp(),
             active_orders,
             closed_trades: self.state.order_manager.trade_tracker.closed_trades.clone(),
             recent_trades: step_trades,

--- a/src/execution/common.rs
+++ b/src/execution/common.rs
@@ -1,7 +1,9 @@
 use crate::event::Event;
 use crate::execution::matcher::MatchContext;
 use crate::log_context::{execution_order_context_from_event, render_log_message};
-use crate::model::{Order, OrderSide, OrderStatus, OrderType, PriceBasis, TimeInForce, Trade};
+use crate::model::{
+    Order, OrderSide, OrderStatus, OrderType, PriceBasis, TimeInForce, Timer, Trade,
+};
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
@@ -9,6 +11,15 @@ use uuid::Uuid;
 pub struct CommonMatcher;
 
 impl CommonMatcher {
+    fn effective_timer_execution_timestamp(timer: &Timer) -> i64 {
+        timer
+            .payload
+            .strip_prefix("__framework_rebalance__|")
+            .and_then(|payload| payload.rsplit('|').next())
+            .and_then(|value| value.parse::<i64>().ok())
+            .unwrap_or(timer.timestamp)
+    }
+
     fn cancelled_unfilled_ioc_fok_warning(order: &Order, event: &Event) -> String {
         render_log_message(
             format!(
@@ -139,7 +150,7 @@ impl CommonMatcher {
             match event {
                 Event::Bar(b) => order.updated_at = b.timestamp,
                 Event::Tick(t) => order.updated_at = t.timestamp,
-                Event::Timer(t) => order.updated_at = t.timestamp,
+                Event::Timer(t) => order.updated_at = Self::effective_timer_execution_timestamp(t),
                 _ => {}
             }
             log::warn!(
@@ -474,6 +485,7 @@ impl CommonMatcher {
                 }
             }
             Event::Timer(timer) => {
+                let execution_timestamp = Self::effective_timer_execution_timestamp(timer);
                 if !matches!(
                     (execution_policy.price_basis, execution_policy.bar_offset),
                     (PriceBasis::Close, 0)
@@ -525,7 +537,7 @@ impl CommonMatcher {
                     let trade_qty = order.quantity - order.filled_quantity;
                     if trade_qty > Decimal::ZERO {
                         order.status = OrderStatus::Filled;
-                        order.updated_at = timer.timestamp;
+                        order.updated_at = execution_timestamp;
                         order.filled_quantity += trade_qty;
                         order.average_filled_price = Some(final_price);
                         let trade = Trade {
@@ -537,7 +549,7 @@ impl CommonMatcher {
                             quantity: trade_qty,
                             price: final_price,
                             commission: Decimal::ZERO,
-                            timestamp: timer.timestamp,
+                            timestamp: execution_timestamp,
                             bar_index,
                             owner_strategy_id: order.owner_strategy_id.clone(),
                         };
@@ -547,7 +559,7 @@ impl CommonMatcher {
                     || order.time_in_force == TimeInForce::FOK
                 {
                     order.status = OrderStatus::Cancelled;
-                    order.updated_at = timer.timestamp;
+                    order.updated_at = execution_timestamp;
                     log::warn!("{}", Self::cancelled_unfilled_ioc_fok_warning(order, event));
                     return Some(Event::ExecutionReport(order.clone(), None));
                 }

--- a/src/pipeline/stages.rs
+++ b/src/pipeline/stages.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub struct ChannelProcessor;
 
 fn process_order_request(engine: &mut Engine, py: Python<'_>, mut order: Order) {
-    let current_time = engine.clock.timestamp().unwrap_or(0);
+    let current_time = engine.context_timestamp();
     engine.maybe_reset_risk_budget_usage(current_time);
     let mut strategy_limit_err = engine.check_strategy_risk_cooldown_mode(&order);
     let mut triggers_risk_fallback = false;
@@ -60,7 +60,7 @@ fn process_order_request(engine: &mut Engine, py: Python<'_>, mut order: Order) 
             market_model: engine.market_manager.model.as_ref(),
             execution_policy_core: engine.execution_policy_core(),
             bar_index: engine.bar_count,
-            current_time: engine.clock.timestamp().unwrap_or(0),
+            current_time,
             session: engine.clock.session,
             active_orders: &engine.state.order_manager.active_orders,
             risk_config: &engine.risk_manager.config,
@@ -72,7 +72,7 @@ fn process_order_request(engine: &mut Engine, py: Python<'_>, mut order: Order) 
     if let Err(err) = check_result {
         order.status = OrderStatus::Rejected;
         order.reject_reason = err.to_string();
-        order.updated_at = engine.clock.timestamp().unwrap_or(0);
+        order.updated_at = current_time;
 
         let mut risk_payload = HashMap::new();
         risk_payload.insert("order_id", order.id.clone());
@@ -144,7 +144,8 @@ fn should_run_phase_for_current_event(
                 Some(Event::Bar(_) | Event::Tick(_)) => true,
                 Some(Event::Timer(timer)) => {
                     matches!(policy.temporal, TemporalPolicy::SameCycle)
-                        && !timer.payload.starts_with("__framework_")
+                        && (!timer.payload.starts_with("__framework_")
+                            || timer.payload.starts_with("__framework_rebalance__|"))
                 }
                 _ => false,
             }
@@ -188,7 +189,7 @@ fn emit_execution_reports_for_current_event(engine: &mut Engine) {
         market_model: engine.market_manager.model.as_ref(),
         execution_policy_core: engine.execution_policy_core(),
         bar_index: engine.bar_count,
-        current_time: engine.clock.timestamp().unwrap_or(0),
+        current_time: engine.context_timestamp(),
         session: engine.clock.session,
         active_orders: &engine.state.order_manager.active_orders,
         risk_config: &engine.risk_manager.config,
@@ -1089,7 +1090,7 @@ impl Processor for ExecutionProcessor {
                         market_model: engine.market_manager.model.as_ref(),
                         execution_policy_core: engine.execution_policy_core(),
                         bar_index: engine.bar_count,
-                        current_time: engine.clock.timestamp().unwrap_or(0),
+                        current_time: engine.context_timestamp(),
                         session: engine.clock.session,
                         active_orders: &engine.state.order_manager.active_orders,
                         risk_config: &engine.risk_manager.config,

--- a/tests/test_multisymbol_cross_section_consistency.py
+++ b/tests/test_multisymbol_cross_section_consistency.py
@@ -588,6 +588,40 @@ class DailyRebalanceSellThenBuySameCycleStrategy(Strategy):
         )
 
 
+class DailyRebalanceCrossSymbolCarryoverStrategy(Strategy):
+    """Cover cross-symbol daily rebalance with retained positions and price drift."""
+
+    def __init__(self) -> None:
+        """Initialize staged rebalance state and reject capture."""
+        super().__init__()
+        self.step = 0
+        self.rejected_reasons: list[str] = []
+
+    def on_daily_rebalance(self, trading_date: object, timestamp: int) -> None:
+        """Rotate targets across days while retaining one drifting position."""
+        _ = (trading_date, timestamp)
+        if self.step == 0:
+            self.order_target_weights(
+                {"AAA": 0.49, "BBB": 0.49},
+                liquidate_unmentioned=True,
+            )
+        elif self.step == 1:
+            self.order_target_weights(
+                {"BBB": 0.49, "CCC": 0.49},
+                liquidate_unmentioned=True,
+            )
+        elif self.step == 2:
+            self.order_target_weights(
+                {"BBB": 0.90},
+                liquidate_unmentioned=True,
+            )
+        self.step += 1
+
+    def on_reject(self, order: Any) -> None:
+        """Capture unexpected reject reasons for assertion."""
+        self.rejected_reasons.append(str(order.reject_reason))
+
+
 class TargetPositionsLongShortRotationStrategy(Strategy):
     """Exercise multi-symbol signed target positions through one advanced API call."""
 
@@ -831,3 +865,49 @@ def test_daily_rebalance_same_cycle_terminal_fill_preserves_result_views() -> No
     assert float(trades_df.iloc[0]["quantity"]) == 9500.0
     assert trades_df.iloc[0]["entry_time"] == timestamps[1]
     assert trades_df.iloc[0]["exit_time"] == timestamps[2]
+
+
+def test_daily_rebalance_uses_complete_timestamp_prices_for_cross_symbol_targets() -> (
+    None
+):
+    """Daily rebalance should wait for a complete slice before sizing target weights."""
+    timestamps = [
+        pd.Timestamp("2022-12-30 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-01 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-02 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-03 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-04 10:00:00", tz="Asia/Shanghai"),
+        pd.Timestamp("2023-01-05 10:00:00", tz="Asia/Shanghai"),
+    ]
+    data_map = {
+        "AAA": _build_symbol_df("AAA", timestamps, [0.98, 0.99, 1.0, 1.0, 1.0, 1.0]),
+        "BBB": _build_symbol_df("BBB", timestamps, [1.0, 0.95, 1.0, 1.0, 2.0, 2.0]),
+        "CCC": _build_symbol_df("CCC", timestamps, [1.02, 0.98, 1.0, 1.0, 1.0, 1.0]),
+    }
+
+    strategy = DailyRebalanceCrossSymbolCarryoverStrategy()
+    result = run_backtest(
+        data=data_map,
+        strategy=strategy,
+        symbols=["AAA", "BBB", "CCC"],
+        initial_cash=1_000_000.0,
+        commission_rate=0.00005,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=5.0,
+        lot_size=100,
+        history_depth=2,
+        start_time="2023-01-02",
+        fill_policy={"price_basis": "close", "bar_offset": 0, "temporal": "same_cycle"},
+        show_progress=False,
+    )
+
+    orders_df = result.orders_df.sort_values("created_at").reset_index(drop=True)
+    assert strategy.rejected_reasons == []
+    assert not any(
+        str(status).lower() == "rejected" for status in orders_df["status"].tolist()
+    )
+    final_positions = result.positions.iloc[-1]
+    assert float(final_positions.get("AAA", 0.0)) == 0.0
+    assert float(final_positions.get("CCC", 0.0)) == 0.0
+    assert float(final_positions.get("BBB", 0.0)) == 670400.0

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -4211,7 +4211,9 @@ def test_build_trading_day_metadata_merges_multi_symbol_day_bounds() -> None:
         ),
     }
 
-    trading_days, day_bounds = _build_trading_day_metadata(data_map, "Asia/Shanghai")
+    trading_days, day_bounds, day_rebalance_timestamps = _build_trading_day_metadata(
+        data_map, "Asia/Shanghai"
+    )
 
     assert trading_days == [pd.Timestamp("2023-01-03", tz="Asia/Shanghai")]
     assert day_bounds == {
@@ -4219,6 +4221,9 @@ def test_build_trading_day_metadata_merges_multi_symbol_day_bounds() -> None:
             pd.Timestamp("2023-01-03 01:30:00", tz="UTC").value,
             pd.Timestamp("2023-01-03 07:00:00", tz="UTC").value,
         )
+    }
+    assert day_rebalance_timestamps == {
+        "2023-01-03": pd.Timestamp("2023-01-03 02:00:00", tz="UTC").value
     }
 
 


### PR DESCRIPTION
重构引擎统一的时间获取方法，替换多处直接获取时钟时间的逻辑
新增每日调仓定时器注册与触发逻辑，确保调仓时所有标的都已获得完整价格数据
修复定时器事件中订单时间戳不正确的问题
新增跨标的每日调仓测试用例，覆盖多标的调仓场景
同步更新项目版本至0.2.42