### PR TITLE
fix(live): 修复多个实盘交易问题并发布v0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 教材第 5 章与教材目录页现已同步补充完整 `on_xxx` 回调地图、学习路径与相关示例入口，便于用户从教材直接理解各类回调的职责边界，并新增 `on_pre_open` 的推荐用法。
 - 示例体系已补充 `examples/50_framework_hooks_demo.py` 与 `examples/51_class_tick_callbacks_demo.py`，分别覆盖框架边界钩子与类风格 `on_tick` 的最小可运行案例。
 - 示例体系新增 `examples/52_pre_open_demo.py`，用于演示 `on_pre_open -> on_order/on_trade -> on_bar` 的触发顺序与当日 open 成交语义。
+- **`supports_short_sell` 在 `broker_live` 下开始真正生效**：该字段此前在实盘下单路径上没有任何消费者（仅服务 `order_target*` 的目标仓位计算），broker 声明了 `False` 也照样把开空单发给柜台，只能等柜台报错。现在 `side=Sell` + `position_effect=open` 会在下单前被本地拒绝。内置 CTP 声明 `True`，不受影响；`ptrade` / `miniqmt` 只声明支持 `auto`，其显式 `open` 早已被 `supported_position_effects` 拦截，行为不变。若自定义 broker 实际支持融券却被拦，请修正其 `get_capabilities()` 中的 `supports_short_sell` 声明。
 
 ### Fixed
+- 修复 `broker_live` 下 `buy()` / `sell()` 缺省参数不解析的问题：`quantity=None` 原先直接透传到拆腿逻辑并以 `TypeError` 崩掉——等价于 `set_sizer()` 在实盘静默失效；`symbol=None` 原先会把 `None` 送进柜台请求。现按回测同口径解析：`symbol` 取当前 bar/tick，买入量走 `strategy.sizer`，卖出量全平持仓。另外解析后 `quantity <= 0` 时不再向柜台发 0 手单，改为返回空回执（与回测一致）。一处有意偏离：卖出全平在实盘取**可用**持仓而非总持仓，因为 A 股 T+1 下按总量报单会被柜台整单拒绝，取可用量退化为部分卖出。
+- 修复 `broker_live` 下 `get_instrument()` / `get_instruments()` / `get_instrument_field()` 对**任何**标的都抛 `KeyError` 的问题：`run_live` 原先从不调用 `_set_instrument_snapshots`，策略侧快照字典恒为空。现由 `LiveRunner` 从传入的 `Instrument` 列表灌入。受实盘入口形态限制，`Instrument` 仅能回读 9 个字段，`option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_*` 在实盘快照中为 `None`（回测不受影响，仍由 `InstrumentConfig` 灌入完整字段）。
+- 修复 `client_order_id` 跨会话撞号的问题：原格式 `{broker}-coid-{序号}` 的序号每次 `run_live` 从 0 起，重启后第一笔单又是 `...-coid-1`，与柜台里同名历史委托冲突——把 `client_order_id` 当幂等键的柜台会直接拒单（实测中间件返回 409 Conflict）。现格式为 `{broker}-{8 位会话标记}-{会话内序号}`，会话标记每次启动重新生成，跨重启与多进程并行均不撞号。
 - 修复 `on_after_trading` 里下 next-open（`bar_offset=1`）单晚一格成交的问题（#324）。它原先在「下一根 bar」到来时才惰性补触发，引擎时钟已越过日界，其中提交的 next-open 单被撮合守卫推迟一格（盘后下单期望次日开盘成交，实际到第三日）。现改为按日终边界定时器在「当日收盘点」的独立事件里触发（早于下一根 bar），使其中提交的次日开盘单落在下一根 bar，而非晚一格。默认（非 precise）与 precise 模式下均已修正；`on_before_trading` 等开始型钩子本就与 `on_bar` 同拍触发，不受影响。`__engine_rule_version__` 相应升至 `1.3.1`。
 - 修复 `on_pre_open` 未兑现「本次 open 成交」契约的问题（#324 家族）。其盘前定时器原先排在当日首根 bar 的同一时刻，订单 `created_at` 与该 bar 同拍、被 next-open 守卫拦截，导致实际成交在**下一日 open**（可由 `examples/52_pre_open_demo.py` 复现）。现将盘前定时器排在首根 bar 之前 1ns，使 `on_pre_open` 中下的默认开盘单落在**当日 open**，与文档承诺一致。
 - 修复短回测区间下 Sharpe/Sortino 因「分子用 CAGR、分母用日波动 × √252」口径不一致而出现异常巨大值（如期货场景 Sharpe 高达数千万）的问题；改用日收益算术均值年化后数值回归合理量级。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.21"
+version = "0.3.22"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/advanced/custom_broker_production_checklist.md
+++ b/docs/en/advanced/custom_broker_production_checklist.md
@@ -15,6 +15,8 @@ Use this checklist to move a custom broker from "works in demo" to "production-r
 - Return existing `broker_order_id` on duplicate active submission
 - Make cancel requests idempotent
 - Cover full order lifecycle states: `Submitted/PartiallyFilled/Filled/Cancelled/Rejected`
