### PR TITLE
perf(engine): 账户指标/成本价按版本缓存 + 冻结现金空订单快速路径

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `BacktestConfig` 新增 `days_per_year`（年化天数因子，默认 252；数字货币 24/7 市场可设 365）与 `risk_free_rate`（年化无风险利率，默认 0.0）两个字段，用于参数化 Sharpe/Sortino/波动率等风险指标的年化口径。`risk_free_rate` 默认 0 不改变任何现有数值。
 
 ### Changed
+- 性能：账户指标与持仓成本价按版本缓存，同一时间片内策略回调、统计与订单事件共享一次计算（宽宇宙负载下减少每 bar 重复 O(P) 计算）；无非终态订单时冻结现金直接返回 0，跳过组合克隆与两轮保证金计算。行为完全等价（golden 净值曲线不变）。
 - **策略参数声明改为内联字段（破坏性）**：策略参数的单一事实来源现在是类体内联字段——直接用 `IntParam` / `FloatParam` / `BoolParam` / `ChoiceParam` / `DateRangeParam` 赋值（如 `fast = IntParam(10, ge=2, le=200)`），经 `self.params.fast` 只读访问；`self.params` 在实例构造期即已校验就绪且 frozen，不支持运行期赋值。
     - **移除**：构造函数签名参数风格（`__init__(self, fast=10): self.fast=fast` 不再作为参数声明入口）、`PARAM_MODEL = XxxParams` 间接层（不再需要单独定义 `ParamModel` 子类）、适配层内部的 `_validate_with_signature` / `_build_signature_schema` 签名回退路径。`get_strategy_param_schema` / `validate_strategy_params` 现在只读取内联字段，不再回退到 `__init__` 签名推断。
     - **行为变更**：`start_time` / `symbols` / `end_time` 现在仅在策略显式声明为对应字段时才会被注入，不再隐式兜底；`strict_strategy_params=True`（默认）下，`param_grid` 或运行期 payload 中的未知键、越界取值（超出 `ge`/`le`、不在 `choices` 内）会直接报错，不再静默忽略；`strict_strategy_params=False` 时未知键会回退到字段默认值构造。

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -50,6 +50,20 @@ pub struct StrategySlot {
 pub struct Engine {
     pub(crate) state: SharedState,
     pub(crate) last_prices: HashMap<String, Decimal>,
+    /// last_prices 每次写入 +1，与 account_version 一起作为指标缓存的键。
+    pub(crate) last_prices_version: u64,
+    /// 账户状态（portfolio/trade_tracker）每次变更 +1：全部成交经由
+    /// flush_accumulated_trades、日结经由 process_daily_settlement、
+    /// 除权除息经由 process_date 三处汇入点统一递增，保证指标缓存
+    /// 不可能返回陈旧值。
+    pub(crate) account_version: u64,
+    /// current_account_metrics 的缓存，键为
+    /// (last_prices_version, account_version)：价格或账户状态变化即失效。
+    /// 同一事件内 strategy/statistics/flush 等多个消费者共享一次计算。
+    pub(crate) metrics_cache: Option<(u64, u64, AccountMetrics)>,
+    /// build_position_entry_prices 的缓存，键为 account_version
+    ///（positions 仅随成交/结算/除权变化）。
+    pub(crate) entry_prices_cache: Option<(u64, Arc<HashMap<String, Decimal>>)>,
     pub(crate) instruments: HashMap<String, Instrument>,
     pub(crate) current_date: Option<NaiveDate>,
     pub(crate) market_manager: MarketManager,
@@ -140,14 +154,22 @@ pub(crate) struct PendingStreamEvent {
 
 // Internal implementation of Engine (not exposed to Python)
 impl Engine {
-    fn current_account_metrics(&self) -> AccountMetrics {
-        calculate_account_metrics(
+    pub(crate) fn current_account_metrics(&mut self) -> AccountMetrics {
+        let key = (self.last_prices_version, self.account_version);
+        if let Some((pv, ev, metrics)) = &self.metrics_cache {
+            if (*pv, *ev) == key {
+                return *metrics;
+            }
+        }
+        let metrics = calculate_account_metrics(
             &self.state.portfolio,
             &self.last_prices,
             &self.instruments,
             &self.state.order_manager.trade_tracker,
             &self.risk_manager.config,
-        )
+        );
+        self.metrics_cache = Some((key.0, key.1, metrics));
+        metrics
     }
 
     /// Cash/margin reserved by open (non-terminal) orders: the incremental used
@@ -155,6 +177,18 @@ impl Engine {
     /// account's `frozen_cash`, computed in Rust so it cannot drift from the
     /// engine's own margin accounting (the Python re-implementation was removed).
     fn current_frozen_cash(&self, active_orders: &[Order]) -> Decimal {
+        // 快速路径：无非终态订单时冻结现金恒为 0（投影与原值相同），
+        // 跳过 portfolio.clone() 与两轮 O(P) used_margin 计算。
+        if !active_orders.iter().any(|order| {
+            matches!(
+                order.status,
+                crate::model::OrderStatus::New
+                    | crate::model::OrderStatus::Submitted
+                    | crate::model::OrderStatus::PartiallyFilled
+            )
+        }) {
+            return Decimal::ZERO;
+        }
         let stock_ratio_override = if self.risk_manager.config.is_margin_account() {
             Some(self.risk_manager.config.stock_initial_margin_ratio())
         } else {
@@ -202,7 +236,12 @@ impl Engine {
         (projected_used - base_used).max(Decimal::ZERO)
     }
 
-    fn build_position_entry_prices(&self) -> Arc<HashMap<String, Decimal>> {
+    fn build_position_entry_prices(&mut self) -> Arc<HashMap<String, Decimal>> {
+        if let Some((av, cached)) = &self.entry_prices_cache {
+            if *av == self.account_version {
+                return Arc::clone(cached);
+            }
+        }
         let mut entry_prices = HashMap::new();
         for (symbol, quantity) in self.state.portfolio.positions.iter() {
             if quantity.is_zero() {
@@ -215,7 +254,9 @@ impl Engine {
                 .get_average_price(symbol);
             entry_prices.insert(symbol.clone(), average_price);
         }
-        Arc::new(entry_prices)
+        let entry_prices = Arc::new(entry_prices);
+        self.entry_prices_cache = Some((self.account_version, Arc::clone(&entry_prices)));
+        entry_prices
     }
 
     pub(crate) fn is_active_timestamp(&self, timestamp: i64) -> bool {
@@ -1080,7 +1121,7 @@ impl Engine {
     }
 
     pub(crate) fn create_context(
-        &self,
+        &mut self,
         active_orders: Arc<Vec<Order>>,
         step_trades: Vec<Trade>,
         step_rejected_orders: Vec<Order>,
@@ -1217,6 +1258,7 @@ impl Engine {
                 let previous_cash = self.state.portfolio.cash;
                 let previous_account_metrics = self.current_account_metrics();
                 self.last_prices.insert(b.symbol.clone(), b.close);
+                self.last_prices_version = self.last_prices_version.wrapping_add(1);
                 let py_ctx = self.get_or_create_strategy_context(
                     slot_index,
                     active_orders,
@@ -1259,6 +1301,7 @@ impl Engine {
                 let previous_cash = self.state.portfolio.cash;
                 let previous_account_metrics = self.current_account_metrics();
                 self.last_prices.insert(t.symbol.clone(), t.price);
+                self.last_prices_version = self.last_prices_version.wrapping_add(1);
                 let py_ctx = self.get_or_create_strategy_context(
                     slot_index,
                     active_orders,

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -507,6 +507,10 @@ impl Engine {
         Engine {
             state: SharedState::new(initial_cash),
             last_prices: HashMap::new(),
+            last_prices_version: 0,
+            account_version: 0,
+            metrics_cache: None,
+            entry_prices_cache: None,
             instruments: HashMap::new(),
             current_date: None,
             market_manager: MarketManager::new(),

--- a/src/pipeline/stages/data.rs
+++ b/src/pipeline/stages/data.rs
@@ -283,6 +283,7 @@ impl Processor for DataProcessor {
                     engine.current_date = Some(local_date);
 
                     // Process Corporate Actions (Split/Dividend)
+                    engine.account_version = engine.account_version.wrapping_add(1);
                     engine.corporate_action_manager.process_date(
                         local_date,
                         &mut engine.state.portfolio,
@@ -326,6 +327,7 @@ impl Processor for DataProcessor {
                         default_strategy_id: engine.default_strategy_id.clone(),
                         day_orders_awaiting_fill_slice: &day_orders_awaiting_fill_slice,
                     };
+                    engine.account_version = engine.account_version.wrapping_add(1);
                     let settlement_outcome = engine.settlement_manager.process_daily_settlement(
                         &mut engine.state.portfolio,
                         &mut engine.state.order_manager.active_orders,

--- a/src/pipeline/stages/shared.rs
+++ b/src/pipeline/stages/shared.rs
@@ -58,6 +58,8 @@ pub(crate) fn flush_accumulated_trades(engine: &mut Engine, trades_to_process: &
     if trades_to_process.is_empty() {
         return;
     }
+    // 账户状态变更汇入点：递增版本号使指标/成本价缓存失效。
+    engine.account_version = engine.account_version.wrapping_add(1);
     engine.state.order_manager.process_trades(
         std::mem::take(trades_to_process),
         &mut engine.state.portfolio,

--- a/src/pipeline/stages/statistics.rs
+++ b/src/pipeline/stages/statistics.rs
@@ -1,4 +1,3 @@
-use crate::account::calculate_account_metrics;
 use crate::engine::Engine;
 use crate::event::Event;
 use crate::pipeline::processor::{Processor, ProcessorResult};
@@ -18,18 +17,11 @@ impl Processor for StatisticsProcessor {
             && let Some(timestamp) = engine.clock.timestamp()
             && engine.is_active_timestamp(timestamp)
         {
-            let equity = calculate_account_metrics(
-                &engine.state.portfolio,
-                &engine.last_prices,
-                &engine.instruments,
-                &engine.state.order_manager.trade_tracker,
-                &engine.risk_manager.config,
-            )
-            .equity;
-            let margin = engine
-                .state
-                .portfolio
-                .calculate_used_margin(&engine.last_prices, &engine.instruments);
+            // 复用引擎每事件指标缓存：同一事件内 strategy 阶段已算过一次，
+            // 此处零成本命中；used_margin 直接取指标字段，不再重复 O(P) 计算。
+            let metrics = engine.current_account_metrics();
+            let equity = metrics.equity;
+            let margin = metrics.used_margin;
             engine.statistics_manager.update(
                 timestamp,
                 equity,


### PR DESCRIPTION
关联 #345（引擎每 bar 固定开销测量与优化计划）。

### 问题
`get_or_create_strategy_context` 每根 bar 重复计算 O(P) 指标：
`calculate_account_metrics`、`build_position_entry_prices`；
`current_frozen_cash` 还要 `portfolio.clone()` + 两轮 used_margin；
`StatisticsProcessor` 每 bar 把同一组指标再算一遍。

### 改法
- 新增 `last_prices_version` / `account_version` 版本计数：last_prices 两处
  写入点递增前者；成交（`flush_accumulated_trades`）、日结
  （`process_daily_settlement`）、除权除息（`process_date`）三处汇入点
  递增后者——覆盖 portfolio/trade_tracker 全部变更路径；
- `current_account_metrics` 以双版本为键缓存（AccountMetrics 为 Copy），
  同事件内 strategy/statistics/flush 等多消费者共享一次计算，跨变更必失效；
- `build_position_entry_prices` 以 account_version 为键缓存；
- `current_frozen_cash` 无非终态订单时直接返回 0（与原逻辑严格等价：
  投影与原值相同），跳过 portfolio.clone() 与两轮 O(P) used_margin；
- `StatisticsProcessor` 改用引擎缓存指标，used_margin 取指标字段。

### 验证
- `cargo test` 124 passed；`uv run pytest` 1328 passed（其余 2 例为 dev 上
  pandas 2.3 既有失败，见 PR-fix，与本改动无关）；`tests/golden`
  **不更新基线**通过（指标是净值曲线的来源，golden 等价性直接证明缓存正确性）
- bench_engine_perbar（4500 标的 × 120 日，3 轮中位）：
  dev 2623.1 → 本 PR **2859.4 bars/sec（+9.0%）**（墙钟 205.9s → 188.8s），
  orders/fills 完全相同（9245/5643）
