### PR TITLE
refactor(chart): 重构图表模块的pane与render_type规范化逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ CLAUDE.md
 
 # ── 本地数据 ──
 /data_catalog/
+/examples/indicator_visualization_preview.html
+/examples/indicator_visualization_outputs.json
 
 # ── AI 工作流文档（内部，不公开）──
 docs/superpowers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.13"
+version = "0.3.14"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/custom_indicator.md
+++ b/docs/en/guide/custom_indicator.md
@@ -220,7 +220,7 @@ class IndicatorExportStrategy(Strategy):
             name="intrabar_spread",
             value=spread,
             display_name="Intra Bar Spread",
-            pane="sub1",
+            pane=1,
             render_type="line",
             precision=4,
             meta={"source": ["high", "low"]},
@@ -228,13 +228,34 @@ class IndicatorExportStrategy(Strategy):
 ```
 
 !!! note "About the `pane` value"
-    `pane` is normalized into a canonical string label: `"main"` (the main pane,
-    equivalent to `0` / `"主图"`), `"sub1"`..`"sub4"` (sub panes, equivalent to the
-    integers `1`..`4` or `"副图1"`..`"副图4"`), plus the special `"signal"`. For
-    backward compatibility, omitting `pane` or passing the legacy `"sub"` both
-    normalize to `"sub1"`. This guarantees the same `record_indicator` call yields
-    an identical `pane` on both the plain backtest export and the frontend stream
-    bridge paths.
+    `pane` is an **integer row index**: `0` is the main (price) pane and `1`..`4`
+    are sub panes stacked below it. Omitting `pane` defaults to the main pane
+    (`0`). Values outside `0..4` raise an error. This matches what chart renderers
+    actually consume, and `record_indicator` emits the same integer `pane` on both
+    the plain backtest export and the frontend stream bridge paths.
+
+!!! warning "Breaking change since 0.3"
+    Earlier versions accepted string panes such as `"main"` / `"sub1"` / `"主图"` /
+    `"signal"`; these have been removed. Use integer indices instead. The former
+    `pane="signal"` semantics (drawing trade signals) is now expressed with
+    `render_type="signal"` rendered on the main pane (`pane=0`).
+
+!!! note "About the `render_type` value"
+    `render_type` is a **closed enum** of 7 values, so consumers can implement
+    exhaustive rendering branches:
+
+    | Value | Rendering |
+    | :--- | :--- |
+    | `line` | Connected line (default) |
+    | `area` | Line filled to zero |
+    | `bar` | Vertical bars |
+    | `column` | Alias of `bar` (semantic: categorical columns) |
+    | `histogram` | Alias of `bar` (semantic: distribution bars) |
+    | `scatter` | Disconnected point markers |
+    | `signal` | Trade-signal markers, drawn on the main pane |
+
+    Passing a value outside the enum raises `ValueError` (fail-fast) rather than
+    silently degrading to a line.
 
 After the run:
 

--- a/docs/zh/guide/custom_indicator.md
+++ b/docs/zh/guide/custom_indicator.md
@@ -222,7 +222,7 @@ class IndicatorExportStrategy(Strategy):
             name="intrabar_spread",
             value=spread,
             display_name="Intra Bar Spread",
-            pane="sub1",
+            pane=1,
             render_type="line",
             precision=4,
             meta={"source": ["high", "low"]},
@@ -230,10 +230,29 @@ class IndicatorExportStrategy(Strategy):
 ```
 
 !!! note "关于 `pane` 取值"
-    `pane` 会被规范化为统一的字符串标签：`"main"`（主图，等价于 `0` / `"主图"`）、
-    `"sub1"`..`"sub4"`（副图，等价于整数 `1`..`4` 或 `"副图1"`..`"副图4"`）、以及特殊的
-    `"signal"`。为向后兼容，省略 `pane` 或传入历史写法 `"sub"` 都会归一化为 `"sub1"`。
-    这保证同一份 `record_indicator` 调用在纯回测导出与前端流式桥接两条路径上得到一致的 `pane`。
+    `pane` 是**整数行索引**：`0` 表示主图（价格图），`1`..`4` 表示主图下方堆叠的副图。
+    省略 `pane` 默认落在主图（`0`）。取值超出 `0..4` 会直接报错。这与图表渲染器实际消费的
+    形态一致，`record_indicator` 在纯回测导出与前端流式桥接两条路径上输出相同的整数 `pane`。
+
+!!! warning "0.3 起的破坏性变更"
+    早期版本 `pane` 曾支持 `"main"` / `"sub1"` / `"主图"` / `"signal"` 等字符串写法，现已移除。
+    请改用整数索引；原先画交易信号用的 `pane="signal"` 语义，改为用 `render_type="signal"`
+    在主图（`pane=0`）上渲染标记。
+
+!!! note "关于 `render_type` 取值"
+    `render_type` 是一个**封闭枚举**，共 7 个值，消费者可据此穷举渲染分支：
+
+    | 值 | 渲染 |
+    | :--- | :--- |
+    | `line` | 折线（默认） |
+    | `area` | 折线 + 向零填充 |
+    | `bar` | 垂直柱 |
+    | `column` | `bar` 的别名（语义化：分类柱） |
+    | `histogram` | `bar` 的别名（语义化：分布柱） |
+    | `scatter` | 离散点标记 |
+    | `signal` | 交易信号标记，渲染在主图 |
+
+    传入枚举以外的值会直接抛 `ValueError`（fail-fast），不会静默退化成折线。
 
 运行结束后：
 

