### PR TITLE
feat(logging): 发布v0.3.10，新增日志审计与增强功能

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -258,6 +258,58 @@ Practical guidance:
 * Inside `on_order`, `on_trade`, and `on_reject`, you usually do not need to manually concatenate order ids into the message
 * Once an `akquant` logger handler is enabled, Rust execution-path warnings also flow through the same pipeline. That includes insufficient-margin rejects, session-close expiry, unknown cancel requests, and same-slice `same-cycle` deferrals, typically with `phase=execution` plus fields such as `symbol`, `order_id`, `strategy_id`, `slot`, and `event_time_iso` when available; `event_time_iso` is always emitted as UTC ISO 8601
 
+#### Log level semantics
+
+AKQuant standardizes level semantics so you can filter and alert consistently:
+
+| Level | Meaning | Trading example |
+| :--- | :--- | :--- |
+| `DEBUG` | Fine-grained diagnostics, enabled only while troubleshooting | Cleanup/inference fallbacks |
+| `INFO` | Key operational milestones | Order submit/fill/cancel audit, training progress, snapshot saved |
+| `WARNING` | Recoverable degradation, unexpected but not fatal | Insufficient-margin reject, ignored non-cancellable order, invalid data field falling back to default |
+| `ERROR` | An operation failed and cannot recover | A custom matcher raised so the order was not executed; Parquet stream read/parse failure (samples truncated) |
+| `CRITICAL` | **System-level fatal, needs immediate human attention** | Live trading front disconnected (cannot place orders); the live runner stops on an uncaught exception |
+
+> `CRITICAL` is reserved for "the framework can no longer safely perform its core job". In production, route `CRITICAL` to a dedicated alert channel (SMS/phone), separate from ordinary logs.
+
+#### Order auditing & sensitive data
+
+* **Order-lifecycle auditing**: under `broker_live`, every order's submit / update / fill / cancel / reject is logged as a structured INFO record under the `akquant.audit.order` namespace (with `client_order_id`, `order_id`, `event`, `price`, `quantity`, …). Set `LogConfig(order_audit_file="logs/orders_audit.log")` to also persist a dedicated audit JSON stream for reconciliation and post-mortem — **the full order lifecycle can be reconstructed from that file alone, even after the process stops**.
+* **Sensitive masking**: logs mask credential-class fields (`password`/`token`/`api_key`, …) fully and account-class fields (`user_id`/`account`, …) keeping the last 4 chars, by default. This is a handler-layer backstop; disable with `LogConfig(mask_sensitive=False)`.
+
+In the console, audit messages are **self-contained** (e.g. `fill Buy 100 600000.SH @10.55 [C1->B1 T1]`) and skip the redundant structured suffix; the full structured fields still go to the JSON audit file for machine consumption.
+
+#### Log language (english by default, optional zh console)
+
+Logs follow industry practice (cf. nautilus_trader / structlog): **messages are english by default** — a searchable, collaboration-friendly contract consumable by alerting/log systems; **structured fields stay english too** (`event=order_fill`, `side`, `price`, …), unaffected by the switch. If you prefer a Chinese console, set `language="zh"`:
+
+```python
+akquant.configure_logging(akquant.LogConfig(profile="live", language="zh"))
+```
+
+It only re-renders the **console order-audit line** from the structured fields; **files and JSON audit streams stay english**, so grep/reconciliation/alerting never fork by language. Free-text diagnostic logs (connect/login/settlement, …) stay english regardless.
+
+#### Recommended live logging config
+
+For a high-frequency live strategy the per-order audit (submit/update/fill) at INFO would flood the console. Raise the **console to `WARNING`** (only human-relevant events) and send the full **INFO audit to `order_audit_file`**:
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        console=True,
+        console_level="WARNING",          # console only keeps human-relevant events
+        filename="logs/live.log",         # main log (incl. INFO) to file
+        file_level="INFO",
+        order_audit_file="logs/orders_audit.log",  # dedicated order-audit JSON stream
+        order_audit_level="INFO",
+        # language="zh",                  # optional: Chinese console audit lines (files stay english)
+    )
+)
+```
+
 ### 3.2 Data Access (Syntactic Sugar)
 
 The `Strategy` class provides properties for quick access to current Bar/Tick data:

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -676,6 +676,11 @@ Core fields:
 *   `profile`: preset profile, one of `research`, `optimize`, or `live`.
 *   `reset_handlers`: whether to reset AKQuant-managed handlers.
 *   `propagate`: whether records should propagate to parent loggers.
+*   `mask_sensitive`: redact sensitive fields (default `True`). Credential-class keys (`password`/`token`/`api_key`, …) are fully masked and account-class keys (`user_id`/`account`, …) keep only their last 4 chars. Masking runs at the handler layer, so a caller can never leak a secret by forgetting to mask it.
+*   `order_audit_file`: path to a dedicated JSON file for live order auditing. When set, every order submit/update/fill/cancel/reject under `broker_live` is additionally written as a JSON line (the `akquant.audit.order` namespace) for later reconciliation and post-mortem.
+*   `order_audit_level`: level for the audit file, default `INFO`.
+*   `order_audit_max_bytes` / `order_audit_backup_count`: size-based rotation threshold and retention count for the audit file (default keeps 5 backups).
+*   `language`: **console** audit message language, `"en"` (default) / `"zh"`. It only re-renders the console order-audit line; files and JSON stay the english canonical, and structured fields (`event`/`side`/`price`, …) never change — so grep/alerting/reconciliation never fork by language.
 
 #### `akquant.configure_logging`
 

--- a/docs/en/textbook/15_live_trading.md
+++ b/docs/en/textbook/15_live_trading.md
@@ -35,3 +35,25 @@ akquant.configure_logging(
 ```
 
 This keeps strategy-side `on_order` / `on_trade` logs and gateway/execution warnings in the same pipeline. It is especially useful when tracing rejects, unknown cancel requests, session-close expiry, or strict-semantics cases where terminal state is not confirmed until broker callbacks arrive.
