### PR TITLE
fix(analysis): RangeIndex 检测兼容 pandas 2.3 dropna 语义

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 示例体系新增 `examples/52_pre_open_demo.py`，用于演示 `on_pre_open -> on_order/on_trade -> on_bar` 的触发顺序与当日 open 成交语义。
 
 ### Fixed
+- 修复 pandas ≥ 2.3 下基准收益序列 RangeIndex 检测失效的问题：`Series.dropna()` 会将 RangeIndex 物化为普通 Index，导致专属拒绝提示不再触发（恢复为明确的 RangeIndex 拒绝信息）。
 - 修复 `on_after_trading` 里下 next-open（`bar_offset=1`）单晚一格成交的问题（#324）。它原先在「下一根 bar」到来时才惰性补触发，引擎时钟已越过日界，其中提交的 next-open 单被撮合守卫推迟一格（盘后下单期望次日开盘成交，实际到第三日）。现改为按日终边界定时器在「当日收盘点」的独立事件里触发（早于下一根 bar），使其中提交的次日开盘单落在下一根 bar，而非晚一格。默认（非 precise）与 precise 模式下均已修正；`on_before_trading` 等开始型钩子本就与 `on_bar` 同拍触发，不受影响。`__engine_rule_version__` 相应升至 `1.3.1`。
 - 修复 `on_pre_open` 未兑现「本次 open 成交」契约的问题（#324 家族）。其盘前定时器原先排在当日首根 bar 的同一时刻，订单 `created_at` 与该 bar 同拍、被 next-open 守卫拦截，导致实际成交在**下一日 open**（可由 `examples/52_pre_open_demo.py` 复现）。现将盘前定时器排在首根 bar 之前 1ns，使 `on_pre_open` 中下的默认开盘单落在**当日 open**，与文档承诺一致。
 - 修复短回测区间下 Sharpe/Sortino 因「分子用 CAGR、分母用日波动 × √252」口径不一致而出现异常巨大值（如期货场景 Sharpe 高达数千万）的问题；改用日收益算术均值年化后数值回归合理量级。

--- a/python/akquant/analysis/benchmark.py
+++ b/python/akquant/analysis/benchmark.py
@@ -38,6 +38,9 @@ def normalize_returns_series_with_reason(
     series: pd.Series, series_label: str = "收益序列"
 ) -> tuple[pd.Series, Optional[str]]:
     """Normalize returns to a daily index and report validation errors."""
+    # pandas >= 2.3 的 dropna 会把 RangeIndex 物化为普通 Index，
+    # 必须在清洗前记录，否则 RangeIndex 会落入数值索引分支、丢失专属提示。
+    is_range_index = isinstance(series.index, pd.RangeIndex)
     cleaned = series.copy()
     cleaned = pd.to_numeric(cleaned, errors="coerce")
     cleaned = cast(pd.Series, cleaned.dropna())
@@ -45,7 +48,7 @@ def normalize_returns_series_with_reason(
         return cast(pd.Series, cleaned), f"{series_label}为空"
 
     raw_index = cleaned.index
-    if isinstance(raw_index, pd.RangeIndex):
+    if is_range_index or isinstance(raw_index, pd.RangeIndex):
         return (
             pd.Series(dtype=float),
             f"{series_label}索引必须为日期索引，当前为 RangeIndex",


### PR DESCRIPTION
### 问题
pandas >= 2.3 中 `Series.dropna()` 会把 `RangeIndex` 物化为普通 `Index`，
导致 `normalize_returns_series_with_reason` 的 `isinstance(raw_index, pd.RangeIndex)`
分支不再命中：RangeIndex 输入落入数值索引分支，用户看到的是
"索引必须为 DatetimeIndex 或可解析的日期索引" 而非明确的 RangeIndex 拒绝提示。
`pyproject.toml` 声明 `pandas>=2.2.0`，pandas 2.3 是合法环境。

受影响测试（pandas 2.3.3 下 dev 分支即失败）：
- `tests/test_report_helpers.py::test_resolve_benchmark_returns_rejects_range_index`
- `tests/test_report_plot_extensions.py::test_report_shows_notice_for_range_index_benchmark`

### 修复
在清洗（to_numeric/dropna）前记录原始索引类型，恢复 RangeIndex 专属诊断。
改动 1 个文件 4 行（`python/akquant/analysis/benchmark.py`）。

### 验证
- 修复前 pandas 2.3.3：2 failed / 1328 passed；修复后：**1330 passed**
- `ruff check`、`mypy` 通过
- 行为影响：仅恢复诊断信息文案，无逻辑变化