--- a/examples/61_indicator_visualization_export_demo.py
+++ b/examples/61_indicator_visualization_export_demo.py
@@ -46,7 +46,7 @@ class IndicatorVisualizationStrategy(Strategy):
             name="intrabar_spread",
             value=intrabar_spread,
             display_name="Intra Bar Spread",
-            pane="sub",
+            pane=1,
             render_type="line",
             precision=4,
             meta={"source": ["high", "low"]},

--- a/examples/62_indicator_streaming_demo.py
+++ b/examples/62_indicator_streaming_demo.py
@@ -44,7 +44,7 @@ class IndicatorStreamingStrategy(Strategy):
             name="close_echo",
             value=bar.close,
             display_name="Close Echo",
-            pane="main",
+            pane=0,
             render_type="line",
             precision=2,
         )
@@ -52,7 +52,7 @@ class IndicatorStreamingStrategy(Strategy):
             name="intrabar_range",
             value=bar.high - bar.low,
             display_name="Intrabar Range",
-            pane="signal",
+            pane=1,
             render_type="bar",
             precision=2,
         )

--- a/examples/63_indicator_ws_bridge_demo.py
+++ b/examples/63_indicator_ws_bridge_demo.py
@@ -44,7 +44,7 @@ class IndicatorBridgeStrategy(Strategy):
             name="close_echo",
             value=bar.close,
             display_name="Close Echo",
-            pane="main",
+            pane=0,
             render_type="line",
             meta={"source": "close"},
         )
@@ -52,7 +52,7 @@ class IndicatorBridgeStrategy(Strategy):
             name="daily_range",
             value=bar.high - bar.low,
             display_name="Daily Range",
-            pane="signal",
+            pane=1,
             render_type="bar",
             meta={"source": ["high", "low"]},
         )

--- a/examples/64_indicator_live_web.py
+++ b/examples/64_indicator_live_web.py
@@ -53,7 +53,7 @@ class LiveIndicatorStrategy(Strategy):
             name="close_echo",
             value=bar.close,
             display_name="Close Echo",
-            pane="main",
+            pane=0,
             render_type="line",
             meta={"source": "close"},
         )
@@ -61,7 +61,7 @@ class LiveIndicatorStrategy(Strategy):
             name="intrabar_range",
             value=bar.high - bar.low,
             display_name="Intrabar Range",
-            pane="signal",
+            pane=1,
             render_type="bar",
             meta={"source": ["high", "low"]},
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.13"
+version = "0.3.14"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -1593,6 +1593,7 @@ class BacktestResult:
             "symbol",
             "indicator_key",
             "timestamp",
+            "timestamp_ms",
             "value",
             "warmup",
         ]
@@ -1604,6 +1605,14 @@ class BacktestResult:
                 frame[column] = None
         frame["timestamp"] = pd.to_numeric(frame["timestamp"], errors="coerce").astype(
             "Int64"
+        )
+        # ``timestamp_ms`` mirrors ``timestamp`` for frontend charting libraries
+        # that expect epoch milliseconds; derive it when a legacy payload omits it.
+        frame["timestamp_ms"] = pd.to_numeric(
+            frame["timestamp_ms"], errors="coerce"
+        ).astype("Int64")
+        frame["timestamp_ms"] = frame["timestamp_ms"].fillna(
+            frame["timestamp"] // 1_000_000
         )
         frame["datetime"] = pd.to_datetime(
             frame["timestamp"],
@@ -1645,8 +1654,10 @@ class BacktestResult:
                 "points": self._json_ready_records(self._indicator_points_df),
             }
             output_path.parent.mkdir(parents=True, exist_ok=True)
