### PR TITLE
feat(indicator, chart): 升级至0.3.13，统一图表指标数据处理

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.12"
+version = "0.3.13"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.12"
+version = "0.3.13"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/custom_indicator.md
+++ b/docs/en/guide/custom_indicator.md
@@ -220,12 +220,21 @@ class IndicatorExportStrategy(Strategy):
             name="intrabar_spread",
             value=spread,
             display_name="Intra Bar Spread",
-            pane="sub",
+            pane="sub1",
             render_type="line",
             precision=4,
             meta={"source": ["high", "low"]},
         )
 ```
+
+!!! note "About the `pane` value"
+    `pane` is normalized into a canonical string label: `"main"` (the main pane,
+    equivalent to `0` / `"主图"`), `"sub1"`..`"sub4"` (sub panes, equivalent to the
+    integers `1`..`4` or `"副图1"`..`"副图4"`), plus the special `"signal"`. For
+    backward compatibility, omitting `pane` or passing the legacy `"sub"` both
+    normalize to `"sub1"`. This guarantees the same `record_indicator` call yields
+    an identical `pane` on both the plain backtest export and the frontend stream
+    bridge paths.
 
 After the run:
 
@@ -393,6 +402,8 @@ The first implementation exposes three structured layers:
 - indicator definitions, such as `display_name`, `pane`, and `render_type`
 - indicator instances grouped by `strategy/symbol/indicator/meta`
 - indicator points as the actual time series values
+
+Each indicator point carries both `timestamp` (nanoseconds) and `timestamp_ms` (milliseconds): the former is for nanosecond parsing on the Python side, while the latter can be consumed directly by frontend charting libraries without any unit conversion. Indicator `meta` is serialized with `ensure_ascii=False`, so non-ASCII characters (e.g. CJK) stay readable.
 
 This keeps AKQuant focused on producing stable indicator data instead of coupling the framework to a specific charting library.
 

--- a/docs/zh/guide/custom_indicator.md
+++ b/docs/zh/guide/custom_indicator.md
@@ -222,12 +222,18 @@ class IndicatorExportStrategy(Strategy):
             name="intrabar_spread",
             value=spread,
             display_name="Intra Bar Spread",
-            pane="sub",
+            pane="sub1",
             render_type="line",
             precision=4,
             meta={"source": ["high", "low"]},
         )
 ```
+
+!!! note "关于 `pane` 取值"
+    `pane` 会被规范化为统一的字符串标签：`"main"`（主图，等价于 `0` / `"主图"`）、
+    `"sub1"`..`"sub4"`（副图，等价于整数 `1`..`4` 或 `"副图1"`..`"副图4"`）、以及特殊的
+    `"signal"`。为向后兼容，省略 `pane` 或传入历史写法 `"sub"` 都会归一化为 `"sub1"`。
+    这保证同一份 `record_indicator` 调用在纯回测导出与前端流式桥接两条路径上得到一致的 `pane`。
 
 运行结束后：
 
@@ -393,6 +399,10 @@ UV_INDEX_URL=https://pypi.org/simple uv run python examples/64_indicator_live_we
 - 指标定义：如 `display_name`、`pane`、`render_type`
 - 指标实例：按 `strategy/symbol/indicator/meta` 归并后的实例信息
 - 指标点位：按时间记录的数值序列
+
+每个指标点位同时带有 `timestamp`（纳秒）与 `timestamp_ms`（毫秒）两个时间字段：前者供
+Python 侧按纳秒解析，后者可被前端图表库直接使用，无需再做单位换算。指标 `meta` 采用
+`ensure_ascii=False` 序列化，中文等非 ASCII 字符保持可读。
 
 这三层结构的目的，是让 AKQuant 负责“生产标准化指标数据”，而不是直接耦合某个具体前端图表库。
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.12"
+version = "0.3.13"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/chart/__init__.py
+++ b/python/akquant/chart/__init__.py
@@ -1,0 +1,22 @@
+"""Chart-oriented helpers shared by indicator recording and frontend bridges.
+
+This package hosts the single source of truth for chart-facing normalization
+(pane names, millisecond timestamps, JSON-safe values) so that the pure
+backtest path and any frontend chart bridge emit identical payloads.
+"""
+
+from ._normalize import (
+    MAX_SUB_PANES,
+    normalize_meta_json,
+    normalize_pane_label,
+    timestamp_ms_from_ns,
+    timestamp_to_ms_and_ns,
+)
+
+__all__ = [
+    "MAX_SUB_PANES",
+    "normalize_meta_json",
+    "normalize_pane_label",
+    "timestamp_ms_from_ns",
+    "timestamp_to_ms_and_ns",
+]