+
+**Order auditing (an offline-reconstructable record).** Under `broker_live`, every order submit / update / fill / cancel / reject is emitted as a structured INFO record under the `akquant.audit.order` namespace. Set `order_audit_file` to also persist a dedicated audit JSON stream — **the full order lifecycle can be reconstructed from that file alone, even after the process stops**:
+
+```python
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        console=True,
+        console_level="WARNING",          # console only keeps rejects/disconnects that need a human
+        filename="logs/live.log",
+        file_level="INFO",
+        order_audit_file="logs/orders_audit.log",  # per-order audit JSON stream
+        order_audit_level="INFO",
+    )
+)
+```
+
+For a high-frequency live strategy this split is strongly recommended: a clean `WARNING` console, with the per-order INFO audit persisted separately.
+
+**Sensitive masking (on by default).** Logs mask credential-class fields (`password`/`token`/`api_key`, …) fully and account-class fields (`user_id`/`account`, …) keeping the last 4 chars, at the handler layer — so even a newly added log statement cannot leak secrets in cleartext. Disable with `mask_sensitive=False`.
+
+**Log language.** Messages are english by default (a searchable, collaboration-friendly contract), and structured fields (`event`/`side`/`price`) are always english. If you prefer a Chinese console, set `language="zh"`: it only re-renders the **console order-audit line**, while **files and JSON audit streams stay english**, so grep/reconciliation/alerting never fork by language. Reserve `CRITICAL` for system-level fatal events (trader front disconnect, runner crash) and route it to a dedicated alert channel.

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -409,6 +409,43 @@ AKQuant 统一约定各级别的语义，便于按级别过滤与告警：
 * **订单生命周期审计**：`broker_live` 下每一笔订单的 提交 / 回报 / 成交 / 撤单 / 拒单 都会经 `akquant.audit.order` 命名空间产出结构化 INFO 审计日志（含 `client_order_id`、`order_id`、`event`、`price`、`quantity` 等）。通过 `LogConfig(order_audit_file="logs/orders_audit.log")` 可另存一份纯审计 JSON 流，用于事后对账与复盘——**进程停止后仍可仅凭该文件重建订单生命周期**。
 * **敏感信息脱敏**：日志默认对密钥类字段（`password`/`token`/`api_key` 等）全掩码、对账户类字段（`user_id`/`account` 等）保留尾 4 位。此为 handler 层兜底，任何调用点忘记脱敏也不会泄漏；如需关闭，设 `LogConfig(mask_sensitive=False)`。
 
+在控制台里，审计日志的 message 是**自包含**的（如 `fill Buy 100 600000.SH @10.55 [C1->B1 T1]`），一眼可读、不再追加冗余的结构化后缀；而完整结构化字段仍进 JSON 审计文件供机器对账。
+
+#### 日志语言（默认英文，可选中文控制台）
+
+AKQuant 的日志遵循业界惯例（对标 nautilus_trader / structlog）：**message 默认英文**——作为可搜索、可协作、可被告警/日志系统消费的通用契约；**结构化字段永远英文**（`event=order_fill`、`side`、`price`…），语言开关不影响它们。
+
+如果你更习惯中文控制台，可开 `language="zh"`：
+
+```python
+akquant.configure_logging(akquant.LogConfig(profile="live", language="zh"))
+```
+
+它只把**控制台的订单审计行**按中文模板从结构化字段重新渲染（如 `成交 Buy 100 600000.SH @10.55 [C1→B1 T1]`）；**文件与 JSON 审计流恒为英文**，因此 grep/对账/告警不会因语言分裂。散文类诊断日志（连接/登录/结算等）统一英文，不随该开关变化。
+
+#### 实盘推荐日志配置
+
+高频策略实盘时，逐笔审计（提交/回报/成交）默认 INFO，会在控制台刷屏。推荐把**控制台调高到 `WARNING`**（只看告警/拒单/断连等需要人关注的事件），把**完整 INFO 审计单独落到 `order_audit_file`**（脱机对账、复盘的凭证）：
+
+```python
+import akquant
+
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        console=True,
+        console_level="WARNING",          # 控制台只留需要人关注的事件
+        filename="logs/live.log",         # 主日志（含 INFO）落文件
+        file_level="INFO",
+        order_audit_file="logs/orders_audit.log",  # 纯订单审计 JSON 流
+        order_audit_level="INFO",
+        # language="zh",                  # 可选：控制台审计行渲染中文（文件仍英文）
+    )
+)
+```
+
+这样：控制台清爽（拒单 `WARNING`、断连 `CRITICAL` 才跳出来），而每一笔订单的完整生命周期都留在 `orders_audit.log`，进程停止后仍可仅凭它重建与对账。
+
 ### 3.2 便捷数据访问 (Data Access)
 
 为了减少代码冗余，`Strategy` 类提供了当前 Bar/Tick 数据的快捷访问属性：

--- a/docs/zh/meta/logging-rfc.md
+++ b/docs/zh/meta/logging-rfc.md
@@ -2,7 +2,7 @@
 
 > **状态**:全部落地(G1–G5) · **日期**:2026-07-20 · **范围**:AKQuant 核心(Python `log.py` + gateway 实盘链路 + Rust 桥接),偏增量演进、保持向后兼容
 >
-> **进度**:✅ G2 敏感信息脱敏(`SensitiveFilter`,默认开启) · ✅ G1 实盘订单审计(`gateway/order_audit.py` + `LogConfig.order_audit_file`) · ✅ G3 print→logging 收敛 · ✅ G4 级别语义(CRITICAL + Rust error 分级 + 级别语义表) · ✅ G5 贯穿式 trace_id
+> **进度**:✅ G2 敏感信息脱敏(`SensitiveFilter`,默认开启) · ✅ G1 实盘订单审计(`gateway/order_audit.py` + `LogConfig.order_audit_file`) · ✅ G3 print→logging 收敛 · ✅ G4 级别语义(CRITICAL + Rust error 分级 + 级别语义表) · ✅ G5 贯穿式 trace_id · ✅ G6 展示给用户强化 + 语言方案(结构化事件+可插拔渲染;默认英文,中文为控制台皮肤)
 >
 > 本文源于用户反馈「日志好像不够完善」。经全仓盘点,结论是:**日志基础设施(中央封装、结构化、Rust 桥接、多进程聚合)已相当成熟,真正的缺口集中在「实盘审计」这一量化特有场景**。本 RFC 把评估固化为可分期实施与评审的跟踪基线。对标实现:**nautilus_trader**(`Logger` + 每笔订单事件落盘审计)、**vnpy**(`OmsEngine` 订单/成交流水 + `LogEngine`)、**Zipline / backtrader**(标准 logging 分层)。
 
@@ -95,6 +95,8 @@
 
 **已落地(2026-07-20)**:审计走 `akquant.audit.order` 命名空间;`gateway/order_audit.py` 提供 `record_submit`/`record_reject`/`record_cancel`/`record_broker_event`,全部防御式(审计异常绝不中断交易主流程);埋点接入提交(`order_submitter` place_order 成功后)、拒单(重复 client_order_id)、回报/成交(`broker_event_bridge.drain_events`)、撤单(`broker_execution.cancel_order`);审计记录默认随主日志落盘,`order_audit_file` 另存纯审计 JSON 流。`trace_id` 全链路贯穿仍属 G5。
 
