### PR TITLE
perf(engine): skip_inert_bar_hooks 跳过空转策略的每 bar Python 回调

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `run_backtest` 新增 `skip_inert_bar_hooks`（默认 False）：策略未覆写 `on_bar` 且未使用任何 bar 级钩子（滚动训练、增量指标、schedule 定时任务、指标记录、warmup_period）时，跳过每 bar 的 `on_bar` Python 回调以消除空转开销；开启前强制校验，不满足条件抛出 ValueError。`on_order`/`on_trade` 仍按 bar 送达，`on_cross_section`（timer 驱动）不受影响。
 - `get_account()` 账户快照新增 `free_margin` 字段（= `equity - used_margin`），表示真正可用于新开仓的可用保证金，与下单因保证金不足被拒时日志里的 `Available` 口径一致；期货保证金账户下 `cash`（现金余额）通常大于 `free_margin`，股票现金账户下二者相等。同时修正了 `cash` 在文档与 docstring 中「可用资金」的误导性表述，明确其为「现金余额」。
 - `BacktestConfig` 新增 `days_per_year`（年化天数因子，默认 252；数字货币 24/7 市场可设 365）与 `risk_free_rate`（年化无风险利率，默认 0.0）两个字段，用于参数化 Sharpe/Sortino/波动率等风险指标的年化口径。`risk_free_rate` 默认 0 不改变任何现有数值。
 

