### PR TITLE
perf(engine): last_prices 新增时间片快照模式，宽宇宙每 bar 固定开销大幅下降

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `run_backtest` 新增 `last_prices_snapshot_per_timestamp`（默认 False）：开启后策略 context 的 `last_prices` 按时间片共享不可变快照（O(1) Arc 克隆），不再每 bar 全表克隆，宽宇宙回测（数千标的）可显著降低每 bar 固定开销；`StrategyContext` 新增 `last_prices` 只读属性。开启后 on_bar/on_tick 内该属性与 `buying_power` 反映上一时间片结束时的价格。
 - `get_account()` 账户快照新增 `free_margin` 字段（= `equity - used_margin`），表示真正可用于新开仓的可用保证金，与下单因保证金不足被拒时日志里的 `Available` 口径一致；期货保证金账户下 `cash`（现金余额）通常大于 `free_margin`，股票现金账户下二者相等。同时修正了 `cash` 在文档与 docstring 中「可用资金」的误导性表述，明确其为「现金余额」。
 - `BacktestConfig` 新增 `days_per_year`（年化天数因子，默认 252；数字货币 24/7 市场可设 365）与 `risk_free_rate`（年化无风险利率，默认 0.0）两个字段，用于参数化 Sharpe/Sortino/波动率等风险指标的年化口径。`risk_free_rate` 默认 0 不改变任何现有数值。
 

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -213,6 +213,7 @@ def run_from_checkpoint(
     portfolio_risk_budget: Optional[float] = ...,
     risk_budget_mode: Literal["order_notional", "trade_notional"] = ...,
     risk_budget_reset_daily: bool = ...,
+    last_prices_snapshot_per_timestamp: bool = ...,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = ...,
     indicator_recorder: Optional[IndicatorSink] = ...,
     config: Optional[BacktestConfig] = ...,

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -2236,6 +2236,7 @@ def run_backtest(
     portfolio_risk_budget: Optional[float] = None,
     risk_budget_mode: str = "order_notional",
     risk_budget_reset_daily: bool = False,
+    last_prices_snapshot_per_timestamp: bool = False,
     analyzer_plugins: Optional[Sequence[AnalyzerPlugin]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     indicator_recorder: Optional[IndicatorSink] = None,
@@ -2347,6 +2348,12 @@ def run_backtest(
     :param portfolio_risk_budget: 可选账户级累计风险预算上限
     :param risk_budget_mode: 风险预算口径，支持 order_notional/trade_notional
     :param risk_budget_reset_daily: 风险预算是否按交易日重置
+    :param last_prices_snapshot_per_timestamp: 策略 context 的 last_prices 是否按
+        时间片快照共享（默认 False，逐 bar 快照）。开启后 Bar/Tick 事件的
+        context 共享时间片边界的不可变快照（O(1)），不再每 bar 全表克隆，
+        宽宇宙回测（数千标的）可显著降低每 bar 固定开销；Timer/成交等事件
+        的 context 仍使用即时快照。注意：开启后 on_bar/on_tick 内
+        `ctx.last_prices`/`ctx.buying_power` 看到的是上一时间片结束时的价格。
     :param analyzer_plugins: Analyzer 插件列表，
                              接收 on_start/on_bar/on_trade/on_finish 生命周期事件
     :param on_event: 可选流式事件回调。阶段 5 后 `run_backtest` 始终走统一事件内核；
@@ -2475,6 +2482,7 @@ def run_backtest(
         risk_budget_mode=risk_budget_mode,
     )
     risk_budget_reset_daily = bool(risk_budget_reset_daily)
+    last_prices_snapshot_per_timestamp = bool(last_prices_snapshot_per_timestamp)
     effective_strategy_id = strategy_id or "_default"
     indicator_stream_requested = (
         on_event is not None or kwargs.get("_stream_on_event") is not None
@@ -3397,6 +3405,10 @@ def run_backtest(
         cast(Any, engine).set_risk_budget_mode(risk_budget_mode)
     if hasattr(engine, "set_risk_budget_reset_daily"):
         cast(Any, engine).set_risk_budget_reset_daily(risk_budget_reset_daily)
+    if hasattr(engine, "set_last_prices_snapshot_per_timestamp"):
+        cast(Any, engine).set_last_prices_snapshot_per_timestamp(
+            last_prices_snapshot_per_timestamp
+        )
     if strategy_max_order_value and hasattr(
         engine, "set_strategy_max_order_value_limits"
     ):

--- a/src/context.rs
+++ b/src/context.rs
@@ -835,6 +835,17 @@ impl StrategyContext {
             .collect()
     }
 
+    /// 最近价格快照（symbol -> price）。逐 bar 快照或时间片快照取决于
+    /// 引擎的 `last_prices_snapshot_per_timestamp` 配置。按需克隆，不要
+    /// 在每 bar 热路径中反复访问。
+    #[getter]
+    fn get_last_prices(&self) -> HashMap<String, f64> {
+        self.last_prices
+            .iter()
+            .map(|(k, v)| (k.clone(), v.to_f64().unwrap_or_default()))
+            .collect()
+    }
+
     /// 注册定时器.
     ///
     /// :param timestamp: 触发时间戳 (纳秒)

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -50,6 +50,14 @@ pub struct StrategySlot {
 pub struct Engine {
     pub(crate) state: SharedState,
     pub(crate) last_prices: HashMap<String, Decimal>,
+    /// 时间片粒度的 last_prices 不可变快照（仅在
+    /// `last_prices_snapshot_per_timestamp` 开启时于时间片边界发布）。
+    /// Bar/Tick 事件的策略 context 共享该 Arc（O(1)），避免每 bar 全表克隆；
+    /// Timer/成交等其他事件仍使用工作副本的即时克隆，保证 buying_power
+    /// 在 cross-section 等回调中使用最新价格。
+    pub(crate) last_prices_snapshot: Arc<HashMap<String, Decimal>>,
+    /// 开关：context 的 last_prices 改为时间片快照（默认 false，保持逐 bar 快照）。
+    pub(crate) last_prices_snapshot_per_timestamp: bool,
     pub(crate) instruments: HashMap<String, Instrument>,
     pub(crate) current_date: Option<NaiveDate>,
     pub(crate) market_manager: MarketManager,
@@ -140,6 +148,26 @@ pub(crate) struct PendingStreamEvent {
 
 // Internal implementation of Engine (not exposed to Python)
 impl Engine {
+    /// 策略 context 使用的 last_prices：开关开启且为 Bar/Tick 事件时共享
+    /// 时间片快照（O(1) Arc 克隆），否则回退为工作副本的即时全表克隆（现行为）。
+    pub(crate) fn context_last_prices(
+        &self,
+        use_snapshot: bool,
+    ) -> Arc<HashMap<String, Decimal>> {
+        if use_snapshot && self.last_prices_snapshot_per_timestamp {
+            Arc::clone(&self.last_prices_snapshot)
+        } else {
+            Arc::new(self.last_prices.clone())
+        }
+    }
+
+    /// 在时间片边界发布 last_prices 不可变快照（仅在开关开启时生效）。
+    pub(crate) fn publish_last_prices_snapshot(&mut self) {
+        if self.last_prices_snapshot_per_timestamp {
+            self.last_prices_snapshot = Arc::new(self.last_prices.clone());
+        }
+    }
+
     fn current_account_metrics(&self) -> AccountMetrics {
         calculate_account_metrics(
             &self.state.portfolio,
@@ -677,6 +705,7 @@ impl Engine {
         step_rejected_orders: Vec<Order>,
         previous_cash: Decimal,
         previous_account_metrics: AccountMetrics,
+        use_last_prices_snapshot: bool,
     ) -> PyResult<Py<StrategyContext>> {
         self.ensure_strategy_context_capacity();
         let account_metrics = self.current_account_metrics();
@@ -685,6 +714,7 @@ impl Engine {
             .current_frozen_cash(&active_orders)
             .to_f64()
             .unwrap_or_default();
+        let last_prices = self.context_last_prices(use_last_prices_snapshot);
         if let Some(existing_ctx) = self
             .strategy_contexts
             .get(slot_index)
@@ -765,7 +795,7 @@ impl Engine {
                             .margin_daily_interest
                             .to_f64()
                             .unwrap_or_default(),
-                        last_prices: Arc::new(self.last_prices.clone()),
+                        last_prices: last_prices.clone(),
                     });
                 }
                 Ok::<_, PyErr>(py_ctx)
@@ -783,6 +813,7 @@ impl Engine {
             strategy_id,
             previous_cash,
             previous_account_metrics,
+            use_last_prices_snapshot,
         );
         let (py_ctx, persistent_ref) = Python::attach(|py| {
             let py_ctx = Py::new(py, ctx).unwrap();
@@ -1087,6 +1118,7 @@ impl Engine {
         strategy_id: Option<String>,
         previous_cash: Decimal,
         previous_account_metrics: AccountMetrics,
+        use_last_prices_snapshot: bool,
     ) -> StrategyContext {
         let account_metrics = self.current_account_metrics();
         let position_entry_prices = self.build_position_entry_prices();
@@ -1150,7 +1182,7 @@ impl Engine {
             margin_accrued_interest: self.margin_accrued_interest.to_f64().unwrap_or_default(),
             margin_daily_interest: self.margin_daily_interest.to_f64().unwrap_or_default(),
             instruments: Arc::new(self.instruments.clone()),
-            last_prices: Arc::new(self.last_prices.clone()),
+            last_prices: self.context_last_prices(use_last_prices_snapshot),
         })
     }
 
@@ -1224,6 +1256,7 @@ impl Engine {
                     step_rejected_orders,
                     previous_cash,
                     previous_account_metrics,
+                    true,
                 )?;
 
                 let args = Python::attach(|py| {
@@ -1266,6 +1299,7 @@ impl Engine {
                     step_rejected_orders,
                     previous_cash,
                     previous_account_metrics,
+                    true,
                 )?;
 
                 let args = Python::attach(|py| {
@@ -1306,6 +1340,7 @@ impl Engine {
                     step_rejected_orders,
                     previous_cash,
                     previous_account_metrics,
+                    false,
                 )?;
 
                 let args = Python::attach(|py| {
@@ -1379,6 +1414,7 @@ impl Engine {
                 step_rejected_orders.clone(),
                 previous_cash,
                 previous_account_metrics,
+                false,
             )?;
             let slot_strategy = self
                 .strategy_slot_strategies

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -498,6 +498,17 @@ impl Engine {
         self.risk_budget_reset_daily = enabled;
     }
 
+    /// 设置策略 context 的 last_prices 是否按时间片快照共享.
+    ///
+    /// 开启后 Bar/Tick 事件的 context 使用时间片边界的不可变快照（O(1) 共享），
+    /// 不再每 bar 全表克隆；Timer/成交等事件仍使用即时快照（现行为）。
+    /// 宽宇宙回测（数千标的）可显著降低每 bar 固定开销。默认 false。
+    ///
+    /// :param enabled: 是否启用时间片快照
+    fn set_last_prices_snapshot_per_timestamp(&mut self, enabled: bool) {
+        self.last_prices_snapshot_per_timestamp = enabled;
+    }
+
     /// 初始化回测引擎.
     ///
     /// :return: Engine 实例
@@ -507,6 +518,8 @@ impl Engine {
         Engine {
             state: SharedState::new(initial_cash),
             last_prices: HashMap::new(),
+            last_prices_snapshot: Arc::new(HashMap::new()),
+            last_prices_snapshot_per_timestamp: false,
             instruments: HashMap::new(),
             current_date: None,
             market_manager: MarketManager::new(),

--- a/src/pipeline/stages/data.rs
+++ b/src/pipeline/stages/data.rs
@@ -173,6 +173,9 @@ impl DataProcessor {
         }
         self.fill_missing_bars(engine);
         self.reject_missing_symbol_orders(engine);
+        // 时间片收尾：发布 last_prices 不可变快照（仅在开关开启时生效），
+        // 供下一时间片 Bar/Tick 事件的策略 context 以 O(1) 共享。
+        engine.publish_last_prices_snapshot();
         self.finalized_timestamp = self.last_timestamp;
         self.current_symbol_events.clear();
     }

--- a/tests/test_last_prices_snapshot.py
+++ b/tests/test_last_prices_snapshot.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""last_prices 时间片快照（last_prices_snapshot_per_timestamp）语义与等价性."""
+
+import akquant as aq
+import pandas as pd
+from akquant import Strategy
+
+TZ = "Asia/Shanghai"
+DAYS = pd.date_range("2024-01-02", periods=4, freq="B", tz=TZ)
+
+
+def _make_bars(symbol: str, closes: list[float]) -> pd.DataFrame:
+    rows = []
+    for d, c in zip(DAYS, closes):
+        rows.append(
+            {
+                "date": d,
+                "open": c,
+                "high": c,
+                "low": c,
+                "close": c,
+                "volume": 1_000_000.0,
+                "symbol": symbol,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+class _PriceProbe(Strategy):
+    """每 bar 记录 ctx.last_prices 中本标的价格（缺省 -1.0 表示快照中不存在）."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen: list[float] = []
+
+    def on_bar(self, bar: aq.Bar) -> None:
+        self.seen.append(self.ctx.last_prices.get(bar.symbol, -1.0))
+
+
+def _run_probe(flag: bool) -> list[float]:
+    strat = _PriceProbe()
+    aq.run_backtest(
+        data={"AAA": _make_bars("AAA", [10.0, 11.0, 12.0, 13.0])},
+        strategy=strat,
+        symbols=["AAA"],
+        initial_cash=100_000.0,
+        commission_rate=0.0,
+        show_progress=False,
+        last_prices_snapshot_per_timestamp=flag,
+    )
+    return strat.seen
+
+
+def test_snapshot_off_sees_same_bar_price() -> None:
+    """默认（关）：context 逐 bar 快照，on_bar 看到当根 bar 价格."""
+    assert _run_probe(flag=False) == [10.0, 11.0, 12.0, 13.0]
+
+
+def test_snapshot_on_sees_previous_timestamp_price() -> None:
+    """开启：context 用上一时间片快照；第一时间片快照尚未发布（读不到）."""
+    assert _run_probe(flag=True) == [-1.0, 10.0, 11.0, 12.0]
+
+
+class _DailyRotate(Strategy):
+    """cross-section 每日轮换：奇数日满仓 AAA、偶数日满仓 BBB（next-open 成交）."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._day = 0
+
+    def on_cross_section(self, trading_date: object, timestamp: int) -> None:
+        _ = trading_date, timestamp
+        self._day += 1
+        pick = "AAA" if self._day % 2 == 1 else "BBB"
+        other = "BBB" if pick == "AAA" else "AAA"
+        self.order_target_percent(target_percent=0.0, symbol=other)
+        self.order_target_percent(target_percent=0.9, symbol=pick)
+
+
+def _run_rotation(flag: bool) -> pd.DataFrame:
+    data = {
+        "AAA": _make_bars("AAA", [10.0, 11.0, 12.0, 13.0]),
+        "BBB": _make_bars("BBB", [20.0, 19.0, 21.0, 18.0]),
+    }
+    result = aq.run_backtest(
+        data=data,
+        strategy=_DailyRotate(),
+        symbols=["AAA", "BBB"],
+        initial_cash=1_000_000.0,
+        commission_rate=0.0003,
+        show_progress=False,
+        last_prices_snapshot_per_timestamp=flag,
+    )
+    return result.trades_df.reset_index(drop=True)
+
+
+def test_snapshot_mode_trades_identical_for_cross_section() -> None:
+    """cross-section 负载下开/关快照成交逐笔一致（Timer 事件仍用即时快照）."""
+    trades_off = _run_rotation(flag=False)
+    trades_on = _run_rotation(flag=True)
+    assert len(trades_off) > 0
+    pd.testing.assert_frame_equal(trades_off, trades_on)


### PR DESCRIPTION
关联 #345；语义权衡讨论见 #346。

### 问题
samply 采样（宽宇宙日频负载，见 #345）显示
`get_or_create_strategy_context` 每根 bar 执行 `Arc::new(last_prices.clone())`
（数千个 String key 的 HashMap 全表克隆），`hashbrown::clone<(String, Decimal)>`
占总 CPU 23~26%，是纯管线开销的最大单项。

### 改法
新增 `last_prices_snapshot_per_timestamp=False`（默认关，开启前后行为完全一致）：
- 开启后 Bar/Tick 事件的策略 context 共享时间片边界发布的不可变快照
  （O(1) Arc 克隆），不再每 bar 全表克隆；
- Timer/成交等事件的 context 仍使用即时快照，`ctx.buying_power` 在
  cross-section 等回调中保持最新价格语义；
- `Engine::publish_last_prices_snapshot` 在时间片收尾
  （`finalize_current_timestamp`）发布；
- `StrategyContext` 新增 `last_prices` 只读 getter（symbol -> price）。

### 语义说明
开启后 `on_bar`/`on_tick` 内 `ctx.last_prices`/`ctx.buying_power` 看到的是
上一时间片结束时的价格（同一时间片内 slot 间不再互相可见当日价格——
该可见性依赖 slot 顺序，属实现细节而非语义保证）。默认关闭无任何影响。

### 测试
新增 `tests/test_last_prices_snapshot.py`：
- 关：on_bar 看到当根 bar 价格（现行为）；
- 开：on_bar 看到上一时间片价格，第一时间片快照未发布时为空；
- cross-section 负载两种模式成交逐笔一致（pd.testing.assert_frame_equal）。

### 验证
- `uv run pytest` 1331 passed（含新增 3 例；其余 2 例为 dev 上 pandas 2.3
  既有失败，见 PR-fix）；`tests/golden` **不更新基线**通过；`cargo test` 124 passed
- bench_engine_perbar（4500 标的 × 120 日 = 54 万 bar，同机对照）：
  - 全链路（3 轮中位）：关 2623.1 → 开 **4180.1 bars/sec（+59.4%）**（墙钟 205.9s → 129.2s），orders/fills 完全相同（9245/5643）
  - 纯管线（--no-orders）：6599 → **29795 bars/sec（4.5x）**
- samply 对照（27 万 bar）：CPU 采样 97s → 58s（-40%），
  `hashbrown::clone<(String,Decimal)>` 从 23.4% 降至消除
