### PR TITLE
fix: report final open position count

### DIFF
--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -415,29 +415,16 @@ class BacktestResult:
             pass
 
         try:
+            # positions_df only retains snapshots for symbols that were held. Its
+            # latest date can therefore precede the backtest end after all assets
+            # have been sold. Use the final portfolio snapshot, which includes
+            # zero quantities, to determine the actual ending positions.
             open_position_count = 0.0
-            pos_df = self.positions_df
-            if not pos_df.empty and "date" in pos_df.columns:
-                latest_date = pos_df["date"].max()
-                latest_positions = pos_df[pos_df["date"] == latest_date].copy()
-                if "quantity" in latest_positions.columns:
-                    quantity = pd.to_numeric(
-                        latest_positions["quantity"], errors="coerce"
-                    ).fillna(0.0)
-                    open_position_count = float(quantity.ne(0.0).sum())
-                elif {
-                    "long_shares",
-                    "short_shares",
-                }.issubset(latest_positions.columns):
-                    long_shares = pd.to_numeric(
-                        latest_positions["long_shares"], errors="coerce"
-                    ).fillna(0.0)
-                    short_shares = pd.to_numeric(
-                        latest_positions["short_shares"], errors="coerce"
-                    ).fillna(0.0)
-                    open_position_count = float(
-                        (long_shares.ne(0.0) | short_shares.ne(0.0)).sum()
-                    )
+            positions = self.positions
+            if not positions.empty:
+                final_positions = positions.iloc[-1]
+                quantities = pd.to_numeric(final_positions, errors="coerce").fillna(0.0)
+                open_position_count = float(quantities.ne(0.0).sum())
             df.loc["open_position_count", "value"] = open_position_count
         except Exception:
             pass

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1832,6 +1832,9 @@ def test_backtest_regression_baseline() -> None:
         assert val == pytest.approx(exp_val, rel=1e-9)
 
     assert len(result.trades) == 1
+    assert float(result.metrics_df.loc["open_position_count", "value"]) == (
+        pytest.approx(0.0)
+    )
     trade = result.trades[0]
     assert trade.symbol == symbol
     assert trade.entry_time == day1


### PR DESCRIPTION
# 修复回测报告未平仓标的数误报

## 问题

回测结束后组合已经全部清仓，但 `backtest_report.html` 仍显示“未平仓标的数”为 `1`。

## 原因

`BacktestResult.metrics_df` 通过 `positions_df` 的最大日期计算未平仓标的数。

`positions_df` 只保留有持仓标的的明细；当所有标的都已卖出时，其最大日期会停留在最后一次持仓快照，而不是回测结束日。因此会把历史持仓误认为回测结束时的持仓。

## 修改

在 `python/akquant/backtest/result.py` 中，改为读取 `self.positions` 的最后一个组合快照：

- 该快照包含全部标的，并保留数量为 `0` 的列；
- 对最终快照中的数量进行数值转换；
- 仅统计数量不为 `0` 的标的。

```python
positions = self.positions
if not positions.empty:
    final_positions = positions.iloc[-1]
    quantities = pd.to_numeric(final_positions, errors="coerce").fillna(0.0)
    open_position_count = float(quantities.ne(0.0).sum())
```

## 测试

```bash
pytest -q
# 1416 passed
```

新增回归断言：最后一个 bar 已清仓时，`metrics_df["open_position_count"]` 必须为 `0`。
