### PR TITLE
feat: 新增实盘模式警告并升级版本至0.3.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 教材第 5 章与教材目录页现已同步补充完整 `on_xxx` 回调地图、学习路径与相关示例入口，便于用户从教材直接理解各类回调的职责边界，并新增 `on_pre_open` 的推荐用法。
 - 示例体系已补充 `examples/50_framework_hooks_demo.py` 与 `examples/51_class_tick_callbacks_demo.py`，分别覆盖框架边界钩子与类风格 `on_tick` 的最小可运行案例。
 - 示例体系新增 `examples/52_pre_open_demo.py`，用于演示 `on_pre_open -> on_order/on_trade -> on_bar` 的触发顺序与当日 open 成交语义。
+- **策略 API 批量改名与硬删（破坏性，不保留兼容别名）**：0.3.x 期间对 `Strategy` 公开面做了一轮收敛，以下旧名**已从 `Strategy` 移除**，旧调用会直接 `AttributeError`。此前这些变更未记入本文件，特此补齐——从 0.2.x / 0.3.早期升级请按下表逐项迁移。
+
+    | 旧 API | 新 API | 迁移写法 |
+    | --- | --- | --- |
+    | `get_cash()` | `cash` 属性 | `self.get_cash()` → `self.cash` |
+    | `get_portfolio_value()` | `equity` 属性 | `self.get_portfolio_value()` → `self.equity` |
+    | `get_positions()` | `positions` 属性 | `self.get_positions()` → `self.positions` |
+    | `hold_bar(symbol)` | `get_holding_bars(symbol)` | 仅改名，签名不变 |
+    | `order_target_positions(...)` | `rebalance_positions(...)` | 仅改名，签名不变 |
+    | `order_target_weights(...)` | `rebalance_weights(...)` | 仅改名，签名不变 |
+    | `place_bracket_order(...)` | `place_bracket(...)` | 仅改名，签名不变 |
+    | `create_oco_order_group(a, b)` | `place_oco(a, b)` | 仅改名；新版两个入参同时接受订单 id 与 `OrderReceipt` |
+    | `register_indicator(name, ind)` | `register_precomputed_indicator(name, ind)` | 旧名本就是该方法的薄别名，去别名后请直接用全名 |
+    | `stop_buy(symbol, trigger_price, quantity, price)` | `submit_order(...)` | `submit_order(symbol=..., side="Buy", quantity=..., trigger_price=..., price=...)`；`price=None` 即触发后转市价 |
+    | `stop_sell(...)` | `submit_order(...)` | 同上，`side="Sell"` |
+    | `buy_all(symbol)` | `order_target_percent(...)` | `order_target_percent(symbol=..., target_percent=1.0)` |
+
+    注：`cash` / `equity` / `positions` 现为**只读属性**（`property`），不能再当方法调用——`self.cash()` 会抛 `TypeError`。执行后端（`strategy.execution`）层的同名方法未改动，自定义 broker 无需跟随调整。
+- **回测成交策略从 dict 收敛为 `FillMode` 对象（破坏性）**：`fill_policy` 不再接受 dict，`make_fill_policy()` 已移除（保留为抛 `TypeError` 的报错壳，错误信息内嵌完整迁移映射）；引擎侧 `set_fill_policy(price_basis, bar_offset, temporal)` 重塑为 `set_fill_mode(mode: ExecutionMode, timer_timing: str)`，非法的 `(basis, offset)` 组合在枚举层已不可表达。`get_fill_policy()` 保留不变（checkpoint 反查依赖）。**迁移映射**：
+
+    | 旧 dict | 新 `FillMode` |
+    | --- | --- |
+    | `{"price_basis": "open"}` | `NextOpen()` |
+    | `{"price_basis": "close", "bar_offset": 0}` | `CurrentClose()` |
+    | `{"price_basis": "close", "bar_offset": 0, "temporal": "next_event"}` | `CurrentClose(timer_fill_timing="deferred")` |
+    | `{"price_basis": "close", "bar_offset": 1}` | `NextClose()` |
+    | `{"price_basis": "ohlc4"}` | `NextAverage()` |
+    | `{"price_basis": "hl2"}` | `NextHighLowMid()` |
+- **`LiveRunner` 从公开 API 移除（破坏性）**：实盘入口统一为 `run_live(...)` 函数门面，与 `run_backtest` 对称。`from akquant import LiveRunner` 会 `ImportError`；原先 `LiveRunner(...).run(cash=..., duration=...)` 的两步用法改为单次 `run_live(..., cash=..., duration=...)` 调用，配置参数一一对应。
+- **`add_daily_timer` 已移除，更名为 `schedule_daily`（破坏性，不保留兼容别名）**：定时器注册端统一为 `schedule` / `schedule_daily` / `schedule_weekly` / `schedule_monthly` 家族（回调端 `on_timer` 不变）。升级后旧调用会直接 `AttributeError`。**迁移**：`self.add_daily_timer("14:55:00", "rebalance")` 改为 `self.schedule_daily("14:55:00", "rebalance")`，参数与触发语义完全一致。注意 `schedule_weekly` / `schedule_monthly` 依赖回测交易日历（`_trading_days`），在**实盘**下会记录一条 warning 并被忽略；实盘的周期性任务请用 `schedule_daily` 配合回调内的日历判断。详见 `docs/zh/meta/timer-api-rfc.md`。
+- **实盘 `subscribe()` 不再静默无效**：`Strategy.subscribe()` 只把标的写入 `_subscriptions`，而该列表**仅**被回测消费——实盘（`run_live`）的订阅集在会话启动时由 `instruments` 一次性交给行情网关，此后调用 `subscribe()` 不会触达任何网关。此前这一调用完全无声，用户以为订阅成功却收不到行情。现在实盘下调用 `subscribe()` 会记录一条 warning，指明应把该标的加入 `run_live(instruments=[...])`（每个标的只告警一次）。行为本身未变（仍会记录进 `_subscriptions`），回测语义完全不受影响。
 - **`supports_short_sell` 在 `broker_live` 下开始真正生效**：该字段此前在实盘下单路径上没有任何消费者（仅服务 `order_target*` 的目标仓位计算），broker 声明了 `False` 也照样把开空单发给柜台，只能等柜台报错。现在 `side=Sell` + `position_effect=open` 会在下单前被本地拒绝。内置 CTP 声明 `True`，不受影响；`ptrade` / `miniqmt` 只声明支持 `auto`，其显式 `open` 早已被 `supported_position_effects` 拦截，行为不变。若自定义 broker 实际支持融券却被拦，请修正其 `get_capabilities()` 中的 `supports_short_sell` 声明。
 
 ### Fixed
