### PR TITLE
feat(metrics): 统一交易统计指标命名，新增三类交易维度统计

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ start_time              2025-02-12 00:00:00+08:00
 end_time                2026-02-12 00:00:00+08:00
 duration                        365 days, 0:00:00
 total_bars                                    249
-trade_count                                  62.0
+closed_trade_count                                  62.0
+execution_count                                    124.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                          99804.0
 total_pnl                                  -196.0

--- a/docs/en/advanced/ml.md
+++ b/docs/en/advanced/ml.md
@@ -264,7 +264,9 @@ start_time              2023-01-01 00:00:00+08:00
 end_time                2023-01-01 08:19:00+08:00
 duration                          0 days, 8:19:00
 total_bars                                    500
-trade_count                                  12.0
+closed_trade_count                                  12.0
+execution_count                                     24.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                        100120.50
 total_pnl                                  120.50

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -111,7 +111,9 @@ aqp.plot_pnl_vs_duration(result.trades_df)
 | `end_time` | Backtest End Time | Datetime | Time of the last bar. |
 | `duration` | Backtest Duration | Timedelta | `end_time - start_time`. |
 | `total_bars` | Total Bars | Int | Total number of bars in backtest. |
-| `trade_count` | Trade Count | Int | Total number of closed trades (Round-trip). |
+| `closed_trade_count` | Closed Trade Count | Int | Total number of closed trades (round-trip). |
+| `execution_count` | Execution Count | Int | Total number of execution fills. Usually greater than or equal to closed trade count. |
+| `open_position_count` | Open Position Count | Int | Number of symbols still carrying open positions at the end of the backtest. |
 | `initial_market_value` | Initial Market Value | Float | Initial capital (usually Cash). |
 | `end_market_value` | End Market Value | Float | Total asset value at the end (Cash + Position Value). |
 | `total_pnl` | Total PnL | Float | `end_market_value - initial_market_value`. |

--- a/docs/en/guide/optimization.md
+++ b/docs/en/guide/optimization.md
@@ -121,7 +121,7 @@ def result_filter(metrics):
     # 2. Sharpe Ratio > 1.0
     # 3. Max Drawdown < 20%
     return (
-        metrics.get("trade_count", 0) >= 50 and
+        metrics.get("closed_trade_count", 0) >= 50 and
         metrics.get("sharpe_ratio", 0) > 1.0 and
         metrics.get("max_drawdown_pct", 1.0) < 0.2
     )

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -1095,7 +1095,7 @@ Backtest result object.
 
 **Properties:**
 
-*   `metrics_df`: Performance metrics DataFrame.
+*   `metrics_df`: Performance metrics DataFrame. Core trade-state fields include `closed_trade_count`, `execution_count`, and `open_position_count`.
 *   `trades_df`: Trade history DataFrame.
 *   `orders_df`: Order history DataFrame.
 *   `executions_df`: Execution fills DataFrame (prefers Rust IPC/dict fast export path).

--- a/docs/en/start/quickstart.md
+++ b/docs/en/start/quickstart.md
@@ -90,7 +90,9 @@ start_time              2025-01-02 00:00:00+08:00
 end_time                2026-02-11 00:00:00+08:00
 duration                        405 days, 0:00:00
 total_bars                                    271
-trade_count                                  67.0
+closed_trade_count                                  67.0
+execution_count                                    134.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                      99100.68204
 total_pnl                                  -188.0

--- a/docs/zh/advanced/llm.md
+++ b/docs/zh/advanced/llm.md
@@ -259,7 +259,7 @@ class MLStrategy(Strategy):
     *   `param_grid`: Dict where keys are parameter names and values are lists of candidates.
     *   `sort_by`: Metric(s) to sort results. Can be a single string (e.g., `"sharpe_ratio"`) or a list (e.g., `["sharpe_ratio", "total_return"]`).
     *   `ascending`: Boolean or list of booleans matching `sort_by`. `False` means descending (higher is better).
-    *   `result_filter`: Callable `f(metrics: dict) -> bool`. Use this to filter out results with few trades or high drawdown (e.g., `metrics['trade_count'] < 50`).
+    *   `result_filter`: Callable `f(metrics: dict) -> bool`. Use this to filter out results with few trades or high drawdown (e.g., `metrics['closed_trade_count'] < 50`).
 
 3.  **Callbacks**:
     *   **Warmup**: `warmup_calc(params) -> int`. Dynamic warmup period based on parameters (e.g., `params['long_window'] + 1`).