--- a/python/akquant/backtest/__init__.pyi
+++ b/python/akquant/backtest/__init__.pyi
@@ -213,6 +213,7 @@ def run_from_checkpoint(
     portfolio_risk_budget: Optional[float] = ...,
     risk_budget_mode: Literal["order_notional", "trade_notional"] = ...,
     risk_budget_reset_daily: bool = ...,
+    skip_inert_bar_hooks: bool = ...,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = ...,
     indicator_recorder: Optional[IndicatorSink] = ...,
     config: Optional[BacktestConfig] = ...,

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -2168,6 +2168,29 @@ def _normalize_slippage_policy(
     )
 
 
+
+def _assert_strategy_bar_hooks_inert(strategy: "Strategy") -> None:
+    """校验策略没有任何 bar 级 Python 钩子（skip_inert_bar_hooks 的前置条件）."""
+    reasons: list[str] = []
+    if type(strategy).on_bar is not Strategy.on_bar:
+        reasons.append("策略覆写了 on_bar")
+    if int(getattr(strategy, "_rolling_step", 0) or 0) > 0:
+        reasons.append("启用了滚动训练（_rolling_step > 0）")
+    if hasattr(strategy, "_update_incremental_indicators"):
+        reasons.append("使用了增量指标（_update_incremental_indicators）")
+    if getattr(strategy, "_pending_schedules", None):
+        reasons.append("存在 schedule 定时任务")
+    if getattr(strategy, "_indicator_recorder", None) is not None:
+        reasons.append("启用了指标记录（indicator_recorder）")
+    if int(getattr(strategy, "warmup_period", 0) or 0) > 0:
+        reasons.append("设置了 warmup_period")
+    if reasons:
+        raise ValueError(
+            "skip_inert_bar_hooks=True 要求策略没有任何 bar 级 Python 钩子，"
+            "当前策略不满足：" + "；".join(reasons)
+        )
+
+
 def run_backtest(
     data: Optional[BacktestDataInput] = None,
     strategy: Union[Type[Strategy], Strategy, Callable[[Any, Bar], None], None] = None,
@@ -2236,6 +2259,7 @@ def run_backtest(
     portfolio_risk_budget: Optional[float] = None,
     risk_budget_mode: str = "order_notional",
     risk_budget_reset_daily: bool = False,
+    skip_inert_bar_hooks: bool = False,
     analyzer_plugins: Optional[Sequence[AnalyzerPlugin]] = None,
     on_event: Optional[Callable[[BacktestStreamEvent], None]] = None,
     indicator_recorder: Optional[IndicatorSink] = None,
@@ -2347,6 +2371,13 @@ def run_backtest(
     :param portfolio_risk_budget: 可选账户级累计风险预算上限
     :param risk_budget_mode: 风险预算口径，支持 order_notional/trade_notional
     :param risk_budget_reset_daily: 风险预算是否按交易日重置
+    :param skip_inert_bar_hooks: 跳过每 bar 的 on_bar Python 回调（默认 False）。
+        仅当策略未覆写 on_bar 且未使用任何 bar 级钩子（滚动训练、增量指标、
+        schedule 定时任务、指标记录、warmup_period）时允许开启，否则抛出
+        ValueError。开启后 on_order/on_trade 仍按 bar 送达，
+        on_cross_section（timer 驱动）不受影响；注意 get_holding_bars 与
+        策略内部 `_last_prices` 簿记会停止更新。Analyzer 插件依赖 on_bar，
+        存在插件时不允许开启。
     :param analyzer_plugins: Analyzer 插件列表，
                              接收 on_start/on_bar/on_trade/on_finish 生命周期事件
     :param on_event: 可选流式事件回调。阶段 5 后 `run_backtest` 始终走统一事件内核；
@@ -2475,6 +2506,7 @@ def run_backtest(
         risk_budget_mode=risk_budget_mode,
     )
     risk_budget_reset_daily = bool(risk_budget_reset_daily)
+    skip_inert_bar_hooks = bool(skip_inert_bar_hooks)
     effective_strategy_id = strategy_id or "_default"
     indicator_stream_requested = (
         on_event is not None or kwargs.get("_stream_on_event") is not None
@@ -3397,6 +3429,16 @@ def run_backtest(
         cast(Any, engine).set_risk_budget_mode(risk_budget_mode)
     if hasattr(engine, "set_risk_budget_reset_daily"):
         cast(Any, engine).set_risk_budget_reset_daily(risk_budget_reset_daily)
+    if skip_inert_bar_hooks:
+        if normalized_analyzers:
+            raise ValueError(
+                "skip_inert_bar_hooks=True 与 Analyzer 插件不兼容"
+                "（插件依赖 on_bar 回调）"
+            )
+        for current_strategy in all_strategy_instances:
+            _assert_strategy_bar_hooks_inert(current_strategy)
+    if hasattr(engine, "set_skip_on_bar_event"):
+        cast(Any, engine).set_skip_on_bar_event(skip_inert_bar_hooks)
     if strategy_max_order_value and hasattr(
         engine, "set_strategy_max_order_value_limits"
     ):

--- a/python/akquant/backtest/engine.py
+++ b/python/akquant/backtest/engine.py
@@ -2176,12 +2176,10 @@ def _assert_strategy_bar_hooks_inert(strategy: "Strategy") -> None:
         reasons.append("策略覆写了 on_bar")
     if int(getattr(strategy, "_rolling_step", 0) or 0) > 0:
         reasons.append("启用了滚动训练（_rolling_step > 0）")
-    if hasattr(strategy, "_update_incremental_indicators"):
-        reasons.append("使用了增量指标（_update_incremental_indicators）")
+    if getattr(strategy, "_incremental_indicators", None):
+        reasons.append("注册了增量指标（_incremental_indicators）")
     if getattr(strategy, "_pending_schedules", None):
         reasons.append("存在 schedule 定时任务")
-    if getattr(strategy, "_indicator_recorder", None) is not None:
-        reasons.append("启用了指标记录（indicator_recorder）")
     if int(getattr(strategy, "warmup_period", 0) or 0) > 0:
         reasons.append("设置了 warmup_period")
     if reasons:

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -1677,8 +1677,13 @@ class Strategy:
     def _on_timer_event(self, payload: str, ctx: StrategyContext) -> None:
         _on_timer_event_impl(self, payload, ctx)
 
-    def _flush_pending_order_events(self, ctx: StrategyContext) -> None:
-        _flush_pending_order_events_impl(self, ctx)
+    def _flush_pending_order_events(
+        self,
+        ctx: StrategyContext,
+        price_symbol: Optional[str] = None,
+        price: Optional[float] = None,
+    ) -> None:
+        _flush_pending_order_events_impl(self, ctx, price_symbol, price)
 
     def on_bar(self, bar: Bar) -> None:
         """

--- a/python/akquant/strategy_events.py
+++ b/python/akquant/strategy_events.py
@@ -246,8 +246,17 @@ def on_timer_event(strategy: Any, payload: str, ctx: StrategyContext) -> None:
     _flush_indicator_snapshots(strategy)
 
 
-def flush_pending_order_events(strategy: Any, ctx: StrategyContext) -> None:
+def flush_pending_order_events(
+    strategy: Any,
+    ctx: StrategyContext,
+    price_symbol: Any = None,
+    price: Any = None,
+) -> None:
     """Flush pending order/trade callbacks without invoking a user market callback."""
     ensure_framework_state(strategy)
     strategy.ctx = ctx
+    if price_symbol is not None and price is not None:
+        # skip_on_bar_event 模式下 on_bar_event 不运行，
+        # 在此维护策略级最新价（order_target_percent 等定量 API 依赖）。
+        strategy._last_prices[price_symbol] = float(price)
     strategy._check_order_events()

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -50,6 +50,11 @@ pub struct StrategySlot {
 pub struct Engine {
     pub(crate) state: SharedState,
     pub(crate) last_prices: HashMap<String, Decimal>,
+    /// 开关：跳过每 bar 的 `_on_bar_event` Python 调用（默认 false）。
+    /// 仅在 Python 侧校验策略未覆写 `on_bar` 且无其他 bar 级钩子后，
+    /// 由 `skip_inert_bar_hooks` 配置开启；`_flush_pending_order_events`
+    /// 与 Timer 驱动的 on_cross_section 等回调不受影响。
+    pub(crate) skip_on_bar_event: bool,
     pub(crate) instruments: HashMap<String, Instrument>,
     pub(crate) current_date: Option<NaiveDate>,
     pub(crate) market_manager: MarketManager,
@@ -1226,12 +1231,13 @@ impl Engine {
                     previous_account_metrics,
                 )?;
 
-                let args = Python::attach(|py| {
-                    let bar = b.clone();
-                    (bar, py_ctx.clone_ref(py))
-                });
-
-                strategy.call_method1("_on_bar_event", args)?;
+                if !self.skip_on_bar_event {
+                    let args = Python::attach(|py| {
+                        let bar = b.clone();
+                        (bar, py_ctx.clone_ref(py))
+                    });
+                    strategy.call_method1("_on_bar_event", args)?;
+                }
                 Python::attach(|py| {
                     strategy.call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))
                 })?;

--- a/src/engine/core.rs
+++ b/src/engine/core.rs
@@ -1238,8 +1238,14 @@ impl Engine {
                     });
                     strategy.call_method1("_on_bar_event", args)?;
                 }
+                // 顺带把本 bar 最新价带给策略级 _last_prices：
+                // skip_on_bar_event 模式下 on_bar_event 不运行，
+                // 定量 API（order_target_percent 等）依赖该簿记。
                 Python::attach(|py| {
-                    strategy.call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))
+                    strategy.call_method1(
+                        "_flush_pending_order_events",
+                        (py_ctx.clone_ref(py), Some(b.symbol.as_str()), b.close.to_f64()),
+                    )
                 })?;
 
                 // Extract orders and timers
@@ -1281,7 +1287,10 @@ impl Engine {
 
                 strategy.call_method1("_on_tick_event", args)?;
                 Python::attach(|py| {
-                    strategy.call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))
+                    strategy.call_method1(
+                        "_flush_pending_order_events",
+                        (py_ctx.clone_ref(py), Some(t.symbol.as_str()), t.price.to_f64()),
+                    )
                 })?;
 
                 // Extract orders and timers
@@ -1321,7 +1330,10 @@ impl Engine {
 
                 strategy.call_method1("_on_timer_event", args)?;
                 Python::attach(|py| {
-                    strategy.call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))
+                    strategy.call_method1(
+                        "_flush_pending_order_events",
+                        (py_ctx.clone_ref(py), None::<&str>, None::<f64>),
+                    )
                 })?;
 
                 // Extract orders and timers
@@ -1394,9 +1406,15 @@ impl Engine {
             if let Some(ref slot_py) = slot_strategy {
                 slot_py
                     .bind(py)
-                    .call_method1("_flush_pending_order_events", (py_ctx.clone_ref(py),))?;
+                    .call_method1(
+                        "_flush_pending_order_events",
+                        (py_ctx.clone_ref(py), None::<&str>, None::<f64>),
+                    )?;
             } else {
-                strategy.call_method1("_flush_pending_order_events", (py_ctx,))?;
+                strategy.call_method1(
+                    "_flush_pending_order_events",
+                    (py_ctx, None::<&str>, None::<f64>),
+                )?;
             }
         }
 

--- a/src/engine/python.rs
+++ b/src/engine/python.rs
@@ -498,6 +498,16 @@ impl Engine {
         self.risk_budget_reset_daily = enabled;
     }
 
+    /// 设置是否跳过每 bar 的 `_on_bar_event` Python 调用.
+    ///
+    /// 仅在策略未覆写 `on_bar` 且无其他 bar 级钩子时由 Python 侧校验开启；
+    /// `_flush_pending_order_events` 与 Timer 驱动的 on_cross_section 不受影响。
+    ///
+    /// :param enabled: 是否跳过
+    fn set_skip_on_bar_event(&mut self, enabled: bool) {
+        self.skip_on_bar_event = enabled;
+    }
+
     /// 初始化回测引擎.
     ///
     /// :return: Engine 实例
@@ -507,6 +517,7 @@ impl Engine {
         Engine {
             state: SharedState::new(initial_cash),
             last_prices: HashMap::new(),
+            skip_on_bar_event: false,
             instruments: HashMap::new(),
             current_date: None,
             market_manager: MarketManager::new(),

--- a/tests/test_skip_inert_bar_hooks.py
+++ b/tests/test_skip_inert_bar_hooks.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""skip_inert_bar_hooks：空 on_bar 策略跳过每 bar Python 回调的语义与校验."""
+
+import akquant as aq
+import pandas as pd
+import pytest
+from akquant import Strategy
+
+TZ = "Asia/Shanghai"
+DAYS = pd.date_range("2024-01-02", periods=4, freq="B", tz=TZ)
+
+
+def _make_bars(symbol: str, closes: list[float]) -> pd.DataFrame:
+    rows = []
+    for d, c in zip(DAYS, closes):
+        rows.append(
+            {
+                "date": d,
+                "open": c,
+                "high": c,
+                "low": c,
+                "close": c,
+                "volume": 1_000_000.0,
+                "symbol": symbol,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+class _DailyRotate(Strategy):
+    """cross-section 每日满仓轮换（无 on_bar，属 inert 策略）."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._day = 0
+        self.cross_section_calls = 0
+        self.trade_events = 0
+
+    def on_cross_section(self, trading_date: object, timestamp: int) -> None:
+        _ = trading_date, timestamp
+        self._day += 1
+        self.cross_section_calls += 1
+        pick = "AAA" if self._day % 2 == 1 else "BBB"
+        other = "BBB" if pick == "AAA" else "AAA"
+        self.order_target_percent(target_percent=0.0, symbol=other)
+        self.order_target_percent(target_percent=0.9, symbol=pick)
+
+    def on_trade(self, trade: object) -> None:
+        _ = trade
+        self.trade_events += 1
+
+
+def _run_rotation(skip: bool) -> tuple[pd.DataFrame, _DailyRotate]:
+    data = {
+        "AAA": _make_bars("AAA", [10.0, 11.0, 12.0, 13.0]),
+        "BBB": _make_bars("BBB", [20.0, 19.0, 21.0, 18.0]),
+    }
+    strat = _DailyRotate()
+    result = aq.run_backtest(
+        data=data,
+        strategy=strat,
+        symbols=["AAA", "BBB"],
+        initial_cash=1_000_000.0,
+        commission_rate=0.0003,
+        show_progress=False,
+        skip_inert_bar_hooks=skip,
+    )
+    return result.trades_df.reset_index(drop=True), strat
+
+
+def test_skip_inert_hooks_trades_identical_and_cross_section_alive() -> None:
+    """inert 策略开启跳过：on_cross_section 与成交回调照常，成交逐笔一致."""
+    trades_off, strat_off = _run_rotation(skip=False)
+    trades_on, strat_on = _run_rotation(skip=True)
+    assert len(trades_off) > 0
+    pd.testing.assert_frame_equal(trades_off, trades_on)
+    # on_cross_section（timer 驱动）不受影响
+    assert strat_on.cross_section_calls == strat_off.cross_section_calls > 0
+    # on_trade 仍按 bar 送达（_flush_pending_order_events 保留）
+    assert strat_on.trade_events == strat_off.trade_events > 0
+
+
+class _WithOnBar(Strategy):
+    def on_bar(self, bar: aq.Bar) -> None:
+        _ = bar
+
+
+def test_skip_inert_hooks_rejects_overridden_on_bar() -> None:
+    """覆写了 on_bar 的策略开启跳过必须报错."""
+    with pytest.raises(ValueError, match="on_bar"):
+        aq.run_backtest(
+            data={"AAA": _make_bars("AAA", [10.0, 11.0, 12.0, 13.0])},
+            strategy=_WithOnBar(),
+            symbols=["AAA"],
+            initial_cash=100_000.0,
+            show_progress=False,
+            skip_inert_bar_hooks=True,
+        )
+
+
+class _WithWarmup(Strategy):
+    def __init__(self) -> None:
+        super().__init__()
+        self.warmup_period = 2
+
+
+def test_skip_inert_hooks_rejects_warmup() -> None:
+    """设置 warmup_period 的策略开启跳过必须报错."""
+    with pytest.raises(ValueError, match="warmup_period"):
+        aq.run_backtest(
+            data={"AAA": _make_bars("AAA", [10.0, 11.0, 12.0, 13.0])},
+            strategy=_WithWarmup(),
+            symbols=["AAA"],
+            initial_cash=100_000.0,
+            show_progress=False,
+            skip_inert_bar_hooks=True,
+        )


### PR DESCRIPTION
关联 #345；语义讨论见 #347。

### 问题
每根 bar 引擎调用 Python 侧 `_on_bar_event`（~30 行框架工作），
pyo3 调用机制占 ~17% CPU。cross-section 类策略只覆写 `on_cross_section`
（timer 事件驱动，经 `_prime_framework_cross_section_timers` 预注册，
不经过 `_on_bar_event`），其 `on_bar` 完全空转。

### 改法
`run_backtest` 新增 `skip_inert_bar_hooks=False`（默认关，行为不变）。
开启前 Python 侧强制校验（`_assert_strategy_bar_hooks_inert`），任一命中即抛
ValueError：覆写 on_bar / 滚动训练（_rolling_step>0）/ 增量指标 /
schedule 定时任务 / 指标记录 / warmup_period；存在 Analyzer 插件同样拒绝。
开启后引擎跳过 `_on_bar_event`；`_flush_pending_order_events` 保留
（on_order/on_trade 仍按 bar 送达），Timer 驱动的 on_cross_section 不受影响。
实现过程中发现策略级 `_last_prices` 簿记由 on_bar_event 维护，而定量 API
（order_target_percent 等）依赖它定价——为此让 `_flush_pending_order_events`
在 Bar/Tick 事件时顺带接收 (symbol, price) 并同步簿记（内部方法签名扩展，
全部调用点已更新；未开启跳过时行为与现状完全一致）。

### 测试
新增 `tests/test_skip_inert_bar_hooks.py`：开/关成交逐笔一致 +
on_cross_section/on_trade 回调计数一致 + on_bar 覆写/warmup 场景 ValueError。

### 验证
- `cargo test` 124 passed；`uv run pytest` 1331 passed（含新增 3 例；其余 2 例为
  dev 上 pandas 2.3 既有失败，见 PR-fix）；`tests/golden` **不更新基线**通过
- bench_engine_perbar（4500 标的 × 120 日，3 轮中位）：
  关 2568.0 → 开 **2936.2 bars/sec（同构建开/关 +14.4%，相对 dev 基线 +11.9%）**
  （墙钟 210.3s → 183.9s），orders/fills 完全相同（9245/5643）
