### PR TITLE
perf(backtest): 向量化 _build_trading_day_metadata，宽截面启动提速约 140 倍

### DIFF
--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -519,44 +519,43 @@ def _build_trading_day_metadata(
     data_map_for_indicators: Dict[str, pd.DataFrame], timezone: str
 ) -> Tuple[List[pd.Timestamp], Dict[str, Tuple[int, int]], Dict[str, int]]:
     """Build sorted trading days, per-day bounds, and rebalance timestamps."""
-    all_dates: set[pd.Timestamp] = set()
-    day_bounds: Dict[str, Tuple[int, int]] = {}
-    day_first_symbol_timestamps: Dict[str, Dict[str, int]] = {}
+    frames = {
+        str(symbol): df
+        for symbol, df in data_map_for_indicators.items()
+        if not df.empty and isinstance(df.index, pd.DatetimeIndex)
+    }
+    if not frames:
+        return [], {}, {}
 
-    for symbol, df in data_map_for_indicators.items():
-        if df.empty or not isinstance(df.index, pd.DatetimeIndex):
-            continue
+    big_index = pd.concat(frames, names=["symbol"]).index
+    dates = big_index.get_level_values(-1)
+    if dates.tz is None:
+        dates = dates.tz_localize("UTC")
+    local_index = dates.tz_convert(timezone)
+    normalized_index = cast(pd.DatetimeIndex, local_index.normalize())
+    all_dates = sorted(set(normalized_index.unique()))
 
-        local_index = _index_to_local_trading_days(
-            cast(pd.DatetimeIndex, df.index), timezone
-        )
-        normalized_index = cast(pd.DatetimeIndex, local_index.normalize())
-        all_dates.update(normalized_index.unique())
+    # pandas datetime64 may use a non-nanosecond unit (e.g. us from polars);
+    # normalize to ns so integer values match Timestamp.value semantics.
+    ns = local_index.tz_convert("UTC").astype("datetime64[ns, UTC]").asi8
+    symbols = big_index.get_level_values(0).astype(str)
 
-        grouped = df.groupby(normalized_index, sort=False)
-        for day_ts, day_df in grouped:
-            day_key = pd.Timestamp(day_ts).date().isoformat()
-            start_ns = int(day_df.index.min().value)
-            end_ns = int(day_df.index.max().value)
-            day_first_symbol_timestamps.setdefault(day_key, {})[str(symbol)] = start_ns
-            if day_key in day_bounds:
-                prev_start, prev_end = day_bounds[day_key]
-                day_bounds[day_key] = (
-                    min(prev_start, start_ns),
-                    max(prev_end, end_ns),
-                )
-            else:
-                day_bounds[day_key] = (start_ns, end_ns)
+    base = pd.DataFrame({"day": normalized_index, "sym": symbols, "ns": ns})
 
-    day_rebalance_timestamps: Dict[str, int] = {}
-    for day_key, symbol_timestamps in day_first_symbol_timestamps.items():
-        if not symbol_timestamps:
-            continue
-        day_rebalance_timestamps[day_key] = max(
-            int(timestamp_ns) for timestamp_ns in symbol_timestamps.values()
-        )
+    bounds = base.groupby("day", sort=False)["ns"].agg(["min", "max"])
+    day_bounds: Dict[str, Tuple[int, int]] = {
+        day_ts.date().isoformat(): (int(start_ns), int(end_ns))
+        for day_ts, start_ns, end_ns in bounds.itertuples()
+    }
 
-    return sorted(all_dates), day_bounds, day_rebalance_timestamps
+    rebalance = (
+        base.groupby(["day", "sym"], sort=False)["ns"].min().groupby("day").max()
+    )
+    day_rebalance_timestamps: Dict[str, int] = {
+        day_ts.date().isoformat(): int(v) for day_ts, v in rebalance.items()
+    }
+
+    return all_dates, day_bounds, day_rebalance_timestamps
 
 
 if TYPE_CHECKING:

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -4206,6 +4206,88 @@ def test_build_trading_day_metadata_merges_multi_symbol_day_bounds() -> None:
     }
 
 