+- If you treat `client_order_id` as an idempotency key: AKQuant generates `{broker}-{session tag}-{sequence}`, where the session tag is regenerated on every `run_live`, so ids never collide across restarts or parallel processes. Do not assume the id is reproducible after a restart.
+- Declare `supports_short_sell` truthfully: when it is `False`, AKQuant rejects `side=Sell` + `position_effect=open` locally before the order reaches your gateway.
 
 ## 3. Reports and State Sync
 

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -695,7 +695,9 @@ Available APIs:
 *   `self.get_instrument_config(symbol, fields=None)`: Compatibility API for single or batch field access.
 *   `self.get_instruments(symbols=None)`: Returns snapshot dict for multiple symbols.
 
-These APIs are available in `on_start` (snapshots are injected before strategy start callbacks).
+These APIs are available in `on_start`: backtest injects snapshots from `InstrumentConfig`, live (`run_live`) injects them from the `Instrument` list you pass in.
+
+Field coverage differs between the two. The live entry point only accepts `Instrument` objects, and `option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_*` exist there only as constructor arguments — they cannot be read back — so those fields are `None` in live snapshots. The `expiry_date` / `strike_price` reads in the example below work in backtest; live strategies must pass them in via strategy params or `context`. See [InstrumentSnapshot](../reference/api.md#akquantinstrumentsnapshot) for the field list.
 
 ```python
 from akquant import Bar, Strategy

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -611,6 +611,7 @@ Notes:
 *   `expiry_date` uses `int(YYYYMMDD)` semantics.
 *   Snapshot data is available in `on_start`.
 *   Prefer `get_instrument` / `get_instrument_config` / `get_instrument_field` in strategy code.
+*   **Field coverage differs between backtest and live.** Backtest snapshots are populated from `InstrumentConfig` and carry every field. Live (`run_live`) only accepts `Instrument` objects, which expose just `symbol` / `asset_type` / `multiplier` / `margin_ratio` / `tick_size` / `lot_size` / `option_margin_model` / `implied_volatility` / `reference_volatility` for read-back, so `option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_type` / `settlement_price` / `static_attrs` are `None` (or empty) in live snapshots. Option strategies that depend on those fields must pass them in via strategy params or `context`.
 
 ### Configuration System Explained
 
@@ -875,11 +876,14 @@ Note: if you do not pass an explicit `fill_mode` here, the framework defaults to
 
 **Trading Methods:**
 
-*   `buy(symbol, quantity, price=None, trigger_price=None, ...)`: Buy (open long / close short).
+*   `buy(symbol=None, quantity=None, price=None, trigger_price=None, ...)`: Buy (open long / close short).
     *   Market order if `price` is not specified.
     *   Limit order if `price` is specified.
     *   Stop order (Stop Market) if `trigger_price` is specified.
-*   `sell(symbol, quantity, price=None, trigger_price=None, ...)`: Sell (close long / open short). Same parameters as above.
+    *   Omitting `symbol` uses the current bar/tick symbol; callbacks without market context (e.g. `on_start`) must pass it explicitly.
+    *   Omitting `quantity` sizes the order via `self.sizer` (defaults to `FixedSize(100)`, replaceable with `set_sizer()`).
+*   `sell(symbol=None, quantity=None, price=None, trigger_price=None, ...)`: Sell (close long / open short). Same parameters as above, except that **omitting `quantity` does not use the sizer — it closes the whole position**: total position in backtest, available position under `broker_live` (China A-share T+1 freezes same-day buys, so sizing off the total gets the whole order rejected by the broker).
+*   When the resolved quantity is `<= 0`, no order is placed and an empty receipt is returned (`len(receipt) == 0`, `receipt.primary == ""`).
 *   `short(symbol, quantity, price=None, ...)`: Short sell.
 *   `cover(symbol, quantity, price=None, ...)`: Buy to cover.
 *   `submit_order(..., order_type="StopTrail", trail_offset=..., trail_reference_price=None)`: Submit a trailing stop order. `trail_offset` must be greater than 0.

--- a/docs/zh/advanced/custom_broker_production_checklist.md
+++ b/docs/zh/advanced/custom_broker_production_checklist.md
@@ -15,6 +15,8 @@
 - 重复提交时返回已存在 `broker_order_id`，不重复报单
 - 撤单接口支持幂等（重复撤单不抛异常）
 - 订单状态机覆盖 `Submitted/PartiallyFilled/Filled/Cancelled/Rejected`
+- 若把 `client_order_id` 当幂等键：AKQuant 生成的格式为 `{broker}-{会话标记}-{会话内序号}`，会话标记每次 `run_live` 重新生成，因此跨重启与多进程并行都不会撞号；不要假设该 id 在重启后可复现
+- 声明 `supports_short_sell` 要与真实能力一致：声明 `False` 时，`side=Sell` + `position_effect=open` 会被 AKQuant 在下单前本地拒绝，不会下发柜台
 
 ## 3. 回报与状态同步
 

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -1097,7 +1097,9 @@ class MyStrategy(Strategy):
 *   `self.get_instrument_config(symbol, fields=None)`: 兼容接口；支持单字段或多字段批量读取。
 *   `self.get_instruments(symbols=None)`: 返回多个标的的快照字典。
 
-这些接口在 `on_start` 即可使用（回测启动阶段已注入快照）。
+这些接口在 `on_start` 即可使用：回测在启动阶段由 `InstrumentConfig` 注入快照，实盘（`run_live`）由传入的 `Instrument` 列表注入。
+
+注意两者字段覆盖不同：实盘入口只接 `Instrument` 对象，`option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_*` 在该对象上只作为构造入参存在、无法回读，因此实盘快照中这些字段为 `None`。上面例子里的 `expiry_date` / `strike_price` 读取在回测可用，实盘需自行通过策略参数或 `context` 传入。字段清单见 [InstrumentSnapshot](../reference/api.md#akquantinstrumentsnapshot)。
 
 ```python
 import akquant

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -594,6 +594,7 @@ class InstrumentSnapshot:
 *   `expiry_date` 使用 `int(YYYYMMDD)` 语义。
 *   快照在 `on_start` 即可访问。
 *   建议在策略中通过 `get_instrument` / `get_instrument_config` / `get_instrument_field` 访问。
+*   **回测与实盘的字段覆盖不同**：回测快照由 `InstrumentConfig` 灌入，字段齐全；实盘（`run_live`）只接 `Instrument` 对象，它仅能回读 `symbol` / `asset_type` / `multiplier` / `margin_ratio` / `tick_size` / `lot_size` / `option_margin_model` / `implied_volatility` / `reference_volatility`，因此 `option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_type` / `settlement_price` / `static_attrs` 在实盘快照里为 `None`（或空 dict）。期权策略若依赖这些字段，需自行通过策略参数或 `context` 传入。
 
 ### 配置系统详解 (Configuration System)
 
@@ -897,11 +898,14 @@ def on_pre_open(self, event: Dict[str, Any]) -> None:
 
 **交易方法:**
 
-*   `buy(symbol, quantity, price=None, trigger_price=None, ...)`: 买入（开多/平空）。
+*   `buy(symbol=None, quantity=None, price=None, trigger_price=None, ...)`: 买入（开多/平空）。
     *   如果不指定 `price`，则为市价单。
     *   如果指定 `price`，则为限价单。
     *   如果指定 `trigger_price`，则为止损/止盈单 (Stop Market)。
-*   `sell(symbol, quantity, price=None, trigger_price=None, ...)`: 卖出（平多/开空）。参数同上。
+    *   不传 `symbol` 时取当前 bar/tick 的标的；在无行情上下文的回调（如 `on_start`）中必须显式传入。
+    *   不传 `quantity` 时按 `self.sizer` 计算下单量（默认 `FixedSize(100)`，可用 `set_sizer()` 替换）。
+*   `sell(symbol=None, quantity=None, price=None, trigger_price=None, ...)`: 卖出（平多/开空）。参数同上，但**不传 `quantity` 时不走 sizer，而是全平当前持仓**：回测取总持仓，`broker_live` 取可用持仓（A 股 T+1 下当日买入部分不可卖，按总量报单会被柜台整单拒绝）。
+*   解析后下单量 `<= 0` 时不报单，返回空回执（`len(receipt) == 0`、`receipt.primary == ""`）。
 *   `submit_order(..., order_type="StopTrail", trail_offset=..., trail_reference_price=None)`: 提交跟踪止损单。`trail_offset` 必须大于 0。
 *   `submit_order(..., order_type="StopTrailLimit", price=..., trail_offset=..., trail_reference_price=None)`: 提交跟踪止损限价单。`price` 与 `trail_offset` 必填。
 *   `submit_order(..., broker_options={...})`: 可选 broker 扩展参数透传（回测阶段仅记录在订单对象 `order.broker_options` 上，便于联调与审计）。

--- a/docs/zh/textbook/15_live_trading.md
+++ b/docs/zh/textbook/15_live_trading.md
@@ -47,6 +47,10 @@ python examples/66_logging_audit_demo.py
 | **成交机制** | 假设成交 (Perfect Fill) | 真实撮合 (Partial/Reject) |
 | **延迟** | 零延迟 (Zero Latency) | 网络延迟 + 内部处理延迟 |
 | **状态管理** | 内存状态 (Transient) | 持久化状态 (Persistent) |
+| **缺省卖出量** | `sell()` 不传量时平总持仓 | 平**可用**持仓（T+1 当日买入部分不可卖） |
+| **标的静态属性** | `InstrumentConfig` 注入，字段齐全 | 仅 `Instrument` 可回读字段，期权/结算类字段为 `None` |
+
+前两行是数据与撮合层面的固有差异，后两行是接口层面的差异：同一段策略代码在两侧都能跑，但缺省下单量与可读的标的字段不完全一致，写策略时不要假设"回测读得到的字段实盘也读得到"。
 
 ### 15.1.2 交易接口 (Gateway)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.21"
+version = "0.3.22"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/gateway/broker_models.py
+++ b/python/akquant/gateway/broker_models.py
@@ -157,8 +157,15 @@ def validate_execution_semantics(
     capability: BrokerCapability,
     position_effect: str | None,
     reduce_only: bool = False,
+    side: str | None = None,
 ) -> str:
-    """Validate order semantics against the declared broker capability matrix."""
+    """Validate order semantics against the declared broker capability matrix.
+
+    `side` 可选(缺省 None 保持既有调用点兼容)。传入时额外校验卖空:
+    `side='sell'` + `position_effect='open'` 是开空语义, broker 若声明
+    `supports_short_sell=False` 则本地拒单——该字段此前在 broker_live 路径上
+    无任何消费者, 声明了也不生效, 只能等柜台报错。
+    """
     normalized_effect = normalize_position_effect(position_effect)
     supported = tuple(
         normalize_position_effect(item)
@@ -167,6 +174,15 @@ def validate_execution_semantics(
     if reduce_only and not capability.reduce_only:
         raise RuntimeError(
             f"broker '{capability.broker_name}' does not support reduce_only orders"
+        )
+    if (
+        str(side or "").strip().lower() == "sell"
+        and normalized_effect == "open"
+        and not capability.supports_short_sell
+    ):
+        raise RuntimeError(
+            f"broker '{capability.broker_name}' does not support short sell "
+            "(supports_short_sell=False)"
         )
     if normalized_effect != "auto" and not capability.position_effect:
         raise RuntimeError(

--- a/python/akquant/gateway/order_submitter.py
+++ b/python/akquant/gateway/order_submitter.py
@@ -8,6 +8,7 @@ from .broker_models import (
     validate_broker_extra,
     validate_execution_semantics,
 )
+from .broker_strategy_api import _resolve_symbol
 from .order_audit import record_reject, record_submit
 from .order_receipt import OrderLeg, OrderReceipt
 
@@ -276,6 +277,56 @@ class BrokerOrderSubmitter:
         self._sync_group_mapping = sync_group_mapping
         self._warned_ignored_params: set[str] = set()
 
+    def _resolve_quantity(
+        self,
+        symbol: str,
+        side: str,
+        price: float | None,
+        quantity: float | None,
+    ) -> float:
+        """把 ``quantity=None`` 解析为具体下单量, 对齐回测的缺省量语义.
+
+        回测两侧口径不同(见 `strategy_trading_api`):
+        买入侧 (`_submit_buy_side_orders`) 走 `sizer.get_size(...)`;
+        卖出侧 (`_submit_sell_side_orders`) 不走 sizer, 而是全平当前持仓。
+        broker_live 此前完全不做这一步, `quantity=None` 直接透传到
+        `resolve_live_order_legs`, 在 `quantity <= 0` 处以 TypeError 崩掉
+        —— 等价于 `set_sizer()` 在实盘静默失效。
+
+        与回测的一处有意偏离: 卖出全平取**可用**持仓而非总持仓。A 股 T+1
+        下总持仓含当日不可卖部分, 按总量报单会被柜台整单拒绝(硬失败),
+        取可用量则退化为部分卖出(软降级), 更贴近用户意图。
+        """
+        if quantity is not None:
+            return float(quantity)
+
+        execution = getattr(self._strategy, "execution", None)
+        if str(side).strip().lower() == "sell":
+            if execution is None:
+                raise RuntimeError(
+                    "quantity 未指定且执行后端未就绪, 无法按持仓推断卖出量"
+                )
+            return float(execution.get_available_position(symbol) or 0.0)
+
+        sizer = getattr(self._strategy, "sizer", None)
+        if sizer is None:
+            raise RuntimeError("quantity 未指定且策略未配置 sizer, 无法推断买入量")
+        ref_price = price
+        if ref_price is None:
+            last_prices = getattr(self._strategy, "_last_prices", None) or {}
+            ref_price = float(last_prices.get(symbol, 0.0) or 0.0)
+        cash = float(execution.get_cash()) if execution is not None else 0.0
+        # 实盘无回测 ctx(为 None); 自定义 sizer 若依赖 context 需自行兼容。
+        size = sizer.get_size(
+            float(ref_price), cash, getattr(self._strategy, "ctx", None), symbol
+        )
+        if size is None:
+            raise RuntimeError(
+                f"sizer {type(sizer).__name__}.get_size() 返回 None "
+                "(get_size 是否漏了 return?)"
+            )
+        return float(size)
+
     def install(self) -> None:
         """No-op: install now happens via `strategy.execution = BrokerExecution(...)`.
 
@@ -286,9 +337,9 @@ class BrokerOrderSubmitter:
 
     def submit_order(
         self,
-        symbol: str,
-        side: str,
-        quantity: float,
+        symbol: str | None = None,
+        side: str = "Buy",
+        quantity: float | None = None,
         price: float | None = None,
         client_order_id: str | None = None,
         order_type: str = "Market",
@@ -315,6 +366,11 @@ class BrokerOrderSubmitter:
         as "the" order id); `str(receipt)` is the `group_id` (client order id) and is
         a *different* id space in production brokers — do not use them
         interchangeably.
+
+        `symbol=None` / `quantity=None` 按回测同口径解析(见
+        :meth:`_resolve_quantity`): symbol 取当前 bar/tick, 买入量走
+        `strategy.sizer`, 卖出量取可用持仓。解析后 `quantity <= 0` 返回空回执,
+        不向柜台报单。
         """
         if not getattr(self._strategy, "broker_ready", True):
             raise RuntimeError(
@@ -346,11 +402,21 @@ class BrokerOrderSubmitter:
                 )
         capability = self._resolve_trader_capabilities(self._trader_gateway)
         validate_broker_extra(capability, extra)
+        # symbol/quantity 的缺省解析: 回测在 strategy_trading_api 内完成,
+        # broker_live 此前整条缺失(仅本地止损路径解析过 symbol), 这里补齐。
+        symbol = _resolve_symbol(self._strategy, symbol)
+        quantity = self._resolve_quantity(
+            symbol=symbol, side=side, price=price, quantity=quantity
+        )
+        if quantity <= 0:
+            # 回测对 quantity<=0 返回空单(不报单); 此前实盘会把 0 手单发给柜台。
+            return OrderReceipt(group_id="", order_ids=(), legs=())
         normalized_asset_type = normalize_asset_type(asset_type)
         normalized_position_effect = validate_execution_semantics(
             capability,
             position_effect,
             reduce_only,
+            side=side,
         )
         owner_strategy_id = str(
             getattr(self._strategy, "_owner_strategy_id", "_default")

--- a/python/akquant/live/_runner.py
+++ b/python/akquant/live/_runner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import threading
 import time
+import uuid
 from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
 
 from ..akquant import Bar, DataFeed, Engine, Instrument
@@ -17,7 +18,7 @@ from ..gateway.order_submitter import (
 )
 from ..indicator_recording import IndicatorSink
 from ..log import build_log_extra, get_logger
-from ..strategy import Strategy
+from ..strategy import InstrumentSnapshot, Strategy
 from ..strategy_loader import resolve_strategy_input
 from ..utils import format_metric_value
 from ._gateway_setup import (
@@ -43,6 +44,55 @@ logger = get_logger("gateway.live")
 
 # Backward-compatible alias; canonical definition lives in _gateway_setup.
 _LEGACY_GATEWAY_OPTION_KEYS = LEGACY_GATEWAY_OPTION_KEYS
+
+
+def _instruments_to_snapshots(
+    instruments: List[Instrument],
+) -> Dict[str, InstrumentSnapshot]:
+    """把 live 的 ``Instrument`` 列表转成策略侧可读的标的快照.
+
+    回测在 ``run_backtest`` 里把 ``InstrumentConfig`` 灌进
+    ``Strategy._set_instrument_snapshots``；live 此前完全没有这一步，
+    ``_instrument_snapshots`` 恒为空 dict，导致 ``get_instrument()`` /
+    ``get_instrument_field()`` 在实盘对**任何** symbol 都抛 KeyError。
+
+    覆盖范围受 live 入口形态限制: ``run_live`` 只接 ``Instrument``(Rust 对象)，
+    而它仅暴露 symbol/asset_type/multiplier/margin_ratio/tick_size/lot_size/
+    option_margin_model/implied_volatility/reference_volatility 九个可读字段。
+    option_type/strike_price/expiry_date/underlying_symbol/settlement_* 只在
+    构造入参上存在、不可回读，故实盘快照里保持 None——期权策略若依赖这些字段，
+    仍需自行传入，不能指望 ``get_instrument()``。
+    """
+    from ..backtest.engine import (
+        _asset_type_to_upper_name,
+        _option_margin_model_to_upper_name,
+    )
+
+    snapshots: Dict[str, InstrumentSnapshot] = {}
+    for inst in instruments or []:
+        symbol = str(inst.symbol)
+        snapshots[symbol] = InstrumentSnapshot(
+            symbol=symbol,
+            asset_type=_asset_type_to_upper_name(inst.asset_type),
+            multiplier=float(inst.multiplier),
+            margin_ratio=float(inst.margin_ratio),
+            tick_size=float(inst.tick_size),
+            lot_size=float(inst.lot_size),
+            option_margin_model=_option_margin_model_to_upper_name(
+                inst.option_margin_model
+            ),
+            implied_volatility=(
+                float(inst.implied_volatility)
+                if inst.implied_volatility is not None
+                else None
+            ),
+            reference_volatility=(
+                float(inst.reference_volatility)
+                if inst.reference_volatility is not None
+                else None
+            ),
+        )
+    return snapshots
 
 
 class _StrategyCallbackFanout:
@@ -492,6 +542,12 @@ class LiveRunner:
             setattr(target, "broker_ready", default_ready)
 
         strategy_targets = [strategy_instance, *slot_strategy_instances.values()]
+        # getattr 兜底与同方法内 trading_mode 一致: 允许绕过 __init__ 的调用方。
+        instrument_snapshots = _instruments_to_snapshots(
+            getattr(self, "instruments", None) or []
+        )
+        for target in strategy_targets:
+            target._set_instrument_snapshots(instrument_snapshots)
         if self.context:
             for target in strategy_targets:
                 if hasattr(target, "_context"):
@@ -791,6 +847,8 @@ class LiveRunner:
         self._broker_event_bridge: Any = None
         self._broker_recovery: Any = None
         self._broker_submit_seq = 0
+        # 会话标记: 让 client_order_id 跨进程/跨重启唯一(见 _next_client_order_id)。
+        self._broker_session_tag = uuid.uuid4().hex[:8]
         self._broker_submit_lock = threading.Lock()
         self._broker_recovery_mode = self._normalize_broker_recovery_mode(
             getattr(self, "gateway_options", {}).get("recovery_mode", "compatible")
@@ -1122,9 +1180,18 @@ class LiveRunner:
         return payload_field(payload, field)
 
     def _next_client_order_id(self) -> str:
+        """生成 client_order_id: ``{broker}-{会话标记}-{会话内序号}``.
+
+        序号是实例字段, 每次 run_live 从 0 起。若只用序号(旧格式
+        ``{broker}-coid-{seq}``), 重启后第一笔单又是 ``...-coid-1``, 会与柜台
+        里同名的历史委托撞号——把 client_order_id 当幂等键的柜台会直接拒单
+        (实测中间件返回 409 Conflict)。加 8 位会话标记后, 同一进程内递增序号
+        保证顺序可读, 跨重启与多进程并行则由标记区分。
+        """
         with self._broker_submit_lock:
             self._broker_submit_seq += 1
-            return f"{self.broker}-coid-{self._broker_submit_seq}"
+            tag = getattr(self, "_broker_session_tag", "") or "nosess"
+            return f"{self.broker}-{tag}-{self._broker_submit_seq}"
 
     def _sync_order_id_mapping(
         self,

--- a/tests/test_gateway_broker_submitter_quantity.py
+++ b/tests/test_gateway_broker_submitter_quantity.py
@@ -1,0 +1,204 @@
+"""broker_live 下 symbol/quantity 缺省解析与卖空拦截(对齐回测口径)."""
+
+from typing import Any
+
+import pytest
+from akquant.gateway.broker_models import BrokerCapability, UnifiedOrderRequest
+from akquant.gateway.order_submitter import BrokerOrderSubmitter
+from akquant.sizer import FixedSize, PercentSizer
+
+
+class _Execution:
+    """最小执行后端桩:只提供 submitter 会读的资金/持仓口径."""
+
+    def __init__(self, cash: float = 0.0, available: float = 0.0) -> None:
+        self._cash = cash
+        self._available = available
+
+    def get_cash(self) -> float:
+        return self._cash
+
+    def get_available_position(self, symbol: str | None = None) -> float:
+        _ = symbol
+        return self._available
+
+
+class _Bar:
+    def __init__(self, symbol: str) -> None:
+        self.symbol = symbol
+
+
+class _Strategy:
+    """带 sizer / execution / 最新价的策略桩."""
+
+    _owner_strategy_id = "_default"
+    broker_ready = True
+    ctx = None
+
+    def __init__(
+        self,
+        sizer: Any = None,
+        execution: Any = None,
+        last_prices: dict[str, float] | None = None,
+        current_bar: Any = None,
+    ) -> None:
+        self.sizer = sizer
+        self.execution = execution
+        self._last_prices = last_prices or {}
+        self.current_bar = current_bar
+        self.current_tick = None
+
+
+def _submitter(
+    strategy: _Strategy,
+    captured: list[UnifiedOrderRequest],
+    capability: BrokerCapability | None = None,
+) -> BrokerOrderSubmitter:
+    """Build a submitter recording every placed request."""
+
+    class _Gw:
+        def place_order(self, req: UnifiedOrderRequest) -> str:
+            captured.append(req)
+            return f"b{len(captured)}"
+
+    cap = capability or BrokerCapability(broker_name="qmf")
+    return BrokerOrderSubmitter(
+        trader_gateway=_Gw(),
+        strategy=strategy,
+        resolve_trader_capabilities=lambda _gw: cap,
+        next_client_order_id=lambda: "c1",
+        can_submit_client_order=lambda _cid: True,
+        sync_order_id_mapping=lambda _c, _b: None,
+        bind_order_owner=lambda _c, _b, _o: None,
+        notify_strategy_error=lambda *_a, **_k: None,
+        payload_field=lambda obj, name: getattr(obj, name, None),
+        get_execution_capabilities=lambda: cap.as_execution_capabilities(),
+        record_order_request=lambda *_a: None,
+    )
+
+
+def test_buy_without_quantity_uses_sizer() -> None:
+    """买入不传 quantity 时走 strategy.sizer(与回测同口径)."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(sizer=FixedSize(300), execution=_Execution(cash=100_000.0))
+    _submitter(strategy, captured).submit_order(
+        symbol="600000.SH", side="Buy", price=10.0
+    )
+    assert [r.quantity for r in captured] == [300.0]
+
+
+def test_buy_without_quantity_and_price_uses_last_price() -> None:
+    """未传 price 时参考价取 _last_prices(PercentSizer 才能算出量)."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(
+        sizer=PercentSizer(10.0),
+        execution=_Execution(cash=100_000.0),
+        last_prices={"600000.SH": 10.0},
+    )
+    _submitter(strategy, captured).submit_order(symbol="600000.SH", side="Buy")
+    # 100000 * 10% / 10.0 = 1000
+    assert [r.quantity for r in captured] == [1000.0]
+
+
+def test_sell_without_quantity_closes_available_position() -> None:
+    """卖出不传 quantity 时全平**可用**持仓(T+1 冻结部分不报单)."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(execution=_Execution(available=400.0))
+    _submitter(strategy, captured).submit_order(
+        symbol="600000.SH", side="Sell", price=10.0
+    )
+    assert [r.quantity for r in captured] == [400.0]
+
+
+def test_sell_without_position_places_nothing() -> None:
+    """无可用持仓时卖出返回空回执,不向柜台报单."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(execution=_Execution(available=0.0))
+    receipt = _submitter(strategy, captured).submit_order(
+        symbol="600000.SH", side="Sell"
+    )
+    assert captured == []
+    assert len(receipt) == 0
+    assert receipt.primary == ""
+
+
+def test_zero_quantity_places_nothing() -> None:
+    """quantity<=0 不报单(此前会把 0 手单发给柜台)."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(execution=_Execution())
+    receipt = _submitter(strategy, captured).submit_order(
+        symbol="600000.SH", side="Buy", quantity=0
+    )
+    assert captured == []
+    assert len(receipt) == 0
+
+
+def test_symbol_defaults_to_current_bar() -> None:
+    """缺省 symbol 取当前 bar(与回测 resolve_symbol 同口径)."""
+    captured: list[UnifiedOrderRequest] = []
+    strategy = _Strategy(
+        sizer=FixedSize(100),
+        execution=_Execution(cash=10_000.0),
+        current_bar=_Bar("000001.SZ"),
+    )
+    _submitter(strategy, captured).submit_order(side="Buy", price=10.0)
+    assert [r.symbol for r in captured] == ["000001.SZ"]
+
+
+def test_sizer_returning_none_reports_clearly() -> None:
+    """自定义 sizer 漏 return 时报错点明原因,而非 NoneType 比较崩溃."""
+
+    class _BadSizer:
+        def get_size(self, *_a: Any, **_k: Any) -> Any:
+            return None
+
+    strategy = _Strategy(sizer=_BadSizer(), execution=_Execution(cash=1.0))
+    with pytest.raises(RuntimeError, match="get_size"):
+        _submitter(strategy, []).submit_order(
+            symbol="600000.SH", side="Buy", price=10.0
+        )
+
+
+def test_buy_without_sizer_reports_clearly() -> None:
+    """未配置 sizer 且不传 quantity 时报错点明原因."""
+    strategy = _Strategy(sizer=None, execution=_Execution(cash=1.0))
+    with pytest.raises(RuntimeError, match="sizer"):
+        _submitter(strategy, []).submit_order(
+            symbol="600000.SH", side="Buy", price=10.0
+        )
+
+
+def test_short_sell_rejected_when_capability_denies() -> None:
+    """capability.supports_short_sell=False 时本地拦截卖空,不打到柜台."""
+    captured: list[UnifiedOrderRequest] = []
+    cap = BrokerCapability(
+        broker_name="middleware",
+        position_effect=True,
+        supports_short_sell=False,
+        supported_position_effects=("auto", "open", "close"),
+    )
+    strategy = _Strategy(execution=_Execution(available=0.0))
+    with pytest.raises(RuntimeError, match="short sell"):
+        _submitter(strategy, captured, capability=cap).submit_order(
+            symbol="600000.SH",
+            side="Sell",
+            quantity=100,
+            position_effect="open",
+        )
+    assert captured == []
+
+
+def test_short_sell_allowed_when_capability_declares() -> None:
+    """声明 supports_short_sell=True 的 broker(如 CTP)不受拦截影响."""
+    captured: list[UnifiedOrderRequest] = []
+    cap = BrokerCapability(
+        broker_name="ctp",
+        position_effect=True,
+        supports_short_sell=True,
+        supported_position_effects=("auto", "open", "close"),
+    )
+    strategy = _Strategy(execution=_Execution())
+    _submitter(strategy, captured, capability=cap).submit_order(
+        symbol="IF2601", side="Sell", quantity=2, position_effect="open"
+    )
+    assert [r.quantity for r in captured] == [2.0]

--- a/tests/test_live_runner_client_order_id.py
+++ b/tests/test_live_runner_client_order_id.py
@@ -1,0 +1,69 @@
+"""client_order_id 生成: 会话内递增 + 跨重启/跨进程唯一(旧格式重启撞号 → 409)."""
+
+import threading
+import uuid
+
+from akquant.live._runner import LiveRunner
+
+
+def _runner(broker: str = "middleware") -> LiveRunner:
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.broker = broker
+    runner._broker_submit_seq = 0
+    runner._broker_session_tag = uuid.uuid4().hex[:8]
+    runner._broker_submit_lock = threading.Lock()
+    return runner
+
+
+def test_ids_increment_within_session() -> None:
+    """同一会话内序号递增且带 broker 前缀."""
+    runner = _runner()
+    ids = [runner._next_client_order_id() for _ in range(3)]
+    assert [i.split("-")[-1] for i in ids] == ["1", "2", "3"]
+    assert all(i.startswith("middleware-") for i in ids)
+    assert len(set(ids)) == 3
+
+
+def test_ids_differ_across_sessions() -> None:
+    """两个 runner(等价于重启)的首个 id 不再相同——旧格式此处必然撞号."""
+    first = _runner()._next_client_order_id()
+    second = _runner()._next_client_order_id()
+    assert first != second
+    assert first.endswith("-1") and second.endswith("-1")
+
+
+def test_session_tag_shared_by_all_ids_of_one_session() -> None:
+    """同一会话所有 id 共享会话标记,便于按会话检索."""
+    runner = _runner()
+    ids = [runner._next_client_order_id() for _ in range(4)]
+    tags = {i.rsplit("-", 1)[0] for i in ids}
+    assert len(tags) == 1
+
+
+def test_concurrent_generation_is_unique() -> None:
+    """并发生成不重号(锁覆盖序号自增)."""
+    runner = _runner()
+    ids: list[str] = []
+    lock = threading.Lock()
+
+    def _worker() -> None:
+        local = [runner._next_client_order_id() for _ in range(50)]
+        with lock:
+            ids.extend(local)
+
+    threads = [threading.Thread(target=_worker) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(ids) == 200
+    assert len(set(ids)) == 200
+
+
+def test_missing_session_tag_falls_back() -> None:
+    """绕过 __init__ 未设标记时退化为固定串,不抛 AttributeError."""
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.broker = "ctp"
+    runner._broker_submit_seq = 0
+    runner._broker_submit_lock = threading.Lock()
+    assert runner._next_client_order_id() == "ctp-nosess-1"

--- a/tests/test_live_runner_instrument_snapshots.py
+++ b/tests/test_live_runner_instrument_snapshots.py
@@ -1,0 +1,98 @@
+"""live 下 instrument 快照灌入(此前实盘 get_instrument 对任何 symbol 都 KeyError)."""
+
+from typing import Any, cast
+
+import pytest
+from akquant import AssetType, Instrument
+from akquant.live._runner import LiveRunner, _instruments_to_snapshots
+from akquant.strategy import Strategy
+
+
+class _DummyEngine:
+    def set_strategy_slots(self, slot_ids: list[str]) -> None:
+        self.slot_ids = slot_ids
+
+    def set_default_strategy_id(self, strategy_id: str) -> None:
+        self.default_strategy_id = strategy_id
+
+    def set_strategy_for_slot(self, slot_index: int, strategy: Any) -> None:
+        _ = (slot_index, strategy)
+
+
+class _DummyStrategy(Strategy):
+    def on_bar(self, bar: Any) -> None:
+        _ = bar
+
+
+def _runner(instruments: list[Instrument]) -> LiveRunner:
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.engine = cast(Any, _DummyEngine())
+    runner.context = {}
+    runner.instruments = instruments
+    return runner
+
+
+def test_maps_readable_instrument_fields() -> None:
+    """Instrument 的可读字段被映射进快照."""
+    snapshots = _instruments_to_snapshots(
+        [
+            Instrument(
+                "600000.SH",
+                AssetType.Stock,
+                multiplier=1.0,
+                margin_ratio=1.0,
+                tick_size=0.01,
+                lot_size=100.0,
+            )
+        ]
+    )
+    snap = snapshots["600000.SH"]
+    assert snap.symbol == "600000.SH"
+    assert snap.asset_type == "STOCK"
+    assert snap.tick_size == pytest.approx(0.01)
+    assert snap.lot_size == pytest.approx(100.0)
+
+
+def test_futures_asset_type_mapped() -> None:
+    """期货标的 asset_type 映射为 FUTURES."""
+    snapshots = _instruments_to_snapshots(
+        [Instrument("IF2601", AssetType.Futures, multiplier=300.0, margin_ratio=0.12)]
+    )
+    snap = snapshots["IF2601"]
+    assert snap.asset_type == "FUTURES"
+    assert snap.multiplier == pytest.approx(300.0)
+    assert snap.margin_ratio == pytest.approx(0.12)
+
+
+def test_empty_instruments_yields_empty_snapshots() -> None:
+    """空标的列表得到空快照(不抛错)."""
+    assert _instruments_to_snapshots([]) == {}
+
+
+def test_configure_slots_populates_strategy_snapshots() -> None:
+    """_configure_strategy_slots 给全部 slot 灌入快照, get_instrument 可用."""
+    instruments = [
+        Instrument("600000.SH", AssetType.Stock, tick_size=0.01, lot_size=100.0),
+        Instrument("000012.SZ", AssetType.Stock, tick_size=0.01, lot_size=100.0),
+    ]
+    runner = _runner(instruments)
+    primary = _DummyStrategy()
+    secondary = _DummyStrategy()
+    runner._configure_strategy_slots(primary, {"beta": secondary}, "alpha")
+
+    for target in (primary, secondary):
+        assert target.get_instrument("600000.SH").symbol == "600000.SH"
+        assert target.get_instrument("000012.SZ").symbol == "000012.SZ"
+        assert set(target.get_instruments()) == {"600000.SH", "000012.SZ"}
+        assert target.get_instrument_field("600000.SH", "lot_size") == pytest.approx(
+            100.0
+        )
+
+
+def test_unknown_symbol_still_raises() -> None:
+    """未配置的标的仍按回测同口径抛 KeyError(不静默返回默认值)."""
+    runner = _runner([Instrument("600000.SH", AssetType.Stock)])
+    strategy = _DummyStrategy()
+    runner._configure_strategy_slots(strategy, {}, "alpha")
+    with pytest.raises(KeyError):
+        strategy.get_instrument("999999.SH")


### PR DESCRIPTION
- 更新版本号至v0.3.22
- 修复client_order_id跨重启和多进程场景的撞号问题
- 让supports_short_sell配置真正生效，本地拦截不支持的卖空开单请求
- 补全实盘下buy/sell接口的缺省参数解析，对齐回测行为
- 修复实盘下get_instrument等接口抛KeyError的问题，灌入标的快照
- 更新中英文官方文档并新增对应测试用例