--- a/python/akquant/chart/_normalize.py
+++ b/python/akquant/chart/_normalize.py
@@ -1,0 +1,138 @@
+"""Stateless normalization helpers for chart-facing indicator payloads.
+
+These functions are the single source of truth shared by the core
+``IndicatorRecorder`` (pure backtest path) and any frontend chart backend.
+Keeping them here guarantees that the same ``record_indicator`` call produces an
+identical pane label, timestamp, and metadata encoding regardless of whether the
+run feeds a plain backtest export or a live chart bridge.
+
+Pane semantics are **string labels** (``"main"`` / ``"sub1".."sub4"`` /
+``"signal"``), matching the contract locked by the backtest result API and the
+indicator stream. This differs from the integer pane index used internally by
+the d3kline renderer; the renderer is free to map these labels to indices.
+"""
+
+import json
+from typing import Any, Dict, Optional, Tuple
+
+import pandas as pd
+
+# Main pane plus up to four stacked sub panes.
+MAX_SUB_PANES = 4
+
+
+def normalize_pane_label(pane: Any, default: str = "sub1") -> str:
+    """Normalize a pane specifier into a canonical string label.
+
+    Accepts the historical spellings used across the codebase and the frontend:
+    ``main`` / ``主图`` / ``0`` -> ``"main"``; ``sub`` / ``sub1`` / ``副图1`` /
+    integer ``1`` -> ``"sub1"``; ``signal`` is preserved verbatim. A bare
+    ``"sub"`` (the historical default) resolves to ``default`` instead of
+    raising, fixing a crash on the frontend bridge path.
+
+    :param pane: Raw pane specifier (str or int).
+    :param default: Label used when the value is empty or a bare ``"sub"``.
+    :return: Canonical pane label.
+    """
+    if pane is None:
+        return "main"
+    if isinstance(pane, bool):
+        raise ValueError("pane must be a string label or integer index")
+    if isinstance(pane, int):
+        return _sub_label_from_index(pane)
+
+    text = str(pane).strip().lower()
+    if not text:
+        return default
+    if text in {"signal"}:
+        return "signal"
+    if text in {"0", "main", "主图"}:
+        return "main"
+    if text == "sub":
+        return default
+    if text.startswith("sub"):
+        text = text[3:]
+    elif text.startswith("副图"):
+        text = text[2:]
+    elif text == "副图":
+        return default
+    if not text:
+        return default
+    if text.isdigit():
+        return _sub_label_from_index(int(text))
+    raise ValueError("pane must be main, sub1..sub4, signal, or 0..4")
+
+
+def _sub_label_from_index(index: int) -> str:
+    """Map an integer pane index to a canonical label."""
+    if index == 0:
+        return "main"
+    if 1 <= index <= MAX_SUB_PANES:
+        return f"sub{index}"
+    raise ValueError(f"pane index supports main plus 1..{MAX_SUB_PANES} sub panes")
+
+
+def timestamp_to_ms_and_ns(timestamp: Any) -> Tuple[int, int]:
+    """Return ``(milliseconds, nanoseconds)`` for a timestamp-like value.
+
+    Recognizes ``pandas.Timestamp``/datetime-like inputs and integer epoch
+    values in millisecond (13-digit), microsecond (16-digit), or nanosecond
+    (19-digit) magnitude. Falls back to pandas parsing for strings.
+
+    :param timestamp: Timestamp-like value.
+    :return: Tuple of epoch milliseconds and epoch nanoseconds.
+    """
+    if isinstance(timestamp, bool):
+        raise ValueError("timestamp must be a timestamp value")
+    if isinstance(timestamp, pd.Timestamp):
+        ns = int(timestamp.value)
+        return ns // 1_000_000, ns
+    if isinstance(timestamp, str):
+        text = timestamp.strip()
+        if text.isdigit():
+            return _ms_ns_from_epoch_int(int(text))
+        ns = int(pd.Timestamp(text).value)
+        return ns // 1_000_000, ns
+    if isinstance(timestamp, float):
+        if not timestamp.is_integer():
+            ns = int(pd.Timestamp(timestamp).value)
+            return ns // 1_000_000, ns
+        timestamp = int(timestamp)
+    if isinstance(timestamp, int):
+        return _ms_ns_from_epoch_int(timestamp)
+    if hasattr(timestamp, "to_pydatetime"):
+        ns = int(pd.Timestamp(timestamp).value)
+        return ns // 1_000_000, ns
+    ns = int(pd.Timestamp(timestamp).value)
+    return ns // 1_000_000, ns
+
+
+def _ms_ns_from_epoch_int(value: int) -> Tuple[int, int]:
+    """Infer ms/ns from an integer epoch value by its digit magnitude."""
+    digits = len(str(abs(value)))
+    if digits <= 13:
+        return value, value * 1_000_000
+    if digits <= 16:
+        ms = value // 1_000
+        return ms, ms * 1_000_000
+    return value // 1_000_000, value
+
+
+def timestamp_ms_from_ns(timestamp_ns: int) -> int:
+    """Convert an epoch-nanosecond integer into epoch milliseconds."""
+    return int(timestamp_ns) // 1_000_000
+
+
+def normalize_meta_json(meta: Optional[Dict[str, Any]]) -> str:
+    """Serialize indicator metadata into a stable, human-readable JSON string.
+
+    Uses ``ensure_ascii=False`` so CJK metadata stays readable, and
+    ``sort_keys=True`` so the encoding is deterministic (important for building
+    stable instance keys).
+
+    :param meta: Optional metadata mapping.
+    :return: JSON string, or an empty string when there is no metadata.
+    """
+    if not meta:
+        return ""
+    return json.dumps(meta, ensure_ascii=False, sort_keys=True, default=str)

