### PR TITLE
feat(live): 发布v0.3.26，完善实时交易经纪人就绪检查逻辑

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.25"
+version = "0.3.26"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/examples/39_live_broker_submit_order_demo.py
+++ b/examples/39_live_broker_submit_order_demo.py
@@ -110,6 +110,11 @@ def main() -> None:
         cash=1_000_000,
         show_progress=False,
         duration="30s",
+        # 本示例用占位柜台地址, 连不上真实柜台。默认 broker_ready_required=True
+        # 会在就绪超时后直接中止启动(实盘就该如此), 这里显式放宽以便离线演示——
+        # on_bar 里已用 ctx.broker_ready 守卫, 未就绪时不会下单。
+        # 真实部署请保留默认值 True。
+        broker_ready_required=False,
     )
 
 

--- a/examples/42_live_broker_event_audit_demo.py
+++ b/examples/42_live_broker_event_audit_demo.py
@@ -78,6 +78,10 @@ def main() -> None:
         cash=1_000_000,
         show_progress=False,
         duration="30s",
+        # 本示例用占位柜台地址, 连不上真实柜台。默认 broker_ready_required=True
+        # 会在就绪超时后直接中止启动(实盘就该如此), 这里显式放宽以便离线演示。
+        # 真实部署请保留默认值 True。
+        broker_ready_required=False,
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.25"
+version = "0.3.26"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/live/_facade.py
+++ b/python/akquant/live/_facade.py
@@ -51,8 +51,8 @@ def run_live(
     on_trade: Optional[Callable[[Any, Any], None]] = None,
     on_reject: Optional[Callable[[Any, Any], None]] = None,
     on_broker_connected: Optional[Callable[[Any], None]] = None,
-    broker_ready_timeout: float = 10.0,
-    broker_ready_required: bool = False,
+    broker_ready_timeout: float = 30.0,
+    broker_ready_required: bool = True,
     on_before_trading: Optional[Callable[[Any, Any, int], None]] = None,
     on_after_trading: Optional[Callable[[Any, Any, int], None]] = None,
     on_cross_section: Optional[Callable[[Any, Any, int], None]] = None,
@@ -83,6 +83,12 @@ def run_live(
     :param cash: Initial cash (default 1,000,000).
     :param show_progress: Whether to show a progress bar.
     :param duration: Optional run duration (e.g. ``"1m"``, ``"30s"``).
+    :param broker_ready_timeout: Max seconds to poll ``trader_gateway.heartbeat()``
+        before giving up (default 30.0).
+    :param broker_ready_required: If True (default), abort the run when the broker
+        is not ready within ``broker_ready_timeout``. Only polled in
+        ``trading_mode='broker_live'``; paper runs are unaffected. Pass False to
+        restore the pre-0.3.25 behaviour of warning and continuing.
     :param indicator_recorder: Optional public :class:`IndicatorSink` to collect
         indicator points; defaults to a streaming sink when ``on_event`` is set.
     :param on_event: Optional stream event callback for realtime indicator flow.

--- a/python/akquant/live/_runner.py
+++ b/python/akquant/live/_runner.py
@@ -16,6 +16,7 @@ from ..gateway.order_submitter import (
     resolve_live_order_legs,
     validate_live_order_client_ids,
 )
+from ..gateway.trader_base import TraderGatewayBase
 from ..indicator_recording import IndicatorSink
 from ..log import build_log_extra, get_logger
 from ..strategy import InstrumentSnapshot, Strategy
@@ -185,8 +186,8 @@ class LiveRunner:
         on_trade: Optional[Callable[[Any, Any], None]] = None,
         on_reject: Optional[Callable[[Any, Any], None]] = None,
         on_broker_connected: Optional[Callable[[Any], None]] = None,
-        broker_ready_timeout: float = 10.0,
-        broker_ready_required: bool = False,
+        broker_ready_timeout: float = 30.0,
+        broker_ready_required: bool = True,
         on_before_trading: Optional[Callable[[Any, Any, int], None]] = None,
         on_after_trading: Optional[Callable[[Any, Any, int], None]] = None,
         on_cross_section: Optional[Callable[[Any, Any, int], None]] = None,
@@ -234,9 +235,16 @@ class LiveRunner:
         :param on_broker_connected: Optional callback fired once the broker
             trader gateway reports readiness (heartbeat) after connect+start.
         :param broker_ready_timeout: Max seconds to poll trader_gateway.heartbeat()
-            before giving up (default 10.0).
-        :param broker_ready_required: If True, raise when broker readiness is not
-            reached within broker_ready_timeout (default False, only warns).
+            before giving up (default 30.0, sized for a real broker login such as
+            QMF's dual-session login plus WS connect).
+        :param broker_ready_required: If True (default), raise when broker
+            readiness is not reached within broker_ready_timeout; pass False to
+            only warn. Readiness is only polled in ``trading_mode='broker_live'``,
+            so paper runs are unaffected. Defaulting to True is deliberate: while
+            not ready, every submit raises RuntimeError anyway (see
+            ``order_submitter``), so continuing to run buys no capability — it only
+            trades one easily-missed warning for a stream of hard-to-attribute
+            exceptions.
         :param on_before_trading: Optional function-style on_before_trading callback.
         :param on_after_trading: Optional function-style on_after_trading callback.
         :param on_cross_section:
@@ -835,7 +843,6 @@ class LiveRunner:
         self._client_to_strategy_ids: dict[str, str] = {}
         self._broker_to_strategy_ids: dict[str, str] = {}
         self._closed_broker_order_ids: set[str] = set()
-        self._broker_report_keys: set[str] = set()
         self._broker_dispatch_stop: threading.Event | None = None
         self._broker_dispatch_thread: threading.Thread | None = None
         self._broker_recovery_stop: threading.Event | None = None
@@ -946,8 +953,28 @@ class LiveRunner:
                 logger.exception("broker baseline sync_today_trades failed")
         self._broker_baseline_done = True
 
+    def _warn_if_heartbeat_not_overridden(self, trader_gateway: Any) -> None:
+        """Warn when a gateway inherits the always-true default heartbeat.
+
+        ``TraderGatewayBase.heartbeat`` returns True unconditionally, so a custom
+        broker that forgets to override it is always judged ready and
+        ``broker_ready_required`` silently has no effect on it — a failed login
+        would still be let through to order submission.
+        """
+        base_heartbeat = getattr(TraderGatewayBase, "heartbeat", None)
+        gateway_heartbeat = getattr(type(trader_gateway), "heartbeat", None)
+        if base_heartbeat is None or gateway_heartbeat is not base_heartbeat:
+            return
+        logger.warning(
+            "%s 未覆写 heartbeat(), 将始终判定为已就绪; broker_ready_required "
+            "对该 gateway 无效——请实现 heartbeat() 返回真实登录/连接状态",
+            type(trader_gateway).__name__,
+            extra=self._runner_log_extra(phase="gateway"),
+        )
+
     def _await_broker_ready(self, trader_gateway: Any, targets: list) -> None:
         """Poll heartbeat() until ready/timeout; set broker_ready, fire callback."""
+        self._warn_if_heartbeat_not_overridden(trader_gateway)
         deadline = time.monotonic() + float(self.broker_ready_timeout)
         ready = False
         while time.monotonic() < deadline:
@@ -970,6 +997,10 @@ class LiveRunner:
                 extra=self._runner_log_extra(phase="gateway"),
             )
             if self.broker_ready_required:
+                # dispatcher/recovery 线程已在 _bind_broker_callbacks 中启动, 而本次
+                # raise 发生在 run() 的 try 之外(finally 的清理不会执行)。此处不收尾,
+                # 一次失败的启动就会留下一个每秒轮询柜台的 recovery 线程。
+                self._stop_broker_dispatcher()
                 raise RuntimeError(
                     f"broker not ready within {self.broker_ready_timeout}s"
                 )
@@ -1144,13 +1175,6 @@ class LiveRunner:
             status = self._payload_field(payload, "status")
             if self._is_terminal_status(status):
                 self._close_order_mapping(client_order_id, broker_order_id)
-            report_key = (
-                f"{self._payload_field(payload, 'broker_order_id')}-"
-                f"{self._payload_field(payload, 'status')}-"
-                f"{self._payload_field(payload, 'timestamp_ns')}"
-            )
-            if report_key:
-                self._broker_report_keys.add(report_key)
         elif event_name == "account":
             self._broker_account_state = payload
 

--- a/tests/test_live_runner_broker_readiness.py
+++ b/tests/test_live_runner_broker_readiness.py
@@ -1,6 +1,12 @@
+import inspect
+import logging
+import threading
 import time
 from typing import Any, cast
 
+import pytest
+from akquant.gateway.trader_base import TraderGatewayBase
+from akquant.live import run_live
 from akquant.live._runner import LiveRunner
 
 
@@ -81,10 +87,77 @@ def test_broker_not_ready_on_heartbeat_timeout() -> None:
     assert fired == []
 
 
+def test_broker_ready_defaults_are_fail_fast() -> None:
+    """默认必须 fail-fast: broker 未就绪即中止启动, 且超时对真实柜台足够宽.
+
+    未就绪时 order_submitter 会对每次下单抛 RuntimeError, 继续运行没有任何
+    可用性——只会把一条易被淹没的 warning 换成一堆难归因的异常。
+    """
+    for func in (LiveRunner.__init__, run_live):
+        params = inspect.signature(func).parameters
+        assert params["broker_ready_required"].default is True, (
+            f"{func.__qualname__}: broker_ready_required 默认应为 True"
+        )
+        assert params["broker_ready_timeout"].default >= 30.0, (
+            f"{func.__qualname__}: 超时应足够真实柜台登录(QMF 双会话 + WS 建连)"
+        )
+
+
+def test_not_ready_raises_when_required() -> None:
+    """required=True 且心跳始终为 False → 抛 RuntimeError 中止启动."""
+    runner = _runner(broker_ready_timeout=0.3, broker_ready_required=True)
+    target = _Target()
+
+    with pytest.raises(RuntimeError, match="broker not ready"):
+        runner._await_broker_ready(_FakeTrader(hb=False), [target])
+
+    assert target.broker_ready is False
+
+
+def test_not_ready_stops_broker_threads_before_raising() -> None:
+    """中止启动前必须停掉 dispatcher/recovery 线程.
+
+    这两个线程在 _bind_broker_callbacks 里就已启动, 而 raise 发生在 run() 的
+    try 之外, finally 的清理不会执行。若不在此处收尾, 一次失败的启动会留下一个
+    每秒轮询柜台的 recovery 线程。
+    """
+    runner = _runner(broker_ready_timeout=0.3, broker_ready_required=True)
+    runner._start_broker_dispatcher(cast(Any, _Target()))
+    assert runner._broker_dispatch_thread is not None, "线程未启动, 测试前提不成立"
+
+    with pytest.raises(RuntimeError):
+        runner._await_broker_ready(_FakeTrader(hb=False), [_Target()])
+
+    assert runner._broker_dispatch_thread is None, "dispatcher 线程未被清理"
+    assert runner._broker_recovery_thread is None, "recovery 线程未被清理"
+
+
+def test_gateway_not_overriding_heartbeat_is_warned(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """未覆写 heartbeat() 的 gateway 会永远判定就绪, 必须告警.
+
+    TraderGatewayBase.heartbeat 默认 return True, 自定义 broker 若忘了覆写,
+    broker_ready_required 对其完全失效——登录失败照样放行到下单。
+    """
+
+    class _NoHeartbeatGateway(TraderGatewayBase):
+        """自定义 broker 的典型疏漏: 没覆写 heartbeat."""
+
+    runner = _runner(broker_ready_required=True)
+    target = _Target()
+
+    with caplog.at_level(logging.WARNING):
+        runner._await_broker_ready(cast(Any, _NoHeartbeatGateway()), [target])
+
+    assert target.broker_ready is True, "基类心跳恒真, 应判定就绪"
+    assert any("heartbeat" in record.getMessage() for record in caplog.records), (
+        "未覆写 heartbeat 的 gateway 应产生告警"
+    )
+
+
 def test_blocking_connect_does_not_block_main_thread() -> None:
     """A blocking connect() (CTP-shaped) runs on the thread, not the caller."""
-    import threading
-
     started = threading.Event()
 
     class _BlockingTrader:


### PR DESCRIPTION
- 调整run_live默认参数：broker_ready_required默认为True（就绪失败则中止启动），broker_ready_timeout设为30秒适配真实柜台登录
- 为未覆写heartbeat()的自定义交易网关添加告警，避免静默失效
- 修复经纪人未就绪时的线程资源泄漏问题
- 清理未使用的经纪人报告键缓存代码
- 更新两个实时交易示例，添加离线演示所需的参数调整注释
- 新增针对经纪人就绪检查的完整单元测试