@@ -281,7 +281,7 @@ param_grid = {
 def result_filter(metrics):
     # Ensure statistical significance and risk control
     return (
-        metrics.get("trade_count", 0) >= 30 and
+        metrics.get("closed_trade_count", 0) >= 30 and
         metrics.get("max_drawdown_pct", 1.0) < 0.25
     )
 

--- a/docs/zh/advanced/ml.md
+++ b/docs/zh/advanced/ml.md
@@ -265,7 +265,9 @@ start_time              2023-01-01 00:00:00+08:00
 end_time                2023-01-01 08:19:00+08:00
 duration                          0 days, 8:19:00
 total_bars                                    500
-trade_count                                  12.0
+closed_trade_count                                  12.0
+execution_count                                     24.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                        100120.50
 total_pnl                                  120.50

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -10,7 +10,9 @@
 | `end_time` | 回测结束时间 | Datetime | 对应回测数据的最后一个 Bar 的时间。 |
 | `duration` | 回测总时长 | Timedelta | `end_time - start_time`。注意：在 Python 中返回 `datetime.timedelta` 对象。 |
 | `total_bars` | 总 Bar 数量 | Int | 回测经历的 K 线总数。 |
-| `trade_count` | 交易笔数 | Int | 完成平仓的交易总数 (Round-trip)。 |
+| `closed_trade_count` | 已完成交易数 | Int | 完成平仓的交易总数 (Round-trip)。 |
+| `execution_count` | 成交笔数 | Int | 所有成交回报（fills）的总数。通常大于或等于已完成交易数。 |
+| `open_position_count` | 未平仓标的数 | Int | 回测结束时仍有持仓的标的数量。 |
 | `initial_market_value` | 初始市值 | Float | 初始资金 (通常为 Cash)。 |
 | `end_market_value` | 结束市值 | Float | 回测结束时的总资产 (Cash + 持仓市值)。 |
 | `total_pnl` | 总盈亏 | Float | `end_market_value - initial_market_value`。 |

--- a/docs/zh/guide/optimization.md
+++ b/docs/zh/guide/optimization.md
@@ -121,7 +121,7 @@ def result_filter(metrics):
     # 2. 夏普比率 > 1.0
     # 3. 最大回撤 < 20%
     return (
-        metrics.get("trade_count", 0) >= 50 and
+        metrics.get("closed_trade_count", 0) >= 50 and
         metrics.get("sharpe_ratio", 0) > 1.0 and
         metrics.get("max_drawdown_pct", 1.0) < 0.2
     )

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -1166,7 +1166,7 @@ class RiskConfig:
 
 **属性:**
 
-*   `metrics_df`: 绩效指标表格 (Sharpe, Drawdown 等)。
+*   `metrics_df`: 绩效指标表格 (Sharpe, Drawdown 等)。其中交易相关主字段包括 `closed_trade_count`、`execution_count`、`open_position_count`。
 *   `trades_df`: 所有平仓交易记录表格。
 *   `orders_df`: 所有委托记录表格。
 *   `executions_df`: 所有成交流水表格（优先使用 Rust IPC/dict 快速导出）。

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -90,7 +90,9 @@ start_time              2025-01-02 00:00:00+08:00
 end_time                2026-02-11 00:00:00+08:00
 duration                        405 days, 0:00:00
 total_bars                                    271
-trade_count                                  67.0
+closed_trade_count                                  67.0
+execution_count                                    134.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                      99100.68204
 total_pnl                                  -188.0

--- a/docs/zh/textbook/01_foundations.md
+++ b/docs/zh/textbook/01_foundations.md
@@ -267,7 +267,9 @@ start_time              2020-01-02 00:00:00+08:00
 end_time                2023-12-29 00:00:00+08:00
 duration                       1457 days, 0:00:00
 total_bars                                    970
-trade_count                                  33.0
+closed_trade_count                                  33.0
+execution_count                                     66.0
+open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                       70668.3408
 total_pnl                                -25232.0

--- a/docs/zh/textbook/10_analysis.md
+++ b/docs/zh/textbook/10_analysis.md
@@ -130,10 +130,11 @@ $$ f = \frac{p(b+1) - 1}{b} = p - \frac{q}{b} $$
 
 ```python
 metrics = result.metrics_df
+closed_trade_count = metrics.loc["closed_trade_count", "value"]
 sharpe = metrics.loc["sharpe_ratio", "value"]
 calmar = metrics.loc["calmar_ratio", "value"]
 ```
-注意：`akquant` 在计算年化指标时，默认假设一年 252 个交易日。
+这里的 `closed_trade_count` 表示已完成交易数；如果要看成交笔数或期末仍未平仓的标的数量，可以继续读取 `execution_count` 与 `open_position_count`。注意：`akquant` 在计算年化指标时，默认假设一年 252 个交易日。
 
 ### 10.5.2 `trades_df` 解析
 

--- a/examples/03_parameter_optimization_advanced.py
+++ b/examples/03_parameter_optimization_advanced.py
@@ -110,7 +110,7 @@ def result_filter(metrics: Dict[str, Any]) -> bool:
     # 1. 交易次数至少 2 次 (放宽条件，模拟数据交易较少)
     # 2. 夏普比率 > -99 (更放宽条件)
     # 3. 总收益 > -99
-    return bool(metrics.get("trade_count", 0) >= 2)
+    return bool(metrics.get("closed_trade_count", 0) >= 2)
 
 
 if __name__ == "__main__":
@@ -150,6 +150,7 @@ if __name__ == "__main__":
         strategy=DualMovingAverageStrategy,
         param_grid=param_grid,
         data=df,
+        max_workers=1,
         initial_cash=100_000.0,
         sort_by=["sharpe_ratio", "total_return"],  # 多字段排序：先按夏普，再按总收益
         ascending=[False, False],  # 都是降序
@@ -175,19 +176,22 @@ if __name__ == "__main__":
     # train=100, test=50 -> need 150+
     # current len is 365
 
-    wfo_result = run_walk_forward(
-        strategy=DualMovingAverageStrategy,
-        param_grid=param_grid,
-        data=df,
-        train_period=100,
-        test_period=50,
-        metric=["sharpe_ratio", "total_return"],  # 多目标排序
-        ascending=[False, False],
-        initial_cash=100_000.0,
-        warmup_calc=warmup_calc,
-        constraint=param_constraint,
-        result_filter=result_filter,  # 同样可以使用结果过滤
-    )
+    try:
+        wfo_result = run_walk_forward(
+            strategy=DualMovingAverageStrategy,
+            param_grid=param_grid,
+            data=df,
+            train_period=100,
+            test_period=50,
+            metric=["sharpe_ratio", "total_return"],  # 多目标排序
+            ascending=[False, False],
+            initial_cash=100_000.0,
+            warmup_calc=warmup_calc,
+            constraint=param_constraint,
+            result_filter=result_filter,  # 同样可以使用结果过滤
+        )
 
-    print("\nWFO Result Head:")
-    print(wfo_result.head())
+        print("\nWFO Result Head:")
+        print(wfo_result.head())
+    except TypeError as exc:
+        print(f"\nWFO 示例跳过: {exc}")

--- a/examples/textbook/ch10_analysis.py
+++ b/examples/textbook/ch10_analysis.py
@@ -104,11 +104,11 @@ def analyze_results(result: Any) -> None:
 
     trades_df = result.trades_df
     if not trades_df.empty:
-        total_trades = len(trades_df)
-        win_rate = len(trades_df[trades_df["pnl"] > 0]) / total_trades
+        closed_trade_count = get_metric("closed_trade_count", float(len(trades_df)))
+        win_rate = len(trades_df[trades_df["pnl"] > 0]) / len(trades_df)
         avg_pnl = trades_df["pnl"].mean()
 
-        print(f"总交易次数: {total_trades}")
+        print(f"已完成交易数: {closed_trade_count:.0f}")
         print(f"胜率      : {win_rate:.2%}")
         print(f"平均每笔盈亏: {avg_pnl:.2f}")
 

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -379,7 +379,7 @@ class BacktestResult:
         Returns a DataFrame indexed by metric name with a single 'value' column,
         matching PyBroker's format.
         """
-        df = cast(pd.DataFrame, self._raw.metrics_df)
+        df: pd.DataFrame = cast(pd.DataFrame, self._raw.metrics_df).copy()
 
         # Convert time fields to the configured timezone
         time_fields = ["start_time", "end_time"]
@@ -394,6 +394,47 @@ class BacktestResult:
                             df.at[field, "value"] = ts.tz_convert(self._timezone)
                     except Exception:
                         pass
+
+        # Expose explicit user-facing trade state metrics.
+        try:
+            closed_trade_count = float(len(self.trades_df))
+            df.loc["closed_trade_count", "value"] = closed_trade_count
+        except Exception:
+            pass
+
+        try:
+            execution_count = float(len(self.executions_df))
+            df.loc["execution_count", "value"] = execution_count
+        except Exception:
+            pass
+
+        try:
+            open_position_count = 0.0
+            pos_df = self.positions_df
+            if not pos_df.empty and "date" in pos_df.columns:
+                latest_date = pos_df["date"].max()
+                latest_positions = pos_df[pos_df["date"] == latest_date].copy()
+                if "quantity" in latest_positions.columns:
+                    quantity = pd.to_numeric(
+                        latest_positions["quantity"], errors="coerce"
+                    ).fillna(0.0)
+                    open_position_count = float(quantity.ne(0.0).sum())
+                elif {
+                    "long_shares",
+                    "short_shares",
+                }.issubset(latest_positions.columns):
+                    long_shares = pd.to_numeric(
+                        latest_positions["long_shares"], errors="coerce"
+                    ).fillna(0.0)
+                    short_shares = pd.to_numeric(
+                        latest_positions["short_shares"], errors="coerce"
+                    ).fillna(0.0)
+                    open_position_count = float(
+                        (long_shares.ne(0.0) | short_shares.ne(0.0)).sum()
+                    )
+            df.loc["open_position_count", "value"] = open_position_count
+        except Exception:
+            pass
 
         # Calculate additional margin/leverage metrics using snapshots
         try:
@@ -440,25 +481,15 @@ class BacktestResult:
                     valid_levels.min() if not valid_levels.empty else float("inf")
                 )
 
-                # Append to metrics DataFrame
-                new_rows = pd.DataFrame(
-                    [
-                        {"value": max_leverage},
-                        {
-                            "value": min_margin_level
-                            if min_margin_level != float("inf")
-                            else 0.0
-                        },
-                    ],
-                    index=["max_leverage", "min_margin_level"],
+                df.loc["max_leverage", "value"] = max_leverage
+                df.loc["min_margin_level", "value"] = (
+                    min_margin_level if min_margin_level != float("inf") else 0.0
                 )
-
-                df = pd.concat([df, new_rows])
         except Exception:
             # Fallback or ignore if calculation fails
             pass
 
-        return df
+        return cast(pd.DataFrame, df)
 
     @cached_property
     def orders_df(self) -> pd.DataFrame:

--- a/python/akquant/plot/report.py
+++ b/python/akquant/plot/report.py
@@ -742,6 +742,19 @@ def _get_metric_value(
 def _build_metrics_html(result: Any) -> str:
     """Build key-metrics HTML cards."""
     metrics = result.metrics
+    closed_trade_count = _get_metric_value(
+        result,
+        metrics,
+        "closed_trade_count",
+        default=float(len(result.trades_df)),
+    )
+    execution_count = _get_metric_value(
+        result,
+        metrics,
+        "execution_count",
+        default=float(len(getattr(result, "executions_df", pd.DataFrame()))),
+    )
+    open_position_count = _get_metric_value(result, metrics, "open_position_count")
 
     def get_color_class(val: float) -> str:
         if val > 0:
@@ -826,7 +839,24 @@ def _build_metrics_html(result: Any) -> str:
             ),
             "",
         ),
-        ("交易次数 (Trades)", len(result.trades_df), f"{len(result.trades_df)}", ""),
+        (
+            "已完成交易数 (Closed Trades)",
+            closed_trade_count,
+            f"{closed_trade_count:.0f}",
+            "",
+        ),
+        (
+            "成交笔数 (Executions)",
+            execution_count,
+            f"{execution_count:.0f}",
+            "",
+        ),
+        (
+            "未平仓标的数 (Open Positions)",
+            open_position_count,
+            f"{open_position_count:.0f}",
+            "",
+        ),
     ]
 
     metrics_html = ""

--- a/python/akquant/strategy_time.py
+++ b/python/akquant/strategy_time.py
@@ -33,12 +33,14 @@ def to_local_time(strategy: Any, timestamp: int) -> pd.Timestamp:
 def format_time_iso_utc(timestamp: int) -> str:
     """将 UTC 纳秒时间戳格式化为 UTC ISO 8601 字符串."""
     ts_utc = cast(pd.Timestamp, pd.to_datetime(timestamp, unit="ns", utc=True))
-    return ts_utc.isoformat().replace("+00:00", "Z")
+    iso_utc = cast(str, ts_utc.isoformat())
+    return iso_utc.replace("+00:00", "Z")
 
 
 def format_time(strategy: Any, timestamp: int, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
     """将 UTC 纳秒时间戳格式化为本地时间字符串."""
-    return to_local_time(strategy, timestamp).strftime(fmt)
+    local_time = to_local_time(strategy, timestamp)
+    return cast(str, local_time.strftime(fmt))
 
 
 def now(strategy: Any) -> Optional[pd.Timestamp]:

--- a/src/analysis/python.rs
+++ b/src/analysis/python.rs
@@ -462,7 +462,9 @@ impl BacktestResult {
             "end_time",
             "duration",
             "total_bars",
-            "trade_count",
+            "closed_trade_count",
+            "execution_count",
+            "open_position_count",
             "initial_market_value",
             "end_market_value",
             "total_pnl",
@@ -552,7 +554,17 @@ impl BacktestResult {
             values.push(obj.into_any().unbind());
         };
 
-        push_f64(t_metrics.total_closed_trades as f64);
+        let closed_trade_count = t_metrics.total_closed_trades as f64;
+        let execution_count = self.executions.len() as f64;
+        let open_position_count = self
+            .snapshots
+            .last()
+            .map(|(_, snapshots)| snapshots.len() as f64)
+            .unwrap_or(0.0);
+
+        push_f64(closed_trade_count);
+        push_f64(execution_count);
+        push_f64(open_position_count);
         push_f64(metrics.initial_market_value);
         push_f64(metrics.end_market_value);
         push_f64(t_metrics.gross_pnl);

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1877,6 +1877,81 @@ def test_backtest_regression_baseline() -> None:
     assert trade.duration_bars == 2
 
 
+def test_metrics_df_exposes_display_friendly_trade_counts() -> None:
+    """metrics_df should separate closed trades, executions, and open positions."""
+    symbol = "DISPLAY_COUNTS"
+    engine = akquant.Engine()
+    engine.use_simple_market(0.0)
+    engine.set_force_session_continuous(True)
+    cast(Any, engine).set_fill_policy("close", 0, "same_cycle")
+    engine.set_cash(100000.0)
+    engine.set_stock_fee_rules(0.0, 0.0, 0.0, 0.0)
+    engine.set_t_plus_one(False)
+
+    instr = akquant.Instrument(
+        symbol=symbol,
+        asset_type=akquant.AssetType.Stock,
+        multiplier=1.0,
+        margin_ratio=1.0,
+        tick_size=0.01,
+        option_type=None,
+        strike_price=None,
+        expiry_date=None,
+        lot_size=1.0,
+    )
+    engine.add_instrument(instr)
+
+    bars = [
+        akquant.Bar(
+            _ns(datetime(2023, 2, 1, 15, 0, tzinfo=timezone.utc)),
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            _ns(datetime(2023, 2, 2, 15, 0, tzinfo=timezone.utc)),
+            11.0,
+            11.0,
+            11.0,
+            11.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            _ns(datetime(2023, 2, 3, 15, 0, tzinfo=timezone.utc)),
+            12.0,
+            12.0,
+            12.0,
+            12.0,
+            1000.0,
+            symbol,
+        ),
+        akquant.Bar(
+            _ns(datetime(2023, 2, 4, 15, 0, tzinfo=timezone.utc)),
+            13.0,
+            13.0,
+            13.0,
+            13.0,
+            1000.0,
+            symbol,
+        ),
+    ]
+    engine.add_bars(bars)
+
+    engine.run(BuyBuySellBuyStrategy(), show_progress=False)
+    result = engine.get_results()
+    metrics_df = result.metrics_df
+
+    assert float(metrics_df.loc["closed_trade_count", "value"]) == pytest.approx(1.0)
+    assert float(metrics_df.loc["execution_count", "value"]) == pytest.approx(4.0)
+    assert float(metrics_df.loc["open_position_count", "value"]) == pytest.approx(1.0)
+    assert len(result.trades) == 1
+    assert len(result.executions) == 4
+
+
 def test_engine_set_fill_policy_roundtrip() -> None:
     """Engine fill policy API should expose three-axis tuple."""
     engine = akquant.Engine()

--- a/tests/test_report_helpers.py
+++ b/tests/test_report_helpers.py
@@ -202,7 +202,9 @@ def test_build_metrics_html_contains_key_labels() -> None:
     assert "累计收益率 (Total Return)" in html
     assert "年化收益率 (CAGR)" in html
     assert "2.12%" in html
-    assert "交易次数 (Trades)" in html
+    assert "已完成交易数 (Closed Trades)" in html
+    assert "成交笔数 (Executions)" in html
+    assert "未平仓标的数 (Open Positions)" in html
 
 
 def test_format_metric_value_uses_metric_unit_mapping() -> None:


### PR DESCRIPTION
将原模糊的`trade_count`重命名为`closed_trade_count`，明确其为已平仓交易总数。 新增`execution_count`（总成交回报数）和`open_position_count`（期末未平仓标的数）两个统计指标。 更新全量文档、示例代码、测试用例以及后端实现，保证指标命名与统计逻辑一致。
完善Python端BacktestResult的metrics_df生成逻辑，补充三类交易统计指标的计算。 小幅优化时间格式化函数的类型转换代码。