@@ -35,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 修复 `on_after_trading` 里下 next-open（`bar_offset=1`）单晚一格成交的问题（#324）。它原先在「下一根 bar」到来时才惰性补触发，引擎时钟已越过日界，其中提交的 next-open 单被撮合守卫推迟一格（盘后下单期望次日开盘成交，实际到第三日）。现改为按日终边界定时器在「当日收盘点」的独立事件里触发（早于下一根 bar），使其中提交的次日开盘单落在下一根 bar，而非晚一格。默认（非 precise）与 precise 模式下均已修正；`on_before_trading` 等开始型钩子本就与 `on_bar` 同拍触发，不受影响。`__engine_rule_version__` 相应升至 `1.3.1`。
 - 修复 `on_pre_open` 未兑现「本次 open 成交」契约的问题（#324 家族）。其盘前定时器原先排在当日首根 bar 的同一时刻，订单 `created_at` 与该 bar 同拍、被 next-open 守卫拦截，导致实际成交在**下一日 open**（可由 `examples/52_pre_open_demo.py` 复现）。现将盘前定时器排在首根 bar 之前 1ns，使 `on_pre_open` 中下的默认开盘单落在**当日 open**，与文档承诺一致。
 - 修复短回测区间下 Sharpe/Sortino 因「分子用 CAGR、分母用日波动 × √252」口径不一致而出现异常巨大值（如期货场景 Sharpe 高达数千万）的问题；改用日收益算术均值年化后数值回归合理量级。
