### PR TITLE
修复(回测分析): 修正total_pnl计算方式并更新相关文档

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -116,7 +116,7 @@ aqp.plot_pnl_vs_duration(result.trades_df)
 | `open_position_count` | Open Position Count | Int | Number of symbols still carrying open positions at the end of the backtest. |
 | `initial_market_value` | Initial Market Value | Float | Initial capital (usually Cash). |
 | `end_market_value` | End Market Value | Float | Total asset value at the end (Cash + Position Value). |
-| `total_pnl` | Total PnL | Float | `end_market_value - initial_market_value`. |
+| `total_pnl` | Total PnL | Float | `end_market_value - initial_market_value` (portfolio-level: realized net PnL + unrealized floating PnL). Note it is NOT equal to `total_profit + total_loss` (which is the trade-level realized gross PnL, before commission and excluding floating PnL); for the trade-level realized gross PnL use `result.trade_metrics.gross_pnl`. |
 | `unrealized_pnl` | Unrealized PnL | Float | Floating PnL of open positions at the end. |
 | `total_return_pct` | Total Return | **%** | `(End MV - Initial MV) / Initial MV * 100`. |
 | `annualized_return` | Annualized Return | Ratio | `(1 + Total Return)^(1/Years) - 1`. |

--- a/docs/en/start/quickstart.md
+++ b/docs/en/start/quickstart.md
@@ -95,7 +95,7 @@ execution_count                                    134.0
 open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                      99100.68204
-total_pnl                                  -188.0
+total_pnl                              -899.31796
 unrealized_pnl                                0.0
 total_return_pct                        -0.899318
 annualized_return                       -0.008109

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -15,7 +15,7 @@
 | `open_position_count` | 未平仓标的数 | Int | 回测结束时仍有持仓的标的数量。 |
 | `initial_market_value` | 初始市值 | Float | 初始资金 (通常为 Cash)。 |
 | `end_market_value` | 结束市值 | Float | 回测结束时的总资产 (Cash + 持仓市值)。 |
-| `total_pnl` | 总盈亏 | Float | `end_market_value - initial_market_value`。 |
+| `total_pnl` | 总盈亏 | Float | `end_market_value - initial_market_value`（组合层：已实现净盈亏 + 未实现浮动盈亏）。注意它不等于 `total_profit + total_loss`（后者是逐笔已实现毛盈亏，未扣佣金、不含浮动盈亏）；若需逐笔已实现毛盈亏请用 `result.trade_metrics.gross_pnl`。 |
 | `unrealized_pnl` | 未实现盈亏 | Float | 结束时持仓的浮动盈亏。 |
 | `total_return_pct` | 总收益率 | **% (百分比)** | `(结束市值 - 初始市值) / 初始市值 * 100`。 |
 | `annualized_return` | 年化收益率 | Ratio (小数) | `(1 + 总收益率)^(1/年数) - 1`。注意这里是小数，如 0.2 表示 20%。 |

--- a/docs/zh/start/quickstart.md
+++ b/docs/zh/start/quickstart.md
@@ -95,7 +95,7 @@ execution_count                                    134.0
 open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                      99100.68204
-total_pnl                                  -188.0
+total_pnl                              -899.31796
 unrealized_pnl                                0.0
 total_return_pct                        -0.899318
 annualized_return                       -0.008109

--- a/docs/zh/textbook/01_foundations.md
+++ b/docs/zh/textbook/01_foundations.md
@@ -272,7 +272,7 @@ execution_count                                     66.0
 open_position_count                                  0.0
 initial_market_value                     100000.0
 end_market_value                       70668.3408
-total_pnl                                -25232.0
+total_pnl                             -29331.6592
 unrealized_pnl                                0.0
 total_return_pct                       -29.331659
 annualized_return                       -0.083297

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.2"
+version = "0.3.3"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -8,7 +8,7 @@ try:
 except metadata.PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
-__engine_rule_version__ = "1.1.0"  # Increment on behavior-changing updates
+__engine_rule_version__ = "1.2.0"  # Increment on behavior-changing updates
 
 from . import akquant as _akquant
 from . import log as _log

--- a/src/analysis/python.rs
+++ b/src/analysis/python.rs
@@ -567,7 +567,9 @@ impl BacktestResult {
         push_f64(open_position_count);
         push_f64(metrics.initial_market_value);
         push_f64(metrics.end_market_value);
-        push_f64(t_metrics.gross_pnl);
+        // total_pnl 为组合层总盈亏，与文档一致 = end_market_value - initial_market_value
+        // （即已实现净盈亏 + 未实现浮动盈亏）。逐笔已实现毛盈亏请用 trade_metrics.gross_pnl。
+        push_f64(metrics.end_market_value - metrics.initial_market_value);
         push_f64(t_metrics.unrealized_pnl);
         push_f64(metrics.total_return_pct);
         push_f64(metrics.annualized_return);


### PR DESCRIPTION
修正了回测结果中total_pnl的错误计算，将原本使用的交易级毛收益改为符合文档定义的期末市值减初始市值。 更新所有相关文档，修正其中的total_pnl示例数值并澄清其含义，涵盖中英双语快速入门、分析指南及中文交易教科书。 同步将引擎规则版本号升级至1.2.0以匹配此次行为变更。