--- a/python/akquant/indicator_recording.py
+++ b/python/akquant/indicator_recording.py
@@ -1,7 +1,14 @@
 import json
 from typing import Any, Callable, Dict, Optional, Tuple
 
-import pandas as pd
+from .chart import (
+    normalize_meta_json as _normalize_meta_json,
+)
+from .chart import (
+    normalize_pane_label,
+    timestamp_ms_from_ns,
+    timestamp_to_ms_and_ns,
+)
 
 
 def _normalize_text(value: Any, default: str = "") -> str:
@@ -9,16 +16,9 @@ def _normalize_text(value: Any, default: str = "") -> str:
     return text or default
 
 
-def _normalize_meta_json(meta: Optional[Dict[str, Any]]) -> str:
-    if not meta:
-        return ""
-    return json.dumps(meta, ensure_ascii=True, sort_keys=True, default=str)
-
-
 def _normalize_timestamp_ns(timestamp: Any) -> int:
-    if isinstance(timestamp, pd.Timestamp):
-        return int(timestamp.value)
-    return int(pd.Timestamp(timestamp).value)
+    _, timestamp_ns = timestamp_to_ms_and_ns(timestamp)
+    return timestamp_ns
 
 
 class IndicatorRecorder:
@@ -75,13 +75,14 @@ class IndicatorRecorder:
 
         symbol_text = _normalize_text(symbol, default="_unknown")
         strategy_id = _normalize_text(owner_strategy_id, default="_default")
-        pane_text = _normalize_text(pane, default="sub")
+        pane_text = normalize_pane_label(pane)
         render_type_text = _normalize_text(render_type, default="line")
         display_name_text = _normalize_text(display_name, default=indicator_key)
         unit_text = _normalize_text(unit)
         color_text = _normalize_text(color)
         meta_json = _normalize_meta_json(meta)
         timestamp_ns = _normalize_timestamp_ns(timestamp)
+        timestamp_ms = timestamp_ms_from_ns(timestamp_ns)
 
         try:
             numeric_value = float(value)
@@ -132,6 +133,7 @@ class IndicatorRecorder:
                 "symbol": symbol_text,
                 "indicator_key": indicator_key,
                 "timestamp": timestamp_ns,
+                "timestamp_ms": timestamp_ms,
                 "value": numeric_value,
                 "warmup": bool(warmup),
             }
@@ -149,6 +151,7 @@ class IndicatorRecorder:
                     "render_type": render_type_text,
                     "symbol": symbol_text,
                     "timestamp": str(timestamp_ns),
+                    "timestamp_ms": str(timestamp_ms),
                     "value": repr(numeric_value),
                     "warmup": str(bool(warmup)).lower(),
                     "meta_json": meta_json,
@@ -184,6 +187,7 @@ class IndicatorRecorder:
                     "owner_strategy_id": strategy_id,
                     "symbol": symbol_text,
                     "timestamp": str(timestamp_ns),