-- 修复 `on_timer` / `add_daily_timer` 场景下，订单级 `fill_policy={"price_basis":"close","bar_offset":0,"temporal":"same_cycle"}` 未在当日 timer 事件内生效的问题；相关卖单现在会按当日 timer 时间与当日 close 成交，不再延后到下一交易日。
+- 修复 `on_timer` / `schedule_daily`（原 `add_daily_timer`）场景下，订单级 `fill_policy={"price_basis":"close","bar_offset":0,"temporal":"same_cycle"}` 未在当日 timer 事件内生效的问题；相关卖单现在会按当日 timer 时间与当日 close 成交，不再延后到下一交易日。
 - 修复 framework 内部 `__framework_rebalance__` / `__framework_boundary__` timer 被误参与 same-cycle 撮合与终态统计的问题，避免出现 `+1ns` 的伪成交、partial fill 被过早补满，以及权益曲线尾部多出额外采样点。
 - 修复 `on_pre_open` 首个交易日可能因延迟注册 timer 而不触发的问题；相关 framework timer 现会在回测事件循环开始前直接注入引擎，从而保证首日也能按预期开盘语义执行。
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.26"
+version = "0.3.27"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.26"
+version = "0.3.27"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/live/_runner.py
+++ b/python/akquant/live/_runner.py
@@ -548,6 +548,11 @@ class LiveRunner:
         default_ready = getattr(self, "trading_mode", "paper") != "broker_live"
         for target in [strategy_instance, *slot_strategy_instances.values()]:
             setattr(target, "broker_ready", default_ready)
+            # 标记实盘: 让 Strategy.subscribe() 能告知用户它在实盘不生效
+            # (实盘订阅集来自 run_live(instruments=...))。
+            mark_live = getattr(target, "_set_live_market_data_owner", None)
+            if callable(mark_live):
+                mark_live()
 
         strategy_targets = [strategy_instance, *slot_strategy_instances.values()]
         # getattr 兜底与同方法内 trading_mode 一致: 允许绕过 __init__ 的调用方。

--- a/python/akquant/strategy.py
+++ b/python/akquant/strategy.py
@@ -31,6 +31,7 @@ from .akquant import (
 )
 from .gateway.order_receipt import OrderReceipt
 from .indicator_recording import IndicatorRecorder
+from .log import get_logger as _get_logger
 from .params import ParamModel, ParamSpec
 from .sizer import FixedSize, Sizer
 from .strategy_events import (
@@ -178,6 +179,9 @@ if TYPE_CHECKING:
     from .backtest.fill_mode import FillMode
     from .indicator import Indicator
     from .ml.model import QuantModel
+
+# 实盘 subscribe() 告警用: 与 strategy_logging 的 "strategy" 通道同源。
+_live_subscribe_logger = _get_logger("strategy")
 
 
 @dataclass
@@ -328,6 +332,8 @@ class Strategy:
     _precomputed_indicators: List["Indicator"]
     _incremental_indicators: Dict[str, IncrementalIndicatorRegistration]
     _subscriptions: List[str]
+    _live_market_data_owner: bool
+    _warned_live_subscriptions: set[str]
     _last_prices: Dict[str, float]
     _rolling_train_window: int
     _rolling_step: int
@@ -467,6 +473,11 @@ class Strategy:
         instance._precomputed_indicators = []
         instance._incremental_indicators = {}
         instance._subscriptions = []
+        # 实盘标记: LiveRunner 在 _configure_strategy_slots 里置位。subscribe()
+        # 据此告警——实盘订阅集来自 run_live(instruments=[...]), _subscriptions
+        # 仅被回测消费。
+        instance._live_market_data_owner = False
+        instance._warned_live_subscriptions = set()
         instance._last_prices = {}
         instance._known_orders = {}
         instance._finalized_orders = {}
@@ -748,6 +759,10 @@ class Strategy:
             self._pending_canceled_order_ids = set()
         if not hasattr(self, "_pending_canceled_order_id_queue"):
             self._pending_canceled_order_id_queue = deque()
+        if not hasattr(self, "_live_market_data_owner"):
+            self._live_market_data_owner = False
+        if not hasattr(self, "_warned_live_subscriptions"):
+            self._warned_live_subscriptions = set()
         if not hasattr(self, "_oco_groups"):
             self._oco_groups = {}
         if not hasattr(self, "_oco_order_to_group"):
@@ -1417,12 +1432,36 @@ class Strategy:
         )
         setattr(self, name, IncrementalIndicatorBinding(self, name))
 
+    def _set_live_market_data_owner(self) -> None:
+        """标记本策略运行于实盘(行情订阅集由 run_live 的 instruments 决定).
+
+        由 :class:`~akquant.live._runner.LiveRunner` 在装配阶段调用。
+        """
+        self._live_market_data_owner = True
+
     def subscribe(self, instrument_id: str) -> None:
         """
         Subscribe to market data for an instrument.
 
+        仅在**回测**生效: ``run_backtest`` 会把 ``_subscriptions`` 并入标的集合。
+        实盘(``run_live``)的订阅集在会话启动时由 ``instruments`` 一次性传给行情
+        网关, 此处调用不会触达任何网关, 因此会记录一条 warning。
+
         :param instrument_id: The instrument identifier (e.g., '600000').
         """