+**展示给用户的可读性(2026-07-20 补强)**:遵循「message 面向人、extra 面向机器」——审计 message 自带人类可读关键信息(动作+方向+量+价+id),如 `下单 Buy 100 600000.SH @10.55 [C1→B1]`、`成交 Buy 100 600000.SH @10.55 [C1→B1 T1]`、`拒单 600000.SH [C2] 原因: ...`;结构化 `extra` 与 JSON 审计文件不变,仍供机器对账。修复了此前 message 贫瘠(`order fill` 零信息)、且价量字段只进 JSON、控制台用户看不到成交价量的问题。
+
 ### G2 — 敏感信息脱敏(🟠 P0)
 
 **现状**:登录成功日志明文记录 `user_id`(账户号)与 `broker_id`(`ctp/native.py:422-428`、`:1007-1013`)。密码目前未进日志(`ctp/native.py:400` 附近仅打 `req_id`),但**无任何统一脱敏层**——任何人新增一行 debug 即可能泄漏。
@@ -171,6 +173,37 @@
 - Python:`CONTEXT_FIELDS` 增 `trace_id`;`build_log_extra`/`build_order_audit_extra` 均支持透传;文本 formatter 上下文后缀也带上。
 - 贯穿链路:submit 直接用 `request_client_order_id`(group 根)作 trace_id;fill/回报经 `resolve_trace_id` 回调(接 `live.py::_lookup_group_id`,复用既有 `client_order_id→group_id` 映射)继承同一 trace_id——`broker_event_bridge`→`broker_runtime`→`live` 镜像 `resolve_owner_strategy_id` 的传递链;拒单用 group 根;撤单暂留空(broker_order_id 已足够关联)。
 - Rust:`AkqLogContext` 增 `trace_id` 字段 + builder,使 `[akq_ctx=...]` 载荷与 Python schema 一致。因引擎 `Order` 尚无 trace 字段,执行链路暂不填充(标 `#[allow(dead_code)]`),待 `Order.trace_id` 落地后点亮。