+                    "timestamp_ms": str(timestamp_ms_from_ns(timestamp_ns)),
                     "indicator_count": str(len(items)),
                     "items_json": json.dumps(
                         items,

--- a/tests/test_chart_normalize.py
+++ b/tests/test_chart_normalize.py
@@ -1,0 +1,91 @@
+"""Unit tests for the shared chart normalization helpers."""
+
+import pandas as pd
+import pytest
+from akquant.chart import (
+    normalize_meta_json,
+    normalize_pane_label,
+    timestamp_ms_from_ns,
+    timestamp_to_ms_and_ns,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "main"),
+        ("main", "main"),
+        ("主图", "main"),
+        (0, "main"),
+        ("0", "main"),
+        ("signal", "signal"),
+        ("SIGNAL", "signal"),
+        ("sub", "sub1"),  # historical default must not crash
+        ("sub1", "sub1"),
+        ("sub4", "sub4"),
+        (1, "sub1"),
+        (4, "sub4"),
+        ("副图2", "sub2"),
+    ],
+)
+def test_normalize_pane_label_accepts_known_spellings(
+    raw: object, expected: str
+) -> None:
+    """All historical pane spellings map to a canonical label."""
+    assert normalize_pane_label(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["sub9", "副图9", "unknown", 9])
+def test_normalize_pane_label_rejects_out_of_range(raw: object) -> None:
+    """Out-of-range or unknown pane specifiers raise ValueError."""
+    with pytest.raises(ValueError):
+        normalize_pane_label(raw)
+
+
+def test_normalize_pane_label_rejects_bool() -> None:
+    """Booleans are not valid pane specifiers even though they are ints."""
+    with pytest.raises(ValueError):
+        normalize_pane_label(True)
+
+
+def test_timestamp_to_ms_and_ns_from_pandas_timestamp() -> None:
+    """A pandas Timestamp yields matching ms and ns integers."""
+    ts = pd.Timestamp("2024-01-02 10:00:00")
+    ms, ns = timestamp_to_ms_and_ns(ts)
+    assert ns == int(ts.value)
+    assert ms == ns // 1_000_000
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_ms"),
+    [
+        (1_704_189_600_000, 1_704_189_600_000),  # 13-digit ms
+        (1_704_189_600_000_000, 1_704_189_600_000),  # 16-digit us
+        (1_704_189_600_000_000_000, 1_704_189_600_000),  # 19-digit ns
+    ],
+)
+def test_timestamp_to_ms_and_ns_infers_epoch_magnitude(
+    value: int, expected_ms: int
+) -> None:
+    """Integer epoch values are disambiguated by digit magnitude."""
+    ms, ns = timestamp_to_ms_and_ns(value)
+    assert ms == expected_ms
+    assert ns == expected_ms * 1_000_000
+
+
+def test_timestamp_ms_from_ns_round_trip() -> None:
+    """Nanosecond-to-millisecond conversion truncates as expected."""
+    assert timestamp_ms_from_ns(1_704_189_600_123_456_789) == 1_704_189_600_123
+
+
+def test_normalize_meta_json_keeps_cjk_readable() -> None:
+    """CJK metadata stays human-readable (no ASCII escaping) and is sorted."""
+    encoded = normalize_meta_json({"名称": "均线", "period": 20})
+    assert "均线" in encoded
+    assert encoded == '{"period": 20, "名称": "均线"}'
+
+
+def test_normalize_meta_json_empty() -> None:
+    """Empty or missing metadata serializes to an empty string."""
+    assert normalize_meta_json(None) == ""
+    assert normalize_meta_json({}) == ""

--- a/tests/test_indicator_recording.py
+++ b/tests/test_indicator_recording.py
@@ -107,6 +107,56 @@ def test_indicator_recording_round_trip(tmp_path: Path) -> None:
     assert len(payload["points"]) == 6
 
 
+class DefaultPaneStrategy(Strategy):
+    """Record an indicator without specifying a pane (exercises the default)."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Record one point relying on the default pane value."""
+        self.record_indicator(name="default_pane", value=bar.close)
+
+
+def test_indicator_points_expose_millisecond_timestamp() -> None:
+    """Recorded points carry a millisecond timestamp alongside the ns value."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+    )
+
+    points = result.indicator_outputs["points"]
+    assert points, "expected recorded indicator points"
+    for point in points:
+        assert "timestamp_ms" in point
+        assert point["timestamp_ms"] == point["timestamp"] // 1_000_000
+
+
+def test_default_pane_normalizes_without_crashing() -> None:
+    """Omitting pane resolves to a canonical sub pane label, not a bare 'sub'."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=DefaultPaneStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+    )
+
+    definitions = result.indicator_definitions
+    assert len(definitions) == 1
+    assert definitions.iloc[0]["pane"] == "sub1"
+
+
 def test_legacy_strategy_without_indicator_recording_stays_empty() -> None:
     """Legacy strategies should still work and expose empty indicator outputs."""
     result = run_backtest(


### PR DESCRIPTION
抽离指标归一化逻辑至独立的chart模块，确保纯回测与前端桥接的输出完全一致
重构指标记录模块，规范化pane参数处理，兼容旧版"sub"写法并将默认值设为"sub1"
新增timestamp_ms字段，前端图表可直接使用无需额外转换时间单位
补充完整的中英文文档与单元测试用例
更新配置文件版本号至0.3.13