+def _reference_build_trading_day_metadata(
+    data_map: dict[str, pd.DataFrame], timezone: str
+) -> tuple[list, dict, dict]:
+    """原逐组迭代实现（对照用，与向量化替换前的生产实现一致）。"""
+    all_dates: set = set()
+    day_bounds: dict = {}
+    day_first_symbol_timestamps: dict = {}
+
+    for symbol, df in data_map.items():
+        if df.empty or not isinstance(df.index, pd.DatetimeIndex):
+            continue
+        local_index = df.index
+        if local_index.tz is None:
+            local_index = local_index.tz_localize("UTC")
+        local_index = local_index.tz_convert(timezone)
+        normalized_index = local_index.normalize()
+        all_dates.update(normalized_index.unique())
+        grouped = df.groupby(normalized_index, sort=False)
+        for day_ts, day_df in grouped:
+            day_key = pd.Timestamp(day_ts).date().isoformat()
+            start_ns = int(day_df.index.min().value)
+            end_ns = int(day_df.index.max().value)
+            day_first_symbol_timestamps.setdefault(day_key, {})[str(symbol)] = start_ns
+            if day_key in day_bounds:
+                prev_start, prev_end = day_bounds[day_key]
+                day_bounds[day_key] = (min(prev_start, start_ns), max(prev_end, end_ns))
+            else:
+                day_bounds[day_key] = (start_ns, end_ns)
+
+    day_rebalance_timestamps: dict = {}
+    for day_key, symbol_timestamps in day_first_symbol_timestamps.items():
+        if symbol_timestamps:
+            day_rebalance_timestamps[day_key] = max(symbol_timestamps.values())
+    return sorted(all_dates), day_bounds, day_rebalance_timestamps
+
+
+def _metadata_fixture() -> dict[str, pd.DataFrame]:
+    days = pd.date_range("2023-01-03", periods=5, freq="B", tz="UTC")
+    data_map = {}
+    for i, symbol in enumerate(["AAA", "BBB", "CCC", "DDD"]):
+        idx = days.append(days[:2] + pd.Timedelta(hours=1))
+        data_map[symbol] = pd.DataFrame(
+            {"close": [10.0 + i + j * 0.01 for j in range(len(idx))]}, index=idx
+        )
+    return data_map
+
+
+def test_build_trading_day_metadata_matches_reference_groupby() -> None:
+    """向量化实现与原逐组迭代实现在多标的多日数据上输出一致。"""
+    data_map = _metadata_fixture()
+    expected = _reference_build_trading_day_metadata(data_map, "Asia/Shanghai")
+    actual = _build_trading_day_metadata(data_map, "Asia/Shanghai")
+    assert actual == expected
+
+
+def test_build_trading_day_metadata_us_unit_and_naive() -> None:
+    """us 单位 datetime64 与 tz-naive 索引口径与原实现一致。"""
+    data_map = _metadata_fixture()
+    for df in data_map.values():
+        df.index = df.index.as_unit("us").tz_localize(None)
+    expected = _reference_build_trading_day_metadata(data_map, "Asia/Shanghai")
+    actual = _build_trading_day_metadata(data_map, "Asia/Shanghai")
+    assert actual == expected
+
+
+def test_build_trading_day_metadata_skips_empty_and_non_datetime() -> None:
+    """空 frame 与非 DatetimeIndex 被跳过；全空时返回空三元组。"""
+    fixture = _metadata_fixture()
+    data_map = {
+        "EMPTY": pd.DataFrame({"close": []}),
+        "RANGER": pd.DataFrame({"close": [1.0, 2.0]}),
+        "AAA": fixture["AAA"],
+    }
+    expected = _reference_build_trading_day_metadata(data_map, "Asia/Shanghai")
+    actual = _build_trading_day_metadata(data_map, "Asia/Shanghai")
+    assert actual == expected
+
+    assert _build_trading_day_metadata(
+        {"X": pd.DataFrame({"close": []})}, "Asia/Shanghai"
+    ) == ([], {}, {})
+
+
 def test_precise_boundary_hooks_delay_after_trading_until_day_end() -> None:
     """Precise boundary hooks should not emit after_trading during same-day timers."""
 


### PR DESCRIPTION
## 概述

`_build_trading_day_metadata` 是 `run_backtest` 启动期的交易日元数据构建函数（Python 层，每次回测调用一次）。原实现逐 （标的 × 交易日） 做 pandas groupby 迭代，在宽截面股票回测（数千标的）中是明显的一次性瓶颈。

本 PR 将其替换为向量化实现：**把全部标的拼成单表后 `groupby.agg` 聚合**，输出与原实现逐字段一致，无任何语义变化。

## 性能

真实宽截面数据（5,218 标的 × 124 交易日，64.1 万 bar):

| 实现 | 耗时 |
|---|---|
| 原（逐组迭代） | ~25.0s |
| 本 PR（向量化） | ~0.18s |

约 **140 倍**提速；少标的使用场景（期货/crypto/单票）本就不是瓶颈，不受影响。

## 实现要点

- `pd.concat` 拼接全部标的后，用 `groupby("day")["ns"].agg(["min", "max"])` 与 `groupby(["day", "sym"])["ns"].min().groupby("day").max()` 一次性算出 `day_bounds` 与 `day_rebalance_timestamps`，替代逐组 Python 循环；
- **pandas 3.x 的 datetime64 可能是 us 单位**（polars 转换而来）,`asi8` 直接取值会得到微秒而非纳秒——先 `astype("datetime64[ns, UTC]")` 统一单位，保持与原实现 `Timestamp.value` 恒为 ns 的口径一致；
- 空 frame、非 `DatetimeIndex`、tz-naive 索引的处理与原实现一致（跳过 / 按 UTC localize)。

## 测试

新增 3 个测试（附在 `tests/test_strategy_extras.py` 现有 metadata 测试旁）:

1. `test_build_trading_day_metadata_matches_reference_groupby`：与原逐组迭代实现（作为参照保留在测试中）在多标的多日数据上输出完全一致；
2. `test_build_trading_day_metadata_us_unit_and_naive`:us 单位 datetime64 + tz-naive 索引口径一致；
3. `test_build_trading_day_metadata_skips_empty_and_non_datetime`：空 frame / 非 DatetimeIndex 跳过，全空返回空三元组。

本地另用 5,218 标的真实数据做了逐字段对账（`all_dates`、`day_bounds`、`day_rebalance_timestamps` 三项全等），现有测试 `test_build_trading_day_metadata_merges_multi_symbol_day_bounds` 亦通过。