+
+### G6 — 展示给用户强化 + 语言方案(🟢 收尾)
+
+**动机**:前五项把日志做得「对机器友好」(结构化/JSON/审计/trace),但用户在**终端实际看到**的体验仍有短板。实证发现:审计行 `order fill` 看不到成交价量、message 贫瘠、控制台后缀冗余。随后就「是否中文/双语」做了一轮设计:先尝试全量中文化,再对照顶级同类方案纠偏。
+
+**对标结论**:日志 i18n 的最佳实践是**不在日志层翻译**——
+- **MS 全球化规范**:日志/调试串与"用户可见字符串"分离,保持单一语言(英文);翻译日志会破坏 grep/跨区域关联/检索。
+- **nautilus_trader**(Rust+Python 同类):纯英文日志,`LogLine` 用结构化 key-value + `correlation_id`(≈ 我们的 `trace_id`)做追踪;控制台彩色渲染、结构化输出并存。
+- **structlog**:写 `event`(稳定英文 snake_case)+ 键值上下文,不写散文;human vs machine **不二选一**——按环境换渲染器(TTY 彩色 / 生产 JSON)。
+
+**最终方案:结构化事件 + 可插拔渲染(默认英文,中文为控制台皮肤)**。语言差异只在**渲染层**,业务代码只发 `event + 字段`,不写任何语言散文:
+
+```
+业务/审计 ──emit──> event(order_fill) + 字段(side/price/qty/trace_id)   ← 单一事实,永远英文
+                     ├─ 文件/JSON handler → 英文 canonical message(grep/告警/对账契约)
+                     └─ 控制台 handler    → language="en"(默认)英文 / "zh" 从字段重渲染中文
+```
+
+**已落地(2026-07-20)**:
+
+1. **审计 message 人类可读且语言中立**:`order_audit.py` 只发 `event`+字段;英文 canonical 由 `log.render_audit_message` 集中渲染(如 `fill Buy 100 600000.SH @10.55 [C1->B1 T1]`)。模板表 `_AUDIT_MESSAGE_TEMPLATES`(en/zh)集中在 `log.py`,单一事实、零业务侧散文。
+2. **`LogConfig.language`(默认 "en")**:仅重渲染**控制台审计行**;`AKQuantFormatter(language=...)` 从 record 结构化字段用目标语言模板重建 message,**渲染后还原 record.msg**,保证文件/JSON handler 恒英文。结构化字段(`event`/`side`/…)任何语言下不变。
+3. **散文诊断日志回退英文**:`live.py`/`ctp/native.py`/`risk.py`/gateway 的连接/登录/结算/断连/订阅、交易摘要、风控告警等回退英文(业界共识:日志单一语言,对国际用户友好)。
+4. **审计 console 精简**:`AKQuantFormatter` 对 `akquant.audit.*` 跳过冗余结构化后缀(message 已自包含)。
+5. **实盘推荐日志配置**:`docs/zh/guide/strategy.md` 增「日志语言」+「实盘推荐日志配置」——控制台 `WARNING` + `order_audit_file` 落 INFO 审计;`language="zh"` 为可选控制台皮肤。
+
+**取舍**:Rust 撮合诊断与少量 `RuntimeError`(异常范畴)本轮保持英文,不纳入。任意第三语言可扩展 `_AUDIT_MESSAGE_TEMPLATES`,无需引入 gettext/babel。
+
+**测试**:`tests/test_order_audit.py`(`TestRenderAuditMessage` en/zh 渲染 + 市价词本地化;`TestAuditConsoleRendering` en canonical / zh 重渲染 / msg 还原 / 非审计不受影响);既有测试断言回退英文(live_runner / ctp_native / account_risk_rules)。
+
+对标来源:[MS 全球化规范](https://learn.microsoft.com/en-us/globalization/methodology/software-internationalization) · [nautilus_trader Logging](https://nautilustrader.io/docs/latest/concepts/logging/) · [structlog Why](https://www.structlog.org/en/stable/why.html)。
 
 ## 5. 实施分期
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -731,6 +731,11 @@ AKQuant 作为库使用时默认保持静默；未显式配置前，`akquant` �
 *   `profile`: 预设 profile，支持 `research`、`optimize`、`live`。
 *   `reset_handlers`: 是否重置 AKQuant 自己管理的 handler。
 *   `propagate`: 是否向上游 logger 传播。
+*   `mask_sensitive`: 是否对敏感字段脱敏（默认 `True`）。密钥类（`password`/`token`/`api_key` 等）全掩码、账户类（`user_id`/`account` 等）保留尾 4 位；在 handler 层兜底，任何调用点忘记脱敏也不会泄漏。
+*   `order_audit_file`: 实盘订单审计的独立 JSON 文件路径。设置后，`broker_live` 下每一笔订单的提交/回报/成交/撤单/拒单会额外以 JSON line 写入该文件（`akquant.audit.order` 命名空间），用于事后对账与复盘。
+*   `order_audit_level`: 审计文件级别，默认 `INFO`。
+*   `order_audit_max_bytes` / `order_audit_backup_count`: 审计文件按大小轮转的阈值与保留份数（默认保留 5 份）。
+*   `language`: **控制台**审计消息语言，`"en"`（默认）/`"zh"`。仅影响控制台的订单审计行渲染；文件与 JSON 恒为英文 canonical，结构化字段（`event`/`side`/`price` 等）任何语言下不变，因此 grep/告警/对账不会因语言分裂。
 
 #### `akquant.configure_logging`
 

--- a/docs/zh/textbook/15_live_trading.md
+++ b/docs/zh/textbook/15_live_trading.md
@@ -19,6 +19,7 @@
 
 - 主示例：[examples/textbook/ch15_live_trading.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_live_trading.py)
 - 进阶示例：[examples/textbook/ch15_strategy_loader.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_strategy_loader.py)
+- 日志/审计示例（自包含，无需网关）：[examples/66_logging_audit_demo.py](https://github.com/akfamily/akquant/blob/main/examples/66_logging_audit_demo.py)
 - 对应指南：[实盘函数式指南](../advanced/live_functional_quickstart.md)
 
 ## 快速运行与验收
@@ -26,6 +27,7 @@
 ```bash
 python examples/textbook/ch15_live_trading.py
 python examples/textbook/ch15_strategy_loader.py
+python examples/66_logging_audit_demo.py
 ```
 
 验收要点：
@@ -33,6 +35,7 @@ python examples/textbook/ch15_strategy_loader.py
 1. 示例可启动并完成最小实盘流程演示。
 2. 日志中可观察到订单状态、网关事件或风控检查信息。
 3. 调整风控参数后，策略行为变化符合预期。
+4. `66_logging_audit_demo.py` 能看到：敏感字段被脱敏、订单审计单独落 JSON 文件、`language="zh"` 只改控制台审计行而文件恒英文。
 
 ## 15.1 实盘架构与接口
 
@@ -181,6 +184,28 @@ akquant.configure_logging(
 *   `on_order` / `on_trade` / `on_reject` 中的策略日志会自动携带 `order_id`、`client_order_id`、`strategy_id`、`symbol` 等结构化字段。
 *   网关与执行链路中的 warning 也会进入同一套日志管线；例如拒单、未知撤单、收盘过期、严格语义下终态尚未确认等问题，都更容易统一排查。
 *   如果打开 `file_json=True`，后续接入日志平台、告警系统或审计落盘会更顺手。
+
+**订单审计（可脱机复盘的凭证）。** 在 `broker_live` 下，每一笔订单的提交 / 回报 / 成交 / 撤单 / 拒单都会经 `akquant.audit.order` 命名空间产出结构化 INFO 审计。设置 `order_audit_file` 后，这些审计还会以 JSON line 单独落到一份纯审计文件——**进程停止后仍可仅凭它重建订单全生命周期，用于对账与事故复盘**：
+
+```python
+akquant.configure_logging(
+    akquant.LogConfig(
+        profile="live",
+        console=True,
+        console_level="WARNING",          # 控制台只留需人关注的拒单/断连
+        filename="logs/live.log",
+        file_level="INFO",
+        order_audit_file="logs/orders_audit.log",  # 逐笔订单审计 JSON 流
+        order_audit_level="INFO",
+    )
+)
+```
+
+高频策略实盘时强烈建议这样分流：控制台 `WARNING` 保持清爽，逐笔 INFO 审计单独落盘，避免刷屏又不丢凭证。
+
+**敏感脱敏（默认开启）。** 日志默认对密钥类字段（`password`/`token`/`api_key` 等）全掩码、对账户类字段（`user_id`/`account` 等）保留尾 4 位。这是 handler 层兜底——即便某处新增日志忘了脱敏，账号密钥也不会明文落盘；如需关闭设 `mask_sensitive=False`。
+
+**日志语言。** 日志消息默认英文（可搜索、可协作、可被告警/日志系统消费的通用契约），结构化字段（`event`/`side`/`price`）也恒为英文。如偏好中文控制台，设 `language="zh"`——它只把**控制台的订单审计行**渲染成中文，**文件与 JSON 审计流仍是英文**，因此 grep/对账/告警不会因语言分裂。`CRITICAL` 用于交易前置断连、runner 崩溃等系统级致命事件，建议单独接告警通道。
 
 ### 15.5.3 代码示例：启动实盘
 

--- a/docs/zh/textbook/index.md
+++ b/docs/zh/textbook/index.md
@@ -109,6 +109,7 @@
     *   实盘与回测的差异处理
     *   主示例：实盘启动与网关接入 ([examples/textbook/ch15_live_trading.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_live_trading.py))
     *   进阶示例：动态策略加载与运行时注入 ([examples/textbook/ch15_strategy_loader.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_strategy_loader.py))
+    *   日志/审计示例：订单审计落盘、敏感脱敏、日志语言 ([examples/66_logging_audit_demo.py](https://github.com/akfamily/akquant/blob/main/examples/66_logging_audit_demo.py))
     *   风控与熔断机制
 
 ### 第六部分：指标工程与工具链 (Indicator Engineering)
@@ -145,7 +146,7 @@
 | 第 12 章 | [ch12_ml.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch12_ml.py) | [10_ml_walk_forward.py](https://github.com/akfamily/akquant/blob/main/examples/10_ml_walk_forward.py), [55_functional_ml_walk_forward.py](https://github.com/akfamily/akquant/blob/main/examples/55_functional_ml_walk_forward.py) | [机器学习指南](../advanced/ml.md) |
 | 第 13 章 | [ch13_visualization.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch13_visualization.py) | [11_plot_visualization.py](https://github.com/akfamily/akquant/blob/main/examples/11_plot_visualization.py) | [可视化指南](../guide/visualization.md) |
 | 第 14 章 | [ch14_factor.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch14_factor.py) | [16_adj_returns_signal.py](https://github.com/akfamily/akquant/blob/main/examples/16_adj_returns_signal.py) | [因子指南](../guide/factor.md) |
-| 第 15 章 | [ch15_live_trading.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_live_trading.py) | [ch15_strategy_loader.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_strategy_loader.py) | [实盘函数式指南](../advanced/live_functional_quickstart.md) |
+| 第 15 章 | [ch15_live_trading.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_live_trading.py) | [ch15_strategy_loader.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch15_strategy_loader.py), [66_logging_audit_demo.py](https://github.com/akfamily/akquant/blob/main/examples/66_logging_audit_demo.py) | [实盘函数式指南](../advanced/live_functional_quickstart.md) |
 | 第 16 章 | [ch16_indicators.py](https://github.com/akfamily/akquant/blob/main/examples/textbook/ch16_indicators.py) | [45_talib_indicator_playbook_demo.py](https://github.com/akfamily/akquant/blob/main/examples/45_talib_indicator_playbook_demo.py), [60_custom_indicator_demo.py](https://github.com/akfamily/akquant/blob/main/examples/60_custom_indicator_demo.py), [62_indicator_streaming_demo.py](https://github.com/akfamily/akquant/blob/main/examples/62_indicator_streaming_demo.py) | [AKQuant 指标全量说明](../guide/rust_indicator_reference.md) |
 
 ---

--- a/examples/66_logging_audit_demo.py
+++ b/examples/66_logging_audit_demo.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""日志系统演示：订单审计、敏感脱敏与日志语言.
+
+演示目标（全部自包含、无需真实网关，可直接运行）:
+- configure_logging 打开控制台 + 独立订单审计文件(order_audit_file)
+- 敏感字段脱敏(密钥全掩码 / 账户保留尾 4 位),handler 层兜底
+- 订单生命周期审计: submit/fill/cancel 逐笔落 JSON,可脱机重建
+- 日志语言: 默认英文(通用契约); language="zh" 只切控制台审计行,文件恒英文
+
+说明: `broker_live` 下审计由 gateway 自动触发; 这里直接调用 order_audit.*
+仅为在无网关环境下演示日志系统的能力。
+"""
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import akquant
+from akquant import LogConfig, configure_logging, get_logger
+from akquant.gateway import order_audit
+from akquant.gateway.broker_models import UnifiedTrade
+
+
+def _emit_sample_events(trace_id: str = "GROUP-1") -> None:
+    """产生一组样例日志: 一条含敏感字段, 加一笔订单的 submit/fill/cancel 审计."""
+    # 普通日志: 敏感字段会被自动脱敏(user_id 保留尾 4 位, password 全掩码)
+    get_logger("gateway.live").info(
+        "login user_id=88881234 password=secret123",
+        extra=akquant.log.build_log_extra(phase="gateway"),
+    )
+    # 订单审计(broker_live 下自动触发, 此处手动调用仅为演示)
+    order_audit.record_submit(
+        strategy_id="demo",
+        symbol="600000.SH",
+        side="Buy",
+        quantity=100,
+        price=10.55,
+        client_order_id="GROUP-1-a-0",
+        broker_order_id="B1",
+        order_type="Limit",
+        trace_id=trace_id,
+    )
+    order_audit.record_broker_event(
+        "trade",
+        UnifiedTrade(
+            trade_id="T1",
+            broker_order_id="B1",
+            client_order_id="GROUP-1-a-0",
+            symbol="600000.SH",
+            side="Buy",
+            quantity=100.0,
+            price=10.55,
+            timestamp_ns=0,
+        ),
+        owner_strategy_id="demo",
+        trace_id=trace_id,
+    )
+    order_audit.record_cancel(
+        broker_order_id="B1", symbol="600000.SH", strategy_id="demo"
+    )
+
+
+def _flush() -> None:
+    """刷新所有 handler, 确保文件内容落盘后可读取."""
+    for name in ("akquant", "akquant.audit.order"):
+        for handler in logging.getLogger(name).handlers:
+            handler.flush()
+
+
+def _dump_audit_file(audit_path: Path) -> None:
+    """读取审计 JSON 文件并打印(证明可脱机重建订单生命周期)."""
+    print("\n--- 审计文件内容(纯 JSON, 机器可对账; message 恒英文) ---")
+    for line in audit_path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        entry: dict[str, Any] = json.loads(line)
+        print(
+            f"  event={entry['event']:<13} "
+            f"trace_id={entry.get('trace_id', '-')} "
+            f"msg={entry['message']}"
+        )
+
+
+def main() -> None:
+    """运行日志系统演示."""
+    tmp_dir = Path(tempfile.mkdtemp(prefix="akquant_log_demo_"))
+    audit_path = tmp_dir / "orders_audit.log"
+
+    # 1) 默认英文控制台 + 独立审计文件 + 脱敏(默认开启)
+    print("=" * 72)
+    print("[1] language='en'(默认): 控制台英文, 审计另落 JSON 文件, 敏感字段脱敏")
+    print("=" * 72)
+    configure_logging(
+        LogConfig(
+            profile="live",
+            level="INFO",
+            console=True,
+            order_audit_file=str(audit_path),
+            order_audit_level="INFO",
+            language="en",
+        )
+    )
+    _emit_sample_events()
+    _flush()
+
+    # 2) 切中文控制台: 只影响控制台审计行, 文件仍英文
+    print("\n" + "=" * 72)
+    print("[2] language='zh': 控制台审计行渲染中文(文件/JSON 仍英文)")
+    print("=" * 72)
+    configure_logging(
+        LogConfig(
+            profile="live",
+            level="INFO",
+            console=True,
+            order_audit_file=str(audit_path),
+            order_audit_level="INFO",
+            language="zh",
+        )
+    )
+    _emit_sample_events(trace_id="GROUP-2")
+    _flush()
+
+    # 3) 证明审计文件可脱机重建(且恒英文, 便于跨团队/工具消费)
+    _dump_audit_file(audit_path)
+
+    # 复位为库默认静默, 不影响后续导入方
+    configure_logging(LogConfig(console=False, filename=None, reset_handlers=True))
+    print(f"\n审计文件路径: {audit_path}")
+    print("完成。")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.9"
+version = "0.3.10"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -28,6 +28,12 @@ class LogConfig:
     profile: typing.Optional[str]
     reset_handlers: bool
     propagate: bool
+    mask_sensitive: bool
+    language: str
+    order_audit_file: typing.Optional[str]
+    order_audit_level: typing.Union[str, int]
+    order_audit_max_bytes: typing.Optional[int]
+    order_audit_backup_count: int
     def __init__(
         self,
         level: typing.Union[str, int] = ...,
@@ -47,6 +53,12 @@ class LogConfig:
         profile: typing.Optional[str] = ...,
         reset_handlers: bool = ...,
         propagate: bool = ...,
+        mask_sensitive: bool = ...,
+        language: str = ...,
+        order_audit_file: typing.Optional[str] = ...,
+        order_audit_level: typing.Union[str, int] = ...,
+        order_audit_max_bytes: typing.Optional[int] = ...,
+        order_audit_backup_count: int = ...,
     ) -> None: ...
 
 def get_logger(name: typing.Optional[str] = ...) -> logging.Logger: ...

--- a/python/akquant/gateway/order_audit.py
+++ b/python/akquant/gateway/order_audit.py
@@ -1,8 +1,12 @@
-"""实盘订单生命周期审计日志 (RFC G1).
+"""实盘订单生命周期审计日志 (RFC G1 / G6).
 
 在 submit / update / fill / cancel / reject 五个跃迁点产出结构化 INFO 审计,
 统一走 ``akquant.audit.order`` 命名空间, 可经 ``LogConfig.order_audit_file``
 落到独立 JSON 审计文件, 用于事后对账、复盘与追责。
+
+**语言中立**(G6): 审计记录只带英文 ``event`` 码 + 结构化字段; 人类可读的
+message 由 ``log.render_audit_message`` 渲染, 英文为 canonical(文件/JSON/grep),
+控制台可选按 ``LogConfig.language`` 渲染其他语言——业务代码不写任何语言散文。
 
 审计是**旁路**关切: 任何埋点异常都不得中断下单/回报主流程, 因此所有对外
 函数都经 ``_safe_emit`` 吞掉自身异常(仅退化为一条 debug), 绝不上抛。
@@ -13,14 +17,20 @@ from __future__ import annotations
 import logging
 from typing import Any, Optional
 
-from ..log import ORDER_AUDIT_LOGGER_NAME, build_order_audit_extra, get_logger
+from ..log import (
+    ORDER_AUDIT_LOGGER_NAME,
+    build_order_audit_extra,
+    get_logger,
+    render_audit_message,
+)
 
 audit_logger = get_logger(ORDER_AUDIT_LOGGER_NAME)
 
 
-def _safe_emit(level: int, message: str, extra: dict[str, Any]) -> None:
-    """Emit one audit record, never propagating an audit-side failure."""
+def _safe_emit(level: int, extra: dict[str, Any]) -> None:
+    """Emit one audit record with an english canonical message, never raising."""
     try:
+        message = render_audit_message(extra.get("event"), extra)
         audit_logger.log(level, message, extra=extra)
     except Exception:  # noqa: BLE001 审计旁路: 失败绝不影响交易主流程
         try:
@@ -62,7 +72,6 @@ def record_submit(
     """Audit a successful order leg submission to the broker."""
     _safe_emit(
         logging.INFO,
-        "order submitted",
         build_order_audit_extra(
             event="order_submit",
             strategy_id=strategy_id,
@@ -91,7 +100,6 @@ def record_reject(
     """Audit a locally-rejected order (never reached the broker)."""
     _safe_emit(
         logging.WARNING,
-        "order rejected",
         build_order_audit_extra(
             event="order_reject",
             strategy_id=strategy_id,
@@ -115,7 +123,6 @@ def record_cancel(
     """Audit a cancel request dispatched to the broker."""
     _safe_emit(
         logging.INFO,
-        "order cancel requested",
         build_order_audit_extra(
             event="order_cancel",
             strategy_id=strategy_id,
@@ -134,33 +141,18 @@ def record_broker_event(
     trace_id: Optional[str] = None,
 ) -> None:
     """Audit an inbound broker push (order update / trade fill / exec report)."""
-    if event_name == "order":
+    symbol = _pick(payload, "symbol")
+    broker_order_id = _pick(payload, "broker_order_id")
+    client_order_id = _pick(payload, "client_order_id")
+    if event_name == "trade":
         _safe_emit(
             logging.INFO,
-            "order update",
-            build_order_audit_extra(
-                event="order_update",
-                strategy_id=owner_strategy_id,
-                symbol=_pick(payload, "symbol"),
-                order_id=_pick(payload, "broker_order_id"),
-                client_order_id=_pick(payload, "client_order_id"),
-                trace_id=trace_id,
-                order_status=_status_text(_pick(payload, "status")),
-                quantity=_pick(payload, "filled_quantity"),
-                price=_pick(payload, "avg_fill_price"),
-                reason=_pick(payload, "reject_reason") or None,
-            ),
-        )
-    elif event_name == "trade":
-        _safe_emit(
-            logging.INFO,
-            "order fill",
             build_order_audit_extra(
                 event="order_fill",
                 strategy_id=owner_strategy_id,
-                symbol=_pick(payload, "symbol"),
-                order_id=_pick(payload, "broker_order_id"),
-                client_order_id=_pick(payload, "client_order_id"),
+                symbol=symbol,
+                order_id=broker_order_id,
+                client_order_id=client_order_id,
                 trace_id=trace_id,
                 side=_pick(payload, "side"),
                 quantity=_pick(payload, "quantity"),
@@ -168,16 +160,15 @@ def record_broker_event(
                 trade_id=_pick(payload, "trade_id"),
             ),
         )
-    elif event_name == "execution_report":
+    elif event_name in ("order", "execution_report"):
         _safe_emit(
             logging.INFO,
-            "order execution report",
             build_order_audit_extra(
                 event="order_update",
                 strategy_id=owner_strategy_id,
-                symbol=_pick(payload, "symbol"),
-                order_id=_pick(payload, "broker_order_id"),
-                client_order_id=_pick(payload, "client_order_id"),
+                symbol=symbol,
+                order_id=broker_order_id,
+                client_order_id=client_order_id,
                 trace_id=trace_id,
                 order_status=_status_text(_pick(payload, "status")),
                 quantity=_pick(payload, "filled_quantity"),

--- a/python/akquant/log.py
+++ b/python/akquant/log.py
@@ -39,6 +39,9 @@ CONTEXT_FIELDS = (
 )
 # The dedicated order-audit logger namespace (child of the root logger).
 ORDER_AUDIT_LOGGER_NAME = "audit.order"
+# Records under this namespace carry self-contained human-readable messages, so
+# the text console formatter omits the (redundant) structured context suffix.
+AUDIT_NAME_PREFIX = f"{ROOT_LOGGER_NAME}.audit."
 
 
 # Sensitive field masking (G2): keys whose values must never appear verbatim.
@@ -215,10 +218,12 @@ class AKQuantFormatter(logging.Formatter):
         *,
         datefmt: str = DATE_FORMAT,
         include_context: bool = False,
+        language: str = "en",
     ) -> None:
         """Initialize a formatter with optional AKQuant context rendering."""
         super().__init__(fmt, datefmt=datefmt)
         self.include_context = include_context
+        self.language = language
 
     def format(self, record: logging.LogRecord) -> str:
         """Format a log record and optionally append structured context text."""
@@ -226,8 +231,26 @@ class AKQuantFormatter(logging.Formatter):
             if not hasattr(record, field_name):
                 setattr(record, field_name, None)
 
+        is_audit = str(record.name).startswith(AUDIT_NAME_PREFIX)
+        # Localized console rendering (RFC G6): rebuild the audit line from the
+        # structured fields in the target language, then RESTORE the canonical
+        # english msg so other handlers (file/JSON) still emit english.
+        event = getattr(record, "event", None)
+        if is_audit and self.language != "en" and event:
+            original_msg, original_args = record.msg, record.args
+            record.msg = render_audit_message(event, record.__dict__, self.language)
+            record.args = ()
+            try:
+                return super().format(record)
+            finally:
+                record.msg, record.args = original_msg, original_args
+
         rendered = super().format(record)
         if not self.include_context:
+            return rendered
+        # Audit records are self-contained (message already carries the key
+        # fields), so skip the redundant structured suffix in the console text.
+        if is_audit:
             return rendered
 
         context_parts: list[str] = []
@@ -425,6 +448,99 @@ def build_order_audit_extra(
     }
 
 
+# --- Order-audit message rendering (RFC G6) -------------------------------
+# The audit *record* is language-neutral (english `event` code + structured
+# fields). The human-readable message is a *rendering* concern: english is the
+# canonical (files/JSON/grep), and a localized console renderer can rebuild the
+# line from the same structured fields. This mirrors structlog's "swap the
+# final renderer" and nautilus_trader's english-only structured logs — we never
+# fork message prose across the business code.
+SUPPORTED_LANGUAGES = ("en", "zh")
+_AUDIT_MESSAGE_TEMPLATES: dict[str, dict[str, str]] = {
+    "en": {
+        "order_submit": "submit {side} {quantity} {symbol} {price} "
+        "[{client_order_id}->{order_id}]",
+        "order_fill": "fill {side} {quantity} {symbol} {price} "
+        "[{client_order_id}->{order_id} {trade_id}]",
+        "order_reject": "reject {symbol} [{client_order_id}] reason: {reason}",
+        "order_cancel": "cancel {symbol} [{order_id}]",
+        "order_update": "update {symbol} status={order_status} "
+        "filled={quantity} [{client_order_id}->{order_id}]",
+    },
+    "zh": {
+        "order_submit": "下单 {side} {quantity} {symbol} {price} "
+        "[{client_order_id}→{order_id}]",
+        "order_fill": "成交 {side} {quantity} {symbol} {price} "
+        "[{client_order_id}→{order_id} {trade_id}]",
+        "order_reject": "拒单 {symbol} [{client_order_id}] 原因: {reason}",
+        "order_cancel": "撤单请求 {symbol} [{order_id}]",
+        "order_update": "订单更新 {symbol} 状态={order_status} "
+        "已成={quantity} [{client_order_id}→{order_id}]",
+    },
+}
+_MARKET_PRICE_TEXT = {"en": "market", "zh": "市价"}
+
+
+def _compact_number(value: Any) -> str:
+    """Render a numeric audit value compactly (drop trailing .0)."""
+    if value is None:
+        return ""
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def render_audit_message(
+    event: Optional[str],
+    fields: Any,
+    language: str = "en",
+) -> str:
+    """Render one order-audit line from structured fields in the given language.
+
+    `fields` is any mapping/record-dict carrying the audit fields (side, price,
+    symbol, ids, …) — typically the `build_order_audit_extra` payload or a
+    LogRecord's ``__dict__``. English is the canonical; other languages are a
+    pure presentation over the same fields.
+    """
+    lang = language if language in _AUDIT_MESSAGE_TEMPLATES else "en"
+    template = _AUDIT_MESSAGE_TEMPLATES[lang].get(str(event or ""))
+    if template is None:
+        return str(event or "")
+
+    def _get(name: str) -> Any:
+        if isinstance(fields, dict):
+            return fields.get(name)
+        return getattr(fields, name, None)
+
+    price = _get("price")
+    if str(event) == "order_submit" and price in (None, ""):
+        price_display = _MARKET_PRICE_TEXT[lang]
+    elif price in (None, ""):
+        price_display = ""
+    else:
+        price_display = f"@{_compact_number(price)}"
+
+    display = {
+        "side": _get("side") or "",
+        "quantity": _compact_number(_get("quantity")),
+        "symbol": _get("symbol") or "",
+        "price": price_display,
+        "client_order_id": _get("client_order_id") or "?",
+        "order_id": _get("order_id") or "?",
+        "trade_id": _get("trade_id") or "",
+        "order_status": _get("order_status") or "?",
+        "reason": _get("reason") or "",
+    }
+    text = template.format_map(display)
+    # An "update" carrying a reject reason appends it (kept out of the template
+    # so the common no-reason path stays clean).
+    if str(event) == "order_update" and display["reason"]:
+        suffix = "原因" if lang == "zh" else "reason"
+        text = f"{text} {suffix}: {display['reason']}"
+    # Collapse the double spaces left by empty optional fields.
+    return " ".join(text.split())
+
+
 _install_log_record_factory()
 
 
@@ -471,6 +587,10 @@ class LogConfig:
     reset_handlers: bool = True
     propagate: bool = True
     mask_sensitive: bool = True
+    # Console message language (RFC G6). English is always the canonical stored
+    # message (files/JSON); this only re-renders the *console* audit line. Files
+    # and JSON stay english regardless, so grep/alerting never fork by language.
+    language: str = "en"
     # Dedicated order-lifecycle audit stream (RFC G1). When set, order audit
     # records are additionally written as JSON lines to this rotating file.
     order_audit_file: Optional[str] = None
@@ -615,6 +735,7 @@ class Logger:
         show_context: bool = False,
         json_output: bool = False,
         mask_sensitive: bool = True,
+        language: str = "en",
     ) -> None:
         r"""
         启用控制台日志.
@@ -623,6 +744,8 @@ class Logger:
         :type format_str: str
         :param level: 控制台日志等级，为 None 时不修改
         :type level: str | int, optional
+        :param language: 控制台审计消息语言（"en"/"zh"）；文件/JSON 恒英文
+        :type language: str
         """
         self._sync_handlers()
         self._remove_null_handler()
@@ -639,6 +762,7 @@ class Logger:
                 format_str,
                 datefmt=DATE_FORMAT,
                 include_context=show_context,
+                language=language,
             )
         )
         if level is not None:
@@ -773,6 +897,7 @@ class Logger:
                 show_context=console_show_context,
                 json_output=console_json,
                 mask_sensitive=config.mask_sensitive,
+                language=config.language,
             )
             effective_levels.append(_normalize_level(console_level))
         else:

--- a/tests/test_order_audit.py
+++ b/tests/test_order_audit.py
@@ -18,12 +18,131 @@ from akquant.gateway.order_audit import (
     record_submit,
 )
 from akquant.log import (
+    AKQuantFormatter,
     LogConfig,
+    build_log_extra,
     build_order_audit_extra,
     configure_logging,
+    render_audit_message,
 )
 
 _FILLED = UnifiedOrderStatus.FILLED
+
+
+def _build_fill_fields() -> dict[str, object]:
+    """Build a canonical fill payload for audit-rendering tests."""
+    return build_order_audit_extra(
+        event="order_fill",
+        side="Buy",
+        quantity=100,
+        price=10.55,
+        symbol="600000.SH",
+        client_order_id="C1",
+        order_id="B1",
+        trade_id="T1",
+    )
+
+
+class TestRenderAuditMessage:
+    """render_audit_message builds the human line from structured fields (G6)."""
+
+    def test_english_is_canonical(self) -> None:
+        """English rendering is the default/canonical."""
+        fields = _build_fill_fields()
+        assert (
+            render_audit_message("order_fill", fields)
+            == "fill Buy 100 600000.SH @10.55 [C1->B1 T1]"
+        )
+
+    def test_chinese_is_a_pure_presentation_over_same_fields(self) -> None:
+        """Chinese rendering reads the same fields, differs only in prose."""
+        fields = _build_fill_fields()
+        assert (
+            render_audit_message("order_fill", fields, "zh")
+            == "成交 Buy 100 600000.SH @10.55 [C1→B1 T1]"
+        )
+
+    def test_market_order_price_word_is_localized(self) -> None:
+        """A submit with no price renders market/市价 per language."""
+        fields = build_order_audit_extra(
+            event="order_submit", side="Buy", quantity=1, symbol="X", price=None
+        )
+        assert "market" in render_audit_message("order_submit", fields, "en")
+        assert "市价" in render_audit_message("order_submit", fields, "zh")
+
+
+class TestAuditConsoleRendering:
+    """Console formatter: english canonical by default, opt-in zh re-render (G6)."""
+
+    def _format(self, name: str, message: str, extra: dict, language: str) -> str:
+        formatter = AKQuantFormatter(
+            "%(name)s | %(message)s", include_context=True, language=language
+        )
+        record = logging.LogRecord(
+            name=name,
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=message,
+            args=(),
+            exc_info=None,
+        )
+        for key, value in extra.items():
+            setattr(record, key, value)
+        return formatter.format(record)
+
+    def test_audit_english_console_no_suffix(self) -> None:
+        """Default (en) console shows the canonical english line, no `phase=` tail."""
+        out = self._format(
+            "akquant.audit.order",
+            "fill Buy 100 600000.SH @10.55 [C1->B1 T1]",
+            _build_fill_fields(),
+            language="en",
+        )
+        assert out == "akquant.audit.order | fill Buy 100 600000.SH @10.55 [C1->B1 T1]"
+        assert "phase=" not in out
+
+    def test_audit_zh_console_rerenders_from_fields(self) -> None:
+        """Chinese console rebuilds the line from the structured fields."""
+        out = self._format(
+            "akquant.audit.order",
+            "fill Buy 100 600000.SH @10.55 [C1->B1 T1]",  # english canonical in
+            _build_fill_fields(),
+            language="zh",
+        )
+        assert "成交" in out
+        assert "600000.SH" in out and "C1" in out and "B1" in out
+        assert "phase=" not in out
+
+    def test_zh_render_restores_canonical_msg(self) -> None:
+        """After zh rendering the record's msg stays english (file/JSON stay en)."""
+        extra = _build_fill_fields()
+        formatter = AKQuantFormatter("%(message)s", include_context=True, language="zh")
+        record = logging.LogRecord(
+            name="akquant.audit.order",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="fill Buy 100 600000.SH @10.55 [C1->B1 T1]",
+            args=(),
+            exc_info=None,
+        )
+        for key, value in extra.items():
+            setattr(record, key, value)
+        out = formatter.format(record)
+        assert "成交" in out
+        assert record.msg == "fill Buy 100 600000.SH @10.55 [C1->B1 T1]"
+
+    def test_non_audit_keeps_suffix_and_ignores_language(self) -> None:
+        """Free-text records keep the suffix and are unaffected by language."""
+        out = self._format(
+            "akquant.gateway.live",
+            "Connecting native CTP trader gateway to tcp://x",
+            build_log_extra(phase="gateway", strategy_id="s1"),
+            language="zh",
+        )
+        assert "phase=gateway" in out and "strategy_id=s1" in out
+        assert "Connecting native CTP trader gateway" in out
 
 
 class _CaptureHandler(logging.Handler):
@@ -98,6 +217,13 @@ class TestRecordFunctions:
         assert getattr(rec, "client_order_id") == "C1"
         assert getattr(rec, "order_id") == "B1"
         assert rec.levelno == logging.INFO
+        # 展示给用户: message 自带方向/量/价/id, 控制台一眼可读(不依赖结构化后缀)
+        message = rec.getMessage()
+        assert "Buy" in message
+        assert "100" in message
+        assert "10.5" in message
+        assert "600000.SH" in message
+        assert "C1" in message and "B1" in message
 
     def test_record_reject_is_warning(self, capture_audit: _CaptureHandler) -> None:
         """A reject is a WARNING with a reason."""


### PR DESCRIPTION
- 更新项目配置文件版本号至0.3.10
- 新增LogConfig的敏感脱敏、订单审计与多语言控制台配置项
- 实现实盘订单全生命周期审计日志，支持落盘独立JSON文件用于对账复盘
- 添加敏感字段自动脱敏能力，密钥类字段全掩码、账户类字段保留尾4位
- 支持控制台审计日志多语言切换，文件与结构化JSON流始终使用英文
- 新增日志审计演示示例与对应测试用例
- 补全中英文文档与API参考，更新Python类型定义文件
- 重构日志与订单审计模块，优化控制台日志可读性