+        if getattr(self, "_live_market_data_owner", False):
+            warned = getattr(self, "_warned_live_subscriptions", None)
+            if warned is None:
+                warned = set()
+                self._warned_live_subscriptions = warned
+            # 逐 symbol 只告警一次: 用户可能在 on_bar 里按条件 subscribe。
+            if instrument_id not in warned:
+                warned.add(instrument_id)
+                _live_subscribe_logger.warning(
+                    "实盘下 subscribe(%r) 不会订阅行情: 实盘订阅集来自 "
+                    "run_live(instruments=[...]), 请把该标的加入 instruments",
+                    instrument_id,
+                )
         if instrument_id not in self._subscriptions:
             self._subscriptions.append(instrument_id)
 

--- a/python/akquant/strategy_framework_hooks.py
+++ b/python/akquant/strategy_framework_hooks.py
@@ -3,6 +3,9 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 import pandas as pd
 
 from .akquant import TradingSession
+from .log import get_logger
+
+logger = get_logger("strategy")
 
 _RUNTIME_DEFAULTS = {
     "enable_precise_day_boundary_hooks": False,
@@ -467,6 +470,17 @@ def register_pre_open_timers(strategy: Any) -> None:
 
     entries = collect_pre_open_timer_entries(strategy)
     if not entries:
+        # 实盘: pre-open 定时器依赖逐交易日的 _trading_day_bounds, 而该字段只由
+        # 回测引擎填充, 实盘恒为空 ⇒ on_pre_open 永不触发。此处必须告警并停止
+        # 重试: 否则每根 bar/tick 都会重跑一次注册并再次失败(既无声又白做功)。
+        # 回测下 bounds 可能只是"还没填", 保持原样按 bar 重试(不告警, 避免误报)。
+        if getattr(strategy, "_live_market_data_owner", False):
+            logger.warning(
+                "实盘下 on_pre_open 不会触发: 该回调依赖回测交易日历推导的盘前"
+                "时点, 实盘无此数据源。请改用 schedule_daily(...) 在盘前时点"
+                "触发 on_timer, 或把盘前逻辑放到 on_before_trading 中"
+            )
+            strategy._framework_pre_open_timers_registered = True
         return
 
     current_time = int(getattr(strategy.ctx, "current_time", 0))

--- a/tests/test_pre_open_live_warns.py
+++ b/tests/test_pre_open_live_warns.py
@@ -1,0 +1,152 @@
+"""实盘下 on_pre_open 不触发, 必须告警而非静默.
+
+``on_pre_open`` 的框架定时器由 ``collect_pre_open_timer_entries`` 依据
+``_trading_day_bounds`` 逐交易日生成, 而该字段**只在** ``backtest/engine.py``
+填充; 实盘走 ``Engine()`` + ``DataFeed.create_live()``, 它恒为空 dict, 于是
+collect 返回空列表、timer 一个都不注册, ``on_pre_open`` 永不触发。
+
+更糟的是 ``register_pre_open_timers`` 在 entries 为空时**不**置
+``_framework_pre_open_timers_registered``, 因此实盘每根 bar/tick 都会重试一遍
+并再次失败——既无声, 也白做功。
+"""
+
+import logging
+from typing import Any, Dict, List, Tuple
+
+import pytest
+from akquant import Strategy
+from akquant.akquant import Bar
+from akquant.strategy_framework_hooks import register_pre_open_timers
+
+
+class _PreOpen(Strategy):
+    """重写 on_pre_open 的策略."""
+
+    def on_pre_open(self, event: Dict[str, Any]) -> None:
+        """盘前决策."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """不做任何事."""
+
+
+class _NoPreOpen(Strategy):
+    """未重写 on_pre_open 的策略."""
+
+    def on_bar(self, bar: Bar) -> None:
+        """不做任何事."""
+
+
+class _Ctx:
+    """最简上下文, 记录 schedule 调用."""
+
+    def __init__(self) -> None:
+        """初始化."""
+        self.current_time = 1_700_000_000_000_000_000
+        self.scheduled: List[Tuple[int, str]] = []
+
+    def schedule(self, timestamp: int, payload: str) -> None:
+        """记录被注册的 timer."""
+        self.scheduled.append((timestamp, payload))
+
+
+def _live_strategy() -> _PreOpen:
+    """构造一个处于实盘、且重写了 on_pre_open 的策略."""
+    strategy = _PreOpen()
+    strategy._set_live_market_data_owner()
+    strategy.ctx = _Ctx()  # type: ignore[assignment]
+    return strategy
+
+
+def test_pre_open_warns_in_live_mode(caplog: pytest.LogCaptureFixture) -> None:
+    """实盘 + 重写 on_pre_open + 无交易日边界 → 必须告警."""
+    strategy = _live_strategy()
+
+    with caplog.at_level(logging.WARNING):
+        register_pre_open_timers(strategy)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("on_pre_open" in message for message in messages), (
+        f"实盘 on_pre_open 不触发却未告警: {messages}"
+    )
+
+
+def test_pre_open_live_warning_states_it_will_not_fire(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """告警须说明该回调在实盘不会触发, 而不是只报一句内部状态."""
+    strategy = _live_strategy()
+
+    with caplog.at_level(logging.WARNING):
+        register_pre_open_timers(strategy)
+
+    text = " ".join(record.getMessage() for record in caplog.records)
+    assert "不会触发" in text or "不触发" in text, f"告警未说明后果: {text}"
+
+
+def test_pre_open_live_warns_only_once(caplog: pytest.LogCaptureFixture) -> None:
+    """register_pre_open_timers 每根 bar/tick 都会被调用, 不能逐 bar 刷屏."""
+    strategy = _live_strategy()
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(10):
+            register_pre_open_timers(strategy)
+
+    warnings = [r for r in caplog.records if "on_pre_open" in r.getMessage()]
+    assert len(warnings) == 1, f"应只告警一次, 实际 {len(warnings)} 次"
+
+
+def test_pre_open_live_stops_retrying() -> None:
+    """告警后应置 registered 标志, 停止每根 bar 的无效重试."""
+    strategy = _live_strategy()
+
+    register_pre_open_timers(strategy)
+
+    assert getattr(strategy, "_framework_pre_open_timers_registered", False) is True, (
+        "实盘下永远拿不到 bounds, 必须停止重试"
+    )
+
+
+def test_no_warning_when_pre_open_not_overridden(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """未重写 on_pre_open 的策略不受影响, 不应告警."""
+    strategy = _NoPreOpen()
+    strategy._set_live_market_data_owner()
+    strategy.ctx = _Ctx()  # type: ignore[assignment]
+
+    with caplog.at_level(logging.WARNING):
+        register_pre_open_timers(strategy)
+
+    assert not caplog.records, f"未重写 on_pre_open 不应告警: {caplog.records}"
+
+
+def test_no_warning_in_backtest(caplog: pytest.LogCaptureFixture) -> None:
+    """回测下 bounds 由引擎填充, 属正常路径, 不得告警.
+
+    此处模拟"引擎尚未填充 bounds"的早期时刻: 回测中它随后就会被填上,
+    告警会是误报。
+    """
+    strategy = _PreOpen()
+    strategy.ctx = _Ctx()  # type: ignore[assignment]
+
+    with caplog.at_level(logging.WARNING):
+        register_pre_open_timers(strategy)
+
+    assert not caplog.records, f"回测不应告警: {caplog.records}"
+
+
+def test_backtest_pre_open_timers_still_registered() -> None:
+    """回归: 有 bounds 时仍照常注册 timer."""
+    strategy = _PreOpen()
+    ctx = _Ctx()
+    strategy.ctx = ctx  # type: ignore[assignment]
+    day_start = ctx.current_time + 86_400_000_000_000
+    strategy._trading_day_bounds = {  # type: ignore[attr-defined]
+        "2023-11-15": (day_start, day_start + 3600_000_000_000)
+    }
+
+    register_pre_open_timers(strategy)
+
+    assert len(ctx.scheduled) == 1, f"回测 timer 未注册: {ctx.scheduled}"
+    assert ctx.scheduled[0][0] == day_start - 1, "pre-open timer 应排在首根 bar 前 1ns"
+    assert ctx.scheduled[0][1].startswith("__framework_pre_open__|")

--- a/tests/test_subscribe_live_warns.py
+++ b/tests/test_subscribe_live_warns.py
@@ -1,0 +1,112 @@
+"""实盘下 subscribe() 无效, 必须告警而非静默.
+
+``Strategy.subscribe()`` 只把 symbol 追加进 ``_subscriptions``, 而该列表**仅**被
+``backtest/engine.py`` 消费; ``LiveRunner`` 从不读它——实盘订阅集完全来自
+``run_live(instruments=[...])``。于是用户在 ``on_start`` 里 subscribe 一个未列入
+instruments 的标的时, 既订不到行情也收不到任何提示。
+"""
+
+import logging
+from typing import Any, cast
+
+import pytest
+from akquant import Strategy
+from akquant.akquant import Bar
+from akquant.live._runner import LiveRunner
+
+
+class _Sub(Strategy):
+    """在 on_start 里订阅的最简策略."""
+
+    def on_start(self) -> None:
+        """订阅一个标的."""
+        self.subscribe("600000")
+
+    def on_bar(self, bar: Bar) -> None:
+        """不做任何事."""
+
+
+class _StubEngine:
+    """吸收 _configure_strategy_slots 对引擎的可选 set_* 调用."""
+
+    def __getattr__(self, name: str) -> Any:
+        """任何属性都返回一个接受任意入参的空函数."""
+
+        def _accept(*args: Any, **kwargs: Any) -> None:
+            return None
+
+        return _accept
+
+
+def test_subscribe_warns_in_live_mode(caplog: pytest.LogCaptureFixture) -> None:
+    """实盘标记存在时, subscribe() 应告警并指向 run_live(instruments=...)."""
+    strategy = _Sub()
+    strategy._set_live_market_data_owner()
+
+    with caplog.at_level(logging.WARNING):
+        strategy.subscribe("600000")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("subscribe" in message for message in messages), (
+        f"实盘 subscribe() 未告警: {messages}"
+    )
+    assert any("instruments" in message for message in messages), (
+        f"告警未指向 run_live(instruments=...): {messages}"
+    )
+
+
+def test_subscribe_silent_in_backtest(caplog: pytest.LogCaptureFixture) -> None:
+    """回测下 subscribe() 是正当用法, 不得产生任何告警."""
+    strategy = _Sub()
+
+    with caplog.at_level(logging.WARNING):
+        strategy.subscribe("600000")
+
+    assert not caplog.records, f"回测 subscribe() 不应告警: {caplog.records}"
+    assert strategy._subscriptions == ["600000"], "回测语义必须保持不变"
+
+
+def test_subscribe_still_records_symbol_in_live_mode() -> None:
+    """告警不改变行为: 仍记录 symbol, 以免破坏读取 _subscriptions 的用户代码."""
+    strategy = _Sub()
+    strategy._set_live_market_data_owner()
+
+    strategy.subscribe("600000")
+
+    assert strategy._subscriptions == ["600000"]
+
+
+def test_subscribe_warns_once_per_symbol(caplog: pytest.LogCaptureFixture) -> None:
+    """同一 symbol 重复 subscribe 只告警一次, 避免刷屏.
+
+    用户可能在 on_bar 里按条件 subscribe, 逐 bar 告警会淹没日志。
+    """
+    strategy = _Sub()
+    strategy._set_live_market_data_owner()
+
+    with caplog.at_level(logging.WARNING):
+        for _ in range(5):
+            strategy.subscribe("600000")
+
+    warnings = [r for r in caplog.records if "subscribe" in r.getMessage()]
+    assert len(warnings) == 1, f"应只告警一次, 实际 {len(warnings)} 次"
+
+
+def test_live_runner_marks_strategies_as_live() -> None:
+    """LiveRunner 必须给主策略与各 slot 都打上实盘标记.
+
+    否则 subscribe() 无从判断自己处于实盘。
+    """
+    runner = LiveRunner.__new__(LiveRunner)
+    runner.trading_mode = "paper"
+    # 测试替身: 这两个属性在 LiveRunner 上有具体类型注解, 此处只需装配阶段够用。
+    runner.context = cast(Any, None)
+    runner.instruments = []
+    runner.engine = cast(Any, _StubEngine())
+
+    primary = _Sub()
+    slot = _Sub()
+    runner._configure_strategy_slots(primary, {"beta": slot}, "alpha")
+
+    for target in (primary, slot):
+        assert getattr(target, "_live_market_data_owner", False) is True


### PR DESCRIPTION
为实盘模式下调用 `Strategy.subscribe()` 添加告警，提示用户应通过 `run_live(instruments=[...])` 指定订阅标的，每个标的仅告警一次 为实盘模式下使用 `on_pre_open` 回调添加告警，说明该回调在实盘不会触发并给出替代方案
新增完整测试用例覆盖上述告警场景与回测/实盘的原有行为保障
更新 CHANGELOG.md 记录本次版本的所有变更
同步更新 Cargo.toml 与 pyproject.toml 中的包版本号