+            # ``ensure_ascii=False`` keeps CJK metadata readable and matches the
+            # indicator collection layer, so the export and stream paths agree.
             output_path.write_text(
-                json.dumps(payload, ensure_ascii=True, indent=2),
+                json.dumps(payload, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
             return
@@ -1691,8 +1702,10 @@ class BacktestResult:
         )
         if output_format == "json":
             output_path.parent.mkdir(parents=True, exist_ok=True)
+            # ``ensure_ascii=False`` keeps CJK benchmark labels readable, matching
+            # export_indicators so all structured exports share one encoding.
             output_path.write_text(
-                json.dumps(payload, ensure_ascii=True, indent=2),
+                json.dumps(payload, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
             return
@@ -1703,7 +1716,7 @@ class BacktestResult:
             metadata = dict(payload)
             metadata.pop("series", None)
             (output_path / "metadata.json").write_text(
-                json.dumps(metadata, ensure_ascii=True, indent=2),
+                json.dumps(metadata, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
             return

--- a/python/akquant/chart/__init__.py
+++ b/python/akquant/chart/__init__.py
@@ -7,16 +7,20 @@ backtest path and any frontend chart bridge emit identical payloads.
 
 from ._normalize import (
     MAX_SUB_PANES,
+    RENDER_TYPE_CANONICAL,
     normalize_meta_json,
-    normalize_pane_label,
+    normalize_pane_index,
+    normalize_render_type,
     timestamp_ms_from_ns,
     timestamp_to_ms_and_ns,
 )
 
 __all__ = [
     "MAX_SUB_PANES",
+    "RENDER_TYPE_CANONICAL",
     "normalize_meta_json",
-    "normalize_pane_label",
+    "normalize_pane_index",
+    "normalize_render_type",
     "timestamp_ms_from_ns",
     "timestamp_to_ms_and_ns",
 ]

--- a/python/akquant/chart/_normalize.py
+++ b/python/akquant/chart/_normalize.py
@@ -3,13 +3,16 @@
 These functions are the single source of truth shared by the core
 ``IndicatorRecorder`` (pure backtest path) and any frontend chart backend.
 Keeping them here guarantees that the same ``record_indicator`` call produces an
-identical pane label, timestamp, and metadata encoding regardless of whether the
+identical pane index, render type, and metadata encoding regardless of whether the
 run feeds a plain backtest export or a live chart bridge.
 
-Pane semantics are **string labels** (``"main"`` / ``"sub1".."sub4"`` /
-``"signal"``), matching the contract locked by the backtest result API and the
-indicator stream. This differs from the integer pane index used internally by
-the d3kline renderer; the renderer is free to map these labels to indices.
+Pane semantics are **integer row indices** (``0`` = main price pane,
+``1``..``MAX_SUB_PANES`` = stacked sub panes).  Unknown or string pane values
+raise ``ValueError`` immediately rather than silently degrading.
+
+``render_type`` is a **closed string enum** (``RENDER_TYPE_CANONICAL``).
+Unknown render types also raise ``ValueError`` so that downstream chart renderers
+can implement exhaustive branches without encountering undefined values.
 """
 
 import json
@@ -20,56 +23,76 @@ import pandas as pd
 # Main pane plus up to four stacked sub panes.
 MAX_SUB_PANES = 4
 
+# Closed set of render types a chart renderer must handle. Each value has a
+# defined rendering in ``akquant.plot.indicator`` and is documented in the guide.
+#   line      -> connected line series
+#   area      -> line series with fill to zero
+#   bar       -> vertical bars
+#   column    -> alias of bar (semantic label for categorical columns)
+#   histogram -> alias of bar (semantic label for distribution-style bars)
+#   scatter   -> disconnected point markers
+#   signal    -> trade-signal markers, drawn on the main price pane
+RENDER_TYPE_CANONICAL = (
+    "line",
+    "area",
+    "bar",
+    "column",
+    "histogram",
+    "scatter",
+    "signal",
+)
 
-def normalize_pane_label(pane: Any, default: str = "sub1") -> str:
-    """Normalize a pane specifier into a canonical string label.
 
-    Accepts the historical spellings used across the codebase and the frontend:
-    ``main`` / ``主图`` / ``0`` -> ``"main"``; ``sub`` / ``sub1`` / ``副图1`` /
-    integer ``1`` -> ``"sub1"``; ``signal`` is preserved verbatim. A bare
-    ``"sub"`` (the historical default) resolves to ``default`` instead of
-    raising, fixing a crash on the frontend bridge path.
+def normalize_render_type(render_type: Any = "line") -> str:
+    """Normalize a render-type specifier against the canonical enum.
 
-    :param pane: Raw pane specifier (str or int).
-    :param default: Label used when the value is empty or a bare ``"sub"``.
-    :return: Canonical pane label.
+    :param render_type: Render type. Empty/``None`` resolves to ``"line"``.
+    :return: A canonical render type from :data:`RENDER_TYPE_CANONICAL`.
+    :raises ValueError: If the value is not a recognized render type.
+    """
+    if render_type is None:
+        return "line"
+    text = str(render_type).strip().lower()
+    if not text:
+        return "line"
+    if text not in RENDER_TYPE_CANONICAL:
+        raise ValueError(
+            "render_type must be one of %s" % ", ".join(RENDER_TYPE_CANONICAL)
+        )
+    return text
+
+
+def normalize_pane_index(pane: Any = 0) -> int:
+    """Normalize a pane specifier into a canonical integer index.
+
+    Panes are plain integer row indices, matching what chart renderers actually
+    consume: ``0`` is the main (price) pane and ``1..MAX_SUB_PANES`` are stacked
+    sub panes below it. ``None`` resolves to the main pane.
+
+    :param pane: Pane index. Accepts ``int`` or an all-digit ``str``.
+    :return: Pane index in ``0..MAX_SUB_PANES``.
+    :raises ValueError: If the pane is out of range or not an integer index.
     """
     if pane is None:
-        return "main"
+        return 0
     if isinstance(pane, bool):
-        raise ValueError("pane must be a string label or integer index")
+        raise ValueError("pane must be an integer index in 0..%d" % MAX_SUB_PANES)
+    if isinstance(pane, str):
+        text = pane.strip()
+        if not text:
+            return 0
+        if not (text.lstrip("+").isdigit()):
+            raise ValueError(
+                "pane must be an integer index in 0..%d (0=main)" % MAX_SUB_PANES
+            )
+        pane = int(text)
     if isinstance(pane, int):
-        return _sub_label_from_index(pane)
-
-    text = str(pane).strip().lower()
-    if not text:
-        return default
-    if text in {"signal"}:
-        return "signal"
-    if text in {"0", "main", "主图"}:
-        return "main"
-    if text == "sub":
-        return default
-    if text.startswith("sub"):
-        text = text[3:]
-    elif text.startswith("副图"):
-        text = text[2:]
-    elif text == "副图":
-        return default
-    if not text:
-        return default
-    if text.isdigit():
-        return _sub_label_from_index(int(text))
-    raise ValueError("pane must be main, sub1..sub4, signal, or 0..4")
-
-
-def _sub_label_from_index(index: int) -> str:
-    """Map an integer pane index to a canonical label."""
-    if index == 0:
-        return "main"
-    if 1 <= index <= MAX_SUB_PANES:
-        return f"sub{index}"
-    raise ValueError(f"pane index supports main plus 1..{MAX_SUB_PANES} sub panes")
+        if 0 <= pane <= MAX_SUB_PANES:
+            return pane
+        raise ValueError(
+            "pane index supports 0 (main) plus 1..%d sub panes" % MAX_SUB_PANES
+        )
+    raise ValueError("pane must be an integer index in 0..%d" % MAX_SUB_PANES)
 
 
 def timestamp_to_ms_and_ns(timestamp: Any) -> Tuple[int, int]:

--- a/python/akquant/indicator_recording.py
+++ b/python/akquant/indicator_recording.py
@@ -5,7 +5,8 @@ from .chart import (
     normalize_meta_json as _normalize_meta_json,
 )
 from .chart import (
-    normalize_pane_label,
+    normalize_pane_index,
+    normalize_render_type,
     timestamp_ms_from_ns,
     timestamp_to_ms_and_ns,
 )
@@ -60,7 +61,7 @@ class IndicatorRecorder:
         timestamp: Any,
         owner_strategy_id: str,
         display_name: Optional[str] = None,
-        pane: str = "sub",
+        pane: int = 0,
         render_type: str = "line",
         unit: Optional[str] = None,
         precision: Optional[int] = None,
@@ -75,8 +76,8 @@ class IndicatorRecorder:
 
         symbol_text = _normalize_text(symbol, default="_unknown")
         strategy_id = _normalize_text(owner_strategy_id, default="_default")
-        pane_text = normalize_pane_label(pane)
-        render_type_text = _normalize_text(render_type, default="line")
+        pane_index = normalize_pane_index(pane)
+        render_type_text = normalize_render_type(render_type)
         display_name_text = _normalize_text(display_name, default=indicator_key)
         unit_text = _normalize_text(unit)
         color_text = _normalize_text(color)
@@ -94,7 +95,7 @@ class IndicatorRecorder:
             self._definitions[indicator_key] = {
                 "indicator_key": indicator_key,
                 "display_name": display_name_text,
-                "pane": pane_text,
+                "pane": pane_index,
                 "render_type": render_type_text,
                 "unit": unit_text,
                 "precision": precision,
@@ -103,8 +104,8 @@ class IndicatorRecorder:
         else:
             if not definition.get("display_name"):
                 definition["display_name"] = display_name_text
-            if not definition.get("pane"):
-                definition["pane"] = pane_text
+            if definition.get("pane") is None:
+                definition["pane"] = pane_index
             if not definition.get("render_type"):
                 definition["render_type"] = render_type_text
             if not definition.get("unit"):
@@ -147,7 +148,7 @@ class IndicatorRecorder:
                     "owner_strategy_id": strategy_id,
                     "indicator_key": indicator_key,
                     "display_name": display_name_text,
-                    "pane": pane_text,
+                    "pane": str(pane_index),
                     "render_type": render_type_text,
                     "symbol": symbol_text,
                     "timestamp": str(timestamp_ns),
@@ -163,7 +164,7 @@ class IndicatorRecorder:
                 {
                     "indicator_key": indicator_key,
                     "display_name": display_name_text,
-                    "pane": pane_text,
+                    "pane": pane_index,
                     "render_type": render_type_text,
                     "value": numeric_value,
                     "warmup": bool(warmup),
@@ -191,7 +192,7 @@ class IndicatorRecorder:
                     "indicator_count": str(len(items)),
                     "items_json": json.dumps(
                         items,
-                        ensure_ascii=True,
+                        ensure_ascii=False,
                         sort_keys=True,
                         default=str,
                     ),

--- a/python/akquant/indicator_stream.py
+++ b/python/akquant/indicator_stream.py
@@ -78,7 +78,7 @@ def to_indicator_message(event: BacktestStreamEvent) -> Optional[dict[str, Any]]
             "owner_strategy_id": str(payload.get("owner_strategy_id", "")),
             "indicator_key": str(payload.get("indicator_key", "")),
             "display_name": str(payload.get("display_name", "")),
-            "pane": str(payload.get("pane", "")),
+            "pane": _to_int(payload.get("pane", 0)),
             "render_type": str(payload.get("render_type", "")),
             "symbol": _normalize_symbol(payload.get("symbol")),
             "timestamp": _to_int(payload.get("timestamp", 0)),
@@ -98,7 +98,7 @@ def to_indicator_message(event: BacktestStreamEvent) -> Optional[dict[str, Any]]
                 {
                     "indicator_key": str(raw_item.get("indicator_key", "")),
                     "display_name": str(raw_item.get("display_name", "")),
-                    "pane": str(raw_item.get("pane", "")),
+                    "pane": _to_int(raw_item.get("pane", 0)),
                     "render_type": str(raw_item.get("render_type", "")),
                     "value": _to_float_or_text(raw_item.get("value")),
                     "warmup": _to_bool(raw_item.get("warmup", False)),
@@ -107,7 +107,7 @@ def to_indicator_message(event: BacktestStreamEvent) -> Optional[dict[str, Any]]
             )
 
     indicator_keys = [item["indicator_key"] for item in items if item["indicator_key"]]
-    panes = sorted({item["pane"] for item in items if item["pane"]})
+    panes = sorted({item["pane"] for item in items})
     render_types = sorted(
         {item["render_type"] for item in items if item["render_type"]}
     )

--- a/python/akquant/plot/indicator.py
+++ b/python/akquant/plot/indicator.py
@@ -1,6 +1,6 @@
 """Indicator plotting module."""
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import pandas as pd
 
@@ -8,6 +8,73 @@ from .utils import check_plotly, get_color, go, make_subplots
 
 if TYPE_CHECKING:
     from ..backtest import BacktestResult
+
+
+def _pane_title(pane: int) -> str:
+    """Render a human-readable pane title from its integer index."""
+    return "Main" if int(pane) == 0 else f"Sub {int(pane)}"
+
+
+def _build_indicator_trace(
+    *,
+    render_type: str,
+    x_data: "pd.Series[Any]",
+    y_data: "pd.Series[Any]",
+    trace_name: str,
+    color_value: Any,
+    use_webgl: bool,
+) -> Any:
+    """Build a Plotly trace for one indicator series by canonical render type.
+
+    Every value in ``RENDER_TYPE_CANONICAL`` has an explicit rendering here so no
+    render type silently degrades to a line.
+    """
+    if render_type in {"bar", "column", "histogram"}:
+        return go.Bar(
+            x=x_data,
+            y=y_data,
+            name=trace_name,
+            marker=dict(color=color_value) if color_value else None,
+        )
+
+    scatter_type = go.Scattergl if use_webgl else go.Scatter
+    if render_type == "scatter":
+        return scatter_type(
+            x=x_data,
+            y=y_data,
+            mode="markers",
+            name=trace_name,
+            marker=dict(color=color_value) if color_value else None,
+        )
+    if render_type == "signal":
+        return scatter_type(
+            x=x_data,
+            y=y_data,
+            mode="markers",
+            name=trace_name,
+            marker=dict(
+                symbol="triangle-up",
+                size=10,
+                color=color_value if color_value else None,
+            ),
+        )
+    if render_type == "area":
+        return scatter_type(
+            x=x_data,
+            y=y_data,
+            mode="lines",
+            name=trace_name,
+            fill="tozeroy",
+            line=dict(color=color_value, width=2) if color_value else dict(width=2),
+        )
+    # render_type == "line" (canonical default)
+    return scatter_type(
+        x=x_data,
+        y=y_data,
+        mode="lines",
+        name=trace_name,
+        line=dict(color=color_value, width=2) if color_value else dict(width=2),
+    )
 
 
 def _build_trace_name(
@@ -76,7 +143,9 @@ def plot_indicators(
         suffixes=("", "_definition"),
     )
     merged["display_name"] = merged["display_name"].fillna(merged["indicator_key"])
-    merged["pane"] = merged["pane"].fillna("main").replace("", "main")
+    merged["pane"] = (
+        pd.to_numeric(merged["pane"], errors="coerce").fillna(0).astype(int)
+    )
     merged["render_type"] = merged["render_type"].fillna("line").replace("", "line")
     merged["owner_strategy_id"] = merged["owner_strategy_id"].fillna("").astype(str)
     merged["symbol"] = merged["symbol"].fillna("").astype(str)
@@ -87,8 +156,8 @@ def plot_indicators(
         print("No indicator data available after filtering invalid rows.")
         return None
 
-    panes = merged["pane"].drop_duplicates().tolist()
-    subplot_titles = [str(pane) for pane in panes]
+    panes = sorted(merged["pane"].drop_duplicates().tolist())
+    subplot_titles = [_pane_title(pane) for pane in panes]
     row_count = max(len(panes), 1)
 
     fig = make_subplots(
@@ -133,36 +202,20 @@ def plot_indicators(
             x_data = series_frame["datetime"]
             y_data = series_frame["value"].astype(float)
 
-            if render_type in {"bar", "histogram", "column"}:
-                fig.add_trace(
-                    go.Bar(
-                        x=x_data,
-                        y=y_data,
-                        name=trace_name,
-                        marker=dict(color=color_value) if color_value else None,
-                    ),
-                    row=row_index,
-                    col=1,
-                )
-            else:
-                trace_type = go.Scattergl if use_webgl else go.Scatter
-                fig.add_trace(
-                    trace_type(
-                        x=x_data,
-                        y=y_data,
-                        mode="lines",
-                        name=trace_name,
-                        line=(
-                            dict(color=color_value, width=2)
-                            if color_value
-                            else dict(width=2)
-                        ),
-                    ),
-                    row=row_index,
-                    col=1,
-                )
+            fig.add_trace(
+                _build_indicator_trace(
+                    render_type=render_type,
+                    x_data=x_data,
+                    y_data=y_data,
+                    trace_name=trace_name,
+                    color_value=color_value,
+                    use_webgl=use_webgl,
+                ),
+                row=row_index,
+                col=1,
+            )
 
-            fig.update_yaxes(title_text=str(pane_name), row=row_index, col=1)
+            fig.update_yaxes(title_text=_pane_title(pane_name), row=row_index, col=1)
 
     xaxis_format = "%Y-%m-%d"
     if len(merged) > 1:

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1744,7 +1744,7 @@ class Strategy:
         *,
         timestamp: Optional[Any] = None,
         display_name: Optional[str] = None,
-        pane: str = "sub",
+        pane: int = 0,
         render_type: str = "line",
         unit: Optional[str] = None,
         precision: Optional[int] = None,

--- a/tests/test_chart_normalize.py
+++ b/tests/test_chart_normalize.py
@@ -3,49 +3,67 @@
 import pandas as pd
 import pytest
 from akquant.chart import (
+    RENDER_TYPE_CANONICAL,
     normalize_meta_json,
-    normalize_pane_label,
+    normalize_pane_index,
+    normalize_render_type,
     timestamp_ms_from_ns,
     timestamp_to_ms_and_ns,
 )
 
 
+@pytest.mark.parametrize("value", RENDER_TYPE_CANONICAL)
+def test_normalize_render_type_accepts_canonical(value: str) -> None:
+    """Every canonical render type normalizes to itself."""
+    assert normalize_render_type(value) == value
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [(None, "line"), ("", "line"), ("  ", "line"), ("LINE", "line"), ("Bar", "bar")],
+)
+def test_normalize_render_type_defaults_and_casing(raw: object, expected: str) -> None:
+    """Empty values default to line and casing is normalized."""
+    assert normalize_render_type(raw) == expected
+
+
+@pytest.mark.parametrize("raw", ["candlestick", "spline", "pie", "unknown"])
+def test_normalize_render_type_rejects_unknown(raw: object) -> None:
+    """Render types outside the canonical enum raise ValueError (fail-fast)."""
+    with pytest.raises(ValueError):
+        normalize_render_type(raw)
+
+
 @pytest.mark.parametrize(
     ("raw", "expected"),
     [
-        (None, "main"),
-        ("main", "main"),
-        ("主图", "main"),
-        (0, "main"),
-        ("0", "main"),
-        ("signal", "signal"),
-        ("SIGNAL", "signal"),
-        ("sub", "sub1"),  # historical default must not crash
-        ("sub1", "sub1"),
-        ("sub4", "sub4"),
-        (1, "sub1"),
-        (4, "sub4"),
-        ("副图2", "sub2"),
+        (None, 0),
+        (0, 0),
+        ("0", 0),
+        (1, 1),
+        (4, 4),
+        ("2", 2),
+        ("", 0),
     ],
 )
-def test_normalize_pane_label_accepts_known_spellings(
-    raw: object, expected: str
+def test_normalize_pane_index_accepts_integer_specifiers(
+    raw: object, expected: int
 ) -> None:
-    """All historical pane spellings map to a canonical label."""
-    assert normalize_pane_label(raw) == expected
+    """Pane specifiers normalize to an integer row index (0=main)."""
+    assert normalize_pane_index(raw) == expected
 
 
-@pytest.mark.parametrize("raw", ["sub9", "副图9", "unknown", 9])
-def test_normalize_pane_label_rejects_out_of_range(raw: object) -> None:
-    """Out-of-range or unknown pane specifiers raise ValueError."""
+@pytest.mark.parametrize("raw", [5, 9, -1, "9", "main", "sub1", "副图2", "signal"])
+def test_normalize_pane_index_rejects_out_of_range_or_labels(raw: object) -> None:
+    """Out-of-range indices and legacy string labels raise ValueError."""
     with pytest.raises(ValueError):
-        normalize_pane_label(raw)
+        normalize_pane_index(raw)
 
 
-def test_normalize_pane_label_rejects_bool() -> None:
+def test_normalize_pane_index_rejects_bool() -> None:
     """Booleans are not valid pane specifiers even though they are ints."""
     with pytest.raises(ValueError):
-        normalize_pane_label(True)
+        normalize_pane_index(True)
 
 
 def test_timestamp_to_ms_and_ns_from_pandas_timestamp() -> None:

--- a/tests/test_indicator_recording.py
+++ b/tests/test_indicator_recording.py
@@ -41,7 +41,7 @@ class IndicatorRecordingStrategy(Strategy):
             name="close_echo",
             value=bar.close,
             display_name="Close Echo",
-            pane="main",
+            pane=0,
             render_type="line",
             precision=2,
             meta={"source": "close"},
@@ -50,8 +50,8 @@ class IndicatorRecordingStrategy(Strategy):
             name="range_echo",
             value=bar.high - bar.low,
             display_name="Range Echo",
-            pane="signal",
-            render_type="bar",
+            pane=1,
+            render_type="signal",
             meta={"source": ["high", "low"]},
             warmup=bar.close < 10.5,
         )
@@ -92,7 +92,7 @@ def test_indicator_recording_round_trip(tmp_path: Path) -> None:
     definitions = result.indicator_definitions
     assert len(definitions) == 2
     assert definitions.iloc[0]["display_name"] == "Close Echo"
-    assert definitions.iloc[0]["pane"] == "main"
+    assert definitions.iloc[0]["pane"] == 0
     assert definitions.iloc[0]["render_type"] == "line"
     assert definitions.iloc[1]["display_name"] == "Range Echo"
 
@@ -137,8 +137,70 @@ def test_indicator_points_expose_millisecond_timestamp() -> None:
         assert point["timestamp_ms"] == point["timestamp"] // 1_000_000
 
 
-def test_default_pane_normalizes_without_crashing() -> None:
-    """Omitting pane resolves to a canonical sub pane label, not a bare 'sub'."""
+class CjkMetaStrategy(Strategy):
+    """Record an indicator carrying CJK display name and metadata."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Record one point with non-ASCII metadata."""
+        self.record_indicator(
+            name="均线",
+            value=bar.close,
+            display_name="五日均线",
+            meta={"名称": "五日线"},
+        )
+
+
+def test_indicator_df_and_export_agree_on_timestamp_ms(tmp_path: Path) -> None:
+    """timestamp_ms must be present on the DataFrame, export JSON, and raw points."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=IndicatorRecordingStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+    )
+
+    frame = result.indicator_df()
+    assert "timestamp_ms" in frame.columns
+    assert (frame["timestamp_ms"] == frame["timestamp"] // 1_000_000).all()
+
+    export_path = tmp_path / "indicators.json"
+    result.export_indicators(str(export_path), format="json")
+    payload = json.loads(export_path.read_text(encoding="utf-8"))
+    for point in payload["points"]:
+        assert "timestamp_ms" in point
+        assert point["timestamp_ms"] == point["timestamp"] // 1_000_000
+
+
+def test_export_indicators_keeps_cjk_readable(tmp_path: Path) -> None:
+    """Exported JSON must keep CJK metadata readable, matching the stream path."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=CjkMetaStrategy,
+        symbols="IND",
+        initial_cash=100000.0,
+        show_progress=False,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        lot_size=1,
+    )
+
+    export_path = tmp_path / "indicators.json"
+    result.export_indicators(str(export_path), format="json")
+    raw_text = export_path.read_text(encoding="utf-8")
+    assert "五日均线" in raw_text
+    assert "\\u" not in raw_text
+
+
+def test_default_pane_is_main() -> None:
+    """Omitting pane resolves to the main pane (index 0)."""
     result = run_backtest(
         data=_build_data(),
         strategy=DefaultPaneStrategy,
@@ -154,7 +216,32 @@ def test_default_pane_normalizes_without_crashing() -> None:
 
     definitions = result.indicator_definitions
     assert len(definitions) == 1
-    assert definitions.iloc[0]["pane"] == "sub1"
+    assert definitions.iloc[0]["pane"] == 0
+
+
+class BadRenderTypeStrategy(Strategy):
+    """Record an indicator with a render type outside the canonical enum."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Attempt to record with an unsupported render type."""
+        self.record_indicator(name="broken", value=bar.close, render_type="candlestick")
+
+
+def test_record_indicator_rejects_unknown_render_type() -> None:
+    """An unsupported render type fails fast rather than degrading silently."""
+    with pytest.raises(ValueError, match="render_type"):
+        run_backtest(
+            data=_build_data(),
+            strategy=BadRenderTypeStrategy,
+            symbols="IND",
+            initial_cash=100000.0,
+            show_progress=False,
+            commission_rate=0.0,
+            stamp_tax_rate=0.0,
+            transfer_fee_rate=0.0,
+            min_commission=0.0,
+            lot_size=1,
+        )
 
 
 def test_legacy_strategy_without_indicator_recording_stays_empty() -> None:
@@ -309,7 +396,7 @@ def test_indicator_stream_bridge_builds_frontend_messages() -> None:
     first_point = next(message for message in messages if message["type"] == "point")
     assert first_point["indicator"]["indicator_key"] == "close_echo"
     assert first_point["indicator"]["display_name"] == "Close Echo"
-    assert first_point["indicator"]["pane"] == "main"
+    assert first_point["indicator"]["pane"] == 0
     assert first_point["indicator"]["render_type"] == "line"
     assert first_point["indicator"]["value"] == 10.0
     assert first_point["indicator"]["meta"] == {"source": "close"}
@@ -327,15 +414,15 @@ def test_indicator_stream_bridge_builds_frontend_messages() -> None:
     assert first_snapshot["snapshot"]["items"][1]["warmup"] is True
     assert first_snapshot["snapshot"]["items"][1]["meta"] == {"source": ["high", "low"]}
     assert first_snapshot["snapshot"]["indicator_keys"] == ["close_echo", "range_echo"]
-    assert first_snapshot["snapshot"]["panes"] == ["main", "signal"]
-    assert first_snapshot["snapshot"]["render_types"] == ["bar", "line"]
+    assert first_snapshot["snapshot"]["panes"] == [0, 1]
+    assert first_snapshot["snapshot"]["render_types"] == ["line", "signal"]
     assert first_snapshot["snapshot"]["value_by_key"]["close_echo"] == pytest.approx(
         10.0
     )
     assert first_snapshot["snapshot"]["value_by_key"]["range_echo"] == pytest.approx(
         0.4
     )
-    assert first_snapshot["snapshot"]["items_by_key"]["range_echo"]["pane"] == "signal"
+    assert first_snapshot["snapshot"]["items_by_key"]["range_echo"]["pane"] == 1
     assert first_snapshot["snapshot"]["warmup_count"] == 1
     assert first_snapshot["snapshot"]["has_warmup"] is True
 
@@ -370,7 +457,7 @@ def test_indicator_stream_bridge_normalizes_unknown_symbols() -> None:
             "owner_strategy_id": "_default",
             "indicator_key": "close_echo",
             "display_name": "Close Echo",
-            "pane": "main",
+            "pane": "0",
             "render_type": "line",
             "symbol": "_unknown",
             "timestamp": "1",
@@ -396,7 +483,7 @@ def test_indicator_stream_bridge_normalizes_unknown_symbols() -> None:
                     {
                         "indicator_key": "close_echo",
                         "display_name": "Close Echo",
-                        "pane": "main",
+                        "pane": "0",
                         "render_type": "line",
                         "value": 10.0,
                         "warmup": False,
@@ -436,7 +523,7 @@ def test_indicator_stream_bridge_accepts_predecoded_payloads() -> None:
                 {
                     "indicator_key": "close_echo",
                     "display_name": "Close Echo",
-                    "pane": "main",
+                    "pane": "0",
                     "render_type": "line",
                     "value": 10.5,
                     "warmup": False,
@@ -445,8 +532,8 @@ def test_indicator_stream_bridge_accepts_predecoded_payloads() -> None:
                 {
                     "indicator_key": "range_echo",
                     "display_name": "Range Echo",
-                    "pane": "signal",
-                    "render_type": "bar",
+                    "pane": "1",
+                    "render_type": "signal",
                     "value": 0.4,
                     "warmup": True,
                     "meta_json": {"source": ["high", "low"]},

--- a/tests/test_report_plot_extensions.py
+++ b/tests/test_report_plot_extensions.py
@@ -51,15 +51,31 @@ class IndicatorPlotStrategy(Strategy):
             name="close_echo",
             value=bar.close,
             display_name="Close Echo",
-            pane="main",
+            pane=0,
             render_type="line",
         )
         self.record_indicator(
             name="distance_from_ten",
             value=bar.close - 10.0,
             display_name="Distance From Ten",
-            pane="signal",
+            pane=1,
             render_type="bar",
+        )
+
+
+class RenderTypeStrategy(Strategy):
+    """Record indicators covering the area, scatter, and signal render types."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """Emit one series per non-line render type on the main pane."""
+        self.record_indicator(
+            name="area_series", value=bar.close, pane=0, render_type="area"
+        )
+        self.record_indicator(
+            name="scatter_series", value=bar.high, pane=0, render_type="scatter"
+        )
+        self.record_indicator(
+            name="signal_series", value=bar.low, pane=0, render_type="signal"
         )
 
 
@@ -420,6 +436,36 @@ def test_backtest_result_exposes_structured_benchmark_analysis() -> None:
     assert payload["series"][0]["date"] == "2023-01-01"
 
 
+def test_export_benchmark_analysis_keeps_cjk_label_readable(tmp_path: Path) -> None:
+    """Exported benchmark JSON keeps CJK labels readable, like export_indicators."""
+    result = run_backtest(
+        data=_build_data(),
+        strategy=RoundTripStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+    benchmark_returns = pd.Series(
+        [0.0, 0.001, -0.0005, 0.0008, 0.0],
+        index=pd.date_range("2023-01-01", periods=5, freq="D"),
+        name="沪深300指数",
+    )
+
+    export_path = tmp_path / "benchmark.json"
+    result.export_benchmark_analysis(
+        str(export_path), benchmark=benchmark_returns, curve_freq="D"
+    )
+    raw_text = export_path.read_text(encoding="utf-8")
+    assert "沪深300指数" in raw_text
+    assert "\\u" not in raw_text
+
+
 def test_report_shows_notice_for_range_index_benchmark(tmp_path: Path) -> None:
     """RangeIndex benchmark input should render a clear validation notice."""
     _skip_if_no_plotly()
@@ -614,8 +660,8 @@ def test_indicator_plot_functions_return_multi_pane_figures() -> None:
         "Distance From Ten",
     }
     assert [annotation.text for annotation in fig.layout.annotations] == [
-        "main",
-        "signal",
+        "Main",
+        "Sub 1",
     ]
 
     filtered_fig = result.plot_indicators(name="distance_from_ten", show=False)
@@ -623,6 +669,36 @@ def test_indicator_plot_functions_return_multi_pane_figures() -> None:
     assert len(filtered_fig.data) == 1
     assert filtered_fig.data[0].name == "Distance From Ten"
     assert filtered_fig.data[0].type == "bar"
+
+
+def test_indicator_plot_renders_each_render_type() -> None:
+    """area/scatter/signal render types map to distinct, non-line traces."""
+    _skip_if_no_plotly()
+    result = run_backtest(
+        data=_build_data(),
+        strategy=RenderTypeStrategy,
+        symbols="TEST",
+        initial_cash=200000.0,
+        commission_rate=0.0,
+        stamp_tax_rate=0.0,
+        transfer_fee_rate=0.0,
+        min_commission=0.0,
+        fill_policy={"price_basis": "close", "temporal": "same_cycle"},
+        lot_size=1,
+        show_progress=False,
+    )
+
+    fig = plot_indicators(result, show=False)
+    assert fig is not None
+    traces = {trace.name: trace for trace in fig.data}
+    assert set(traces) == {"area_series", "scatter_series", "signal_series"}
+    # area is a filled line
+    assert traces["area_series"].mode == "lines"
+    assert traces["area_series"].fill == "tozeroy"
+    # scatter and signal are marker series
+    assert traces["scatter_series"].mode == "markers"
+    assert traces["signal_series"].mode == "markers"
+    assert traces["signal_series"].marker.symbol == "triangle-up"
 
 
 def test_indicator_plot_returns_none_without_indicator_data() -> None:


### PR DESCRIPTION
升级包版本至0.3.14，本次为破坏性变更，具体变更如下：
- 重构pane处理逻辑，将pane参数从字符串标识改为整数索引，0为主图，1~4为堆叠副图，废弃旧的字符串pane写法
- 新增render_type规范化校验，未知类型直接抛出ValueError，避免静默降级
- 更新所有示例代码、官方文档与测试用例以适配新API
- 优化JSON导出编码，使用ensure_ascii=False保留中文可读性
- 完善timestamp_ms字段的自动填充与处理逻辑