### PR TITLE
refactor(gateway, docs): 完善混合broker功能并发布v0.3.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     没有行情网关的 broker（`market_gateway=None`）不装转发器，`subscribe()` 退回记录 warning（措辞已更新为「该 broker 未提供行情网关」），因为那类 broker 确实无处可下发。回测语义完全不变。
 
-- **行情源与交易源可分开指定**：`create_gateway_bundle` 与 `run_live` 新增 `market_broker` / `trader_broker` 两个可选参数。`broker` 是两侧的**默认源**，`market_broker` 只覆盖行情源、`trader_broker` 只覆盖交易源；两者都不传时行为与单 broker 完全一致。
+- **行情源与交易源可分开指定**：`create_gateway_bundle` 与 `run_live` 新增 `market_broker` / `trader_broker` 两个可选参数。两种模式二选一——只传 `broker` 时由它同时提供两侧（原语义不变）；同时传 `market_broker` 与 `trader_broker` 时各供一侧，**`broker` 完全不参与构建**。只传其中一个会报错，要求把另一侧也写明：若让 `broker` 兼任缺失的那侧，它就一词双义了（读 `broker='qmf', market_broker='replay'` 必须先知道「qmf 只有交易通道」才能推出 `broker` 在此指交易源）。
 
-    这补齐了两类「单边 broker」的组合——`GatewayBundle` 的 `market_gateway` / `trader_gateway` 本就是两个独立可选字段，`replay` 只有行情（不能下单），而某些券商/柜台插件只有交易通道（收不到任何行情、`current_tick` 恒为 `None`），此前二者无法拼接。下面两种写法等价：
+    这补齐了两类「单边 broker」的组合——`GatewayBundle` 的 `market_gateway` / `trader_gateway` 本就是两个独立可选字段，`replay` 只有行情（不能下单），而某些券商/柜台插件只有交易通道（收不到任何行情、`current_tick` 恒为 `None`），此前二者无法拼接：
 
     ```python
-    run_live(..., broker="my_trade_only_broker", market_broker="replay")
-    run_live(..., broker="replay", trader_broker="my_trade_only_broker")
+    run_live(..., market_broker="replay", trader_broker="my_trade_only_broker")
     ```
 
-    要点：`gateway_options` 同时传给两个 builder；覆盖项与 `broker` 同名时视为未覆盖、不重复构建（builder 可能连柜台、起线程）；`metadata` 记录 `market_broker` / `trader_broker` 便于排障，且行情侧声明的会话级信息（如 `replay` 的 `bounded_event_total`，`LiveRunner` 据此在事件放完后结束会话）不会因混搭而丢失；未注册的名字会报错并点名具体参数，而非静默缺失某一侧通道。副产品是「回放行情 + 真实柜台下单」的联调组合现在可行。
+    要点：`gateway_options` 同时传给两个 builder；两侧同名时只构建一次（builder 可能连柜台、起线程）；`metadata` 记录 `market_broker` / `trader_broker` 便于排障，且行情侧声明的会话级信息（如 `replay` 的 `bounded_event_total`，`LiveRunner` 据此在事件放完后结束会话）不会因分开指定而丢失；未注册的名字会报错并点名具体参数，而非静默缺失某一侧通道。副产品是「回放行情 + 真实柜台下单」的联调组合现在可行。
+
+    另外，`create_gateway_bundle` 的 `broker` 参数由必填改为可选（分开指定时无需传）。所有既有调用点都以关键字传参，不受影响。
 
 - `get_account()` 账户快照新增 `free_margin` 字段（= `equity - used_margin`），表示真正可用于新开仓的可用保证金，与下单因保证金不足被拒时日志里的 `Available` 口径一致；期货保证金账户下 `cash`（现金余额）通常大于 `free_margin`，股票现金账户下二者相等。同时修正了 `cash` 在文档与 docstring 中「可用资金」的误导性表述，明确其为「现金余额」。
 - `BacktestConfig` 新增 `days_per_year`（年化天数因子，默认 252；数字货币 24/7 市场可设 365）与 `risk_free_rate`（年化无风险利率，默认 0.0）两个字段，用于参数化 Sharpe/Sortino/波动率等风险指标的年化口径。`risk_free_rate` 默认 0 不改变任何现有数值。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.30"
+version = "0.3.31"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/zh/advanced/live_functional_quickstart.md
+++ b/docs/zh/advanced/live_functional_quickstart.md
@@ -159,28 +159,31 @@ run_live(
 
 这两类「单边 broker」可以拼起来用：
 
-- `broker`: 两侧的**默认源**。
-- `market_broker`: 只覆盖**行情**源。
-- `trader_broker`: 只覆盖**交易**源。
+两种模式，二选一：
+
+- **单 broker**：只传 `broker`，由它同时提供两侧（原语义，不变）。
+- **分开指定**：同时传 `market_broker` 与 `trader_broker`，各供一侧；此时 `broker`
+  完全不参与构建。
 
 ```python
 run_live(
     strategy_cls=MyStrategy,
     instruments=instruments,
-    broker="my_trade_only_broker",   # 交易源：只有交易通道的插件
-    market_broker="replay",          # 行情源：借用回放行情
+    market_broker="replay",               # 行情源：借用回放行情
+    trader_broker="my_trade_only_broker", # 交易源：只有交易通道的插件
     trading_mode="paper",
     gateway_options={"bars": bars},
 )
 ```
 
-等价的对称写法是 `broker="replay", trader_broker="my_trade_only_broker"`——两者描述
-的是同一件事。两侧都不传时行为与单 broker 完全一致。
+**只给一侧会报错**，要求把另一侧也写明。这是刻意的：若让 `broker` 兼任缺失的那侧，
+它就一词双义了——读 `broker='qmf', market_broker='replay'` 得先知道「qmf 只有交易
+通道」才能推出 `broker` 在此指交易源。两侧都写明就没有这层推断。
 
 几个要点：
 
 - `gateway_options` 会同时传给两个 builder，两侧参数放在同一个 dict 里即可。
-- 覆盖项与 `broker` 同名时视为未覆盖，不重复构建（builder 可能连柜台、起线程）。
+- 两侧同名时只构建一次（builder 可能连柜台、起线程）。
 - 名字未注册会报错并点名具体参数，不会静默缺失某一侧通道。
 - 这个组合让「回放行情 + 真实柜台下单」的联调成为可能：用确定性数据驱动策略，
   同时把订单真正发到柜台的仿真环境。注意此时仍受上面 timer 语义的限制。

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -1128,40 +1128,34 @@ bundle = create_gateway_bundle(
 
 `create_gateway_bundle` 与 `run_live` 支持把两侧分开指定：
 
-*   `broker`: 两侧的**默认源**。
-*   `market_broker`: 只覆盖**行情**源（可选）。
-*   `trader_broker`: 只覆盖**交易**源（可选）。
+两种模式，二选一：
 
-两侧都不传时行为与单 broker 完全一致。下面两种写法等价，都表示「行情来自
-`replay`、交易来自 `demo`」：
+*   **单 broker**：只传 `broker`，由它同时提供行情与交易两侧（原语义，不变）。
+*   **分开指定**：同时传 `market_broker` 与 `trader_broker`，各供一侧；此时
+    `broker` **完全不参与构建**。
 
 ```python
 run_live(
     strategy_cls=MyStrategy,
     instruments=instruments,
-    broker="demo",            # 交易源
     market_broker="replay",   # 行情源
-    trading_mode="paper",
-    gateway_options={"bars": bars},
-)
-
-run_live(
-    strategy_cls=MyStrategy,
-    instruments=instruments,
-    broker="replay",          # 行情源
     trader_broker="demo",     # 交易源
     trading_mode="paper",
     gateway_options={"bars": bars},
 )
 ```
 
+**只传其中一个会报错**，要求把另一侧也写明。这是刻意的设计：如果让 `broker` 去
+兼任缺失的那一侧，它就一词双义了——读 `broker='qmf', market_broker='replay'` 时，
+你必须先知道「qmf 只有交易通道」才能推断出 `broker` 在这里指交易源，而参数名本身
+没有表达这件事。两侧都写明则无需这层推断。
+
 要点：
 
 *   `gateway_options` 会**同时**传给两个 builder，两侧所需参数放在同一个 dict 里即可。
-*   覆盖项与 `broker` 同名时视为未覆盖，不会重复构建（builder 可能连柜台、起线程，
-    构建两次有副作用）。
+*   两侧同名时只构建一次（builder 可能连柜台、起线程，构建两次有副作用）。
 *   `metadata` 会记录 `market_broker` / `trader_broker` 便于排障；行情侧声明的
-    会话级信息（如 `replay` 的 `bounded_event_total`）不会因混搭而丢失。
+    会话级信息（如 `replay` 的 `bounded_event_total`）不会因分开指定而丢失。
 *   未注册的名字会报错并点名具体参数（`market_broker must be one of: ...`），
     而不是静默缺失某一侧通道。
 

--- a/docs/zh/textbook/15_live_trading.md
+++ b/docs/zh/textbook/15_live_trading.md
@@ -92,23 +92,26 @@ bundle = create_gateway_bundle(
 行情（无法下单），而某些券商/柜台插件只有交易通道（收不到行情，`on_bar` /
 `on_tick` 不触发、`self.current_tick` 恒为 `None`）。
 
-这两类「单边 broker」可以组合使用：`broker` 是两侧的默认源，`market_broker` 与
-`trader_broker` 各自覆盖一侧。
+这两类「单边 broker」可以组合使用：同时指定 `market_broker`（行情源）与
+`trader_broker`（交易源），各供一侧。
 
 ```python
 run_live(
     strategy_cls=MyStrategy,
     instruments=instruments,
-    broker="my_trade_only_broker",   # 交易源
-    market_broker="replay",          # 行情源
+    market_broker="replay",                # 行情源
+    trader_broker="my_trade_only_broker",  # 交易源
     trading_mode="paper",
     gateway_options={"bars": bars},
 )
 ```
 
-对称写法 `broker="replay", trader_broker="my_trade_only_broker"` 与上式等价。两侧
-都不传时行为与单 broker 完全一致。这个组合的价值在于：既能用确定性回放数据驱动
-策略，又能把订单真正发往柜台仿真环境做联调。
+两侧必须**同时写明**，只给一侧会报错——若让 `broker` 兼任缺失的那侧，它就一词双义
+了（读 `broker='qmf', market_broker='replay'` 得先知道「qmf 只有交易通道」才能推出
+`broker` 在此指交易源）。`broker` 只用于「单个 broker 供两侧」的场景，此时语义不变。
+
+这个组合的价值在于：既能用确定性回放数据驱动策略，又能把订单真正发往柜台仿真
+环境做联调。
 
 建议结合以下文档落地：
 

--- a/examples/39_live_mixed_broker_demo.py
+++ b/examples/39_live_mixed_broker_demo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""行情源与交易源分开指定示例（market_broker / trader_broker）.
+"""行情源与交易源分开指定示例（market_broker + trader_broker）.
 
 说明:
 - 一个 broker 不必同时提供行情与交易两条通道: `GatewayBundle` 的
@@ -7,8 +7,10 @@
 - 本例注册一个**只有交易通道**的 broker（`market_gateway=None`，形如某些券商/
   柜台插件）。它单独使用时策略收不到任何行情——`on_bar` 不触发、
   `current_tick` 恒为 None。
-- 通过 `market_broker="replay"` 借用内置回放行情源补上这一侧，无需柜台即可实跑。
-- 对称写法 `broker="replay", trader_broker=...` 与本例等价。
+- 用 `market_broker="replay"` 借用内置回放行情源补上这一侧，无需柜台即可实跑。
+- 两侧必须**同时写明**: 只给一侧会报错。这样 `broker` 不必兼任另一侧，避免
+  "读 broker='qmf', market_broker='replay' 得先知道 qmf 只有交易通道" 的歧义。
+  `broker` 仅用于"单个 broker 供两侧"的场景。
 """
 
 from typing import Any, Callable, Sequence
@@ -104,7 +106,7 @@ def _trade_only_builder(
 
 
 class MixedBrokerStrategy(Strategy):
-    """记录收到的 bar，用于验证行情确实来自 market_broker."""
+    """记录收到的 bar，用于验证行情确实来自 market_broker 指定的源."""
 
     def on_start(self) -> None:
         """初始化计数器."""
@@ -157,14 +159,16 @@ def main() -> None:
         ]
 
         strategy = MixedBrokerStrategy()
-        print(f"broker={TRADE_ONLY_BROKER}（只有交易）+ market_broker=replay（行情）")
+        print(
+            f"market_broker=replay（行情）+ trader_broker={TRADE_ONLY_BROKER}（交易）"
+        )
         run_live(
             strategy_cls=strategy,
             instruments=instruments,
-            # 交易源: 只有交易通道的 broker。单独使用时收不到任何行情。
-            broker=TRADE_ONLY_BROKER,
-            # 行情源: 借用内置回放行情补上缺失的那一侧。
+            # 行情源: 借用内置回放行情补上这个 broker 缺失的那一侧。
             market_broker="replay",
+            # 交易源: 只有交易通道的 broker。单独使用时收不到任何行情。
+            trader_broker=TRADE_ONLY_BROKER,
             trading_mode="paper",
             gateway_options={"bars": _make_bars()},
             cash=1_000_000,
@@ -177,8 +181,8 @@ def main() -> None:
         print(f"\n收到 {len(strategy.received)} 根 bar")
         if not strategy.received:
             raise SystemExit("行情通路未接通: 未收到任何 bar")
-        print("行情来自 market_broker、交易来自 broker —— 混搭生效。")
-        print("对称写法: broker='replay', trader_broker='demo_trade_only'")
+        print("行情来自 market_broker、交易来自 trader_broker —— 分开指定生效。")
+        print("注意: 两侧必须同时写明, 只给一侧会报错。")
     finally:
         unregister_broker(TRADE_ONLY_BROKER)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.30"
+version = "0.3.31"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/gateway/factory.py
+++ b/python/akquant/gateway/factory.py
@@ -6,9 +6,9 @@ from .registry import create_registered_gateway_bundle, list_registered_brokers
 
 
 def create_gateway_bundle(
-    broker: str,
-    feed: DataFeed,
-    symbols: Sequence[str],
+    broker: Optional[str] = None,
+    feed: Optional[DataFeed] = None,
+    symbols: Optional[Sequence[str]] = None,
     use_aggregator: bool = True,
     market_broker: Optional[str] = None,
     trader_broker: Optional[str] = None,
@@ -16,25 +16,37 @@ def create_gateway_bundle(
 ) -> GatewayBundle:
     """Create a market/trader gateway bundle by broker key (registry-based).
 
-    ``broker`` 是两侧的**默认源**; ``market_broker`` / ``trader_broker`` 各自
-    覆盖一侧, 用于把行情源与交易源分开指定。这补齐了两类单边 broker 的组合——
-    ``broker='qmf'`` 只有交易通道、``broker='replay'`` 只有行情通道, 此前二者
-    无法拼接。以下两种写法等价(都是"行情来自 replay、交易来自 qmf")::
+    两种模式, 二选一:
 
-        create_gateway_bundle(broker="qmf", market_broker="replay", ...)
-        create_gateway_bundle(broker="replay", trader_broker="qmf", ...)
+    - **单 broker**: 只传 ``broker``, 由它同时提供行情与交易两侧(原语义, 不变)。
+    - **分开指定**: 同时传 ``market_broker`` 与 ``trader_broker``, 各供一侧;
+      此时 ``broker`` **完全不参与构建**。
 
-    两侧都不覆盖时, 返回的 bundle 与单 broker 时完全一致(含 metadata)。
+    分开指定用于把两类"单边 broker"拼起来——``GatewayBundle`` 的 ``market_gateway``
+    / ``trader_gateway`` 本就是独立可选字段, ``replay`` 只有行情(不能下单), 而某些
+    券商/柜台插件只有交易通道(收不到行情)::
+
+        create_gateway_bundle(market_broker="replay", trader_broker="qmf", ...)
+
+    只传其中一个会报错: 另一侧的来源无从确定。让 ``broker`` 去兼任另一侧会使它
+    一词双义——读 ``broker='qmf', market_broker='replay'`` 必须先知道"qmf 只有交易
+    通道"才能推出 ``broker`` 在此指交易源, 参数名本身没有表达这件事。
     """
-    broker_key = broker.strip().lower()
+    # feed / symbols 形式上可选只为让 broker 能有默认值(Python 不允许有默认值的
+    # 参数排在无默认值参数之前), 实际仍必填。
+    if feed is None:
+        raise ValueError("feed is required")
+
     market_key = (market_broker or "").strip().lower()
     trader_key = (trader_broker or "").strip().lower()
 
-    # 同名视为未覆盖: builder 可能连柜台/起线程, 同一 broker 不应构建两次。
-    if market_key == broker_key:
-        market_key = ""
-    if trader_key == broker_key:
-        trader_key = ""
+    if bool(market_key) != bool(trader_key):
+        missing = "trader_broker" if market_key else "market_broker"
+        given = "market_broker" if market_key else "trader_broker"
+        raise ValueError(
+            f"{given} 已指定, 但缺少 {missing}: 行情源与交易源必须同时写明"
+            f"(或改为只传 broker 让单个 broker 供两侧)"
+        )
 
     built: Dict[str, GatewayBundle] = {}
 
@@ -45,7 +57,7 @@ def create_gateway_bundle(
         bundle = create_registered_gateway_bundle(
             name=key,
             feed=feed,
-            symbols=symbols,
+            symbols=symbols or [],
             use_aggregator=use_aggregator,
             **kwargs,
         )
@@ -55,22 +67,27 @@ def create_gateway_bundle(
         built[key] = bundle
         return bundle
 
-    base_bundle = _build(broker_key, "broker")
-    if not market_key and not trader_key:
-        return base_bundle
+    # 单 broker 模式。
+    if not market_key:
+        broker_key = (broker or "").strip().lower()
+        if not broker_key:
+            raise ValueError(
+                "broker is required (或同时指定 market_broker 与 trader_broker)"
+            )
+        return _build(broker_key, "broker")
 
-    market_bundle = _build(market_key, "market_broker") if market_key else base_bundle
-    trader_bundle = _build(trader_key, "trader_broker") if trader_key else base_bundle
+    # 分开指定: broker 不参与——它可能只是 run_live 的默认值 'ctp', 构建它会因
+    # 缺少 md_front 等参数而报出与本次配置无关的错误。同名时只构建一次(builder
+    # 可能连柜台/起线程, 建两次有副作用)。
+    market_bundle = _build(market_key, "market_broker")
+    trader_bundle = _build(trader_key, "trader_broker")
 
     # 行情侧 metadata 作底、交易侧覆盖其上: 行情 broker 可能声明会话级信息
     # (如 replay 的 ``bounded_event_total`` —— runner 据此在事件放完后结束会话),
-    # 只保留交易侧会丢掉它, 混搭会话便只能等 duration 墙钟超时。``broker`` 键由
-    # 交易侧覆盖胜出, 与单 broker 时一致。
+    # 只保留交易侧会丢掉它, 混搭会话便只能等 duration 墙钟超时。
     metadata = {**(market_bundle.metadata or {}), **(trader_bundle.metadata or {})}
-    if market_key:
-        metadata["market_broker"] = market_key
-    if trader_key:
-        metadata["trader_broker"] = trader_key
+    metadata["market_broker"] = market_key
+    metadata["trader_broker"] = trader_key
     return GatewayBundle(
         market_gateway=market_bundle.market_gateway,
         trader_gateway=trader_bundle.trader_gateway,

--- a/python/akquant/live/_facade.py
+++ b/python/akquant/live/_facade.py
@@ -85,6 +85,18 @@ def run_live(
     :param cash: Initial cash (default 1,000,000).
     :param show_progress: Whether to show a progress bar.
     :param duration: Optional run duration (e.g. ``"1m"``, ``"30s"``).
+    :param broker: Broker supplying **both** market data and trading (default
+        ``"ctp"``). Leave ``market_broker`` / ``trader_broker`` unset to use it.
+    :param market_broker: Market-data source, overriding ``broker`` for that side.
+        Must be given together with ``trader_broker``; passing only one raises
+        ``ValueError``. When both are given, ``broker`` is not used at all.
+    :param trader_broker: Trading source, the counterpart of ``market_broker``.
+        Use this pair to combine two single-sided brokers — ``replay`` only
+        provides market data (cannot place orders), while some broker plugins
+        only provide a trading channel (no market data, so ``on_bar`` /
+        ``on_tick`` never fire and ``current_tick`` stays ``None``)::
+
+            run_live(..., market_broker="replay", trader_broker="qmf")
     :param broker_ready_timeout: Max seconds to poll ``trader_gateway.heartbeat()``
         before giving up (default 30.0).
     :param broker_ready_required: If True (default), abort the run when the broker

--- a/python/akquant/live/_runner.py
+++ b/python/akquant/live/_runner.py
@@ -227,6 +227,15 @@ class LiveRunner:
         :param app_id: CTP App ID (optional).
         :param auth_code: CTP Auth Code (optional).
         :param use_aggregator: Whether to use BarAggregator (default True).
+        :param broker: Broker supplying **both** market data and trading
+            (default ``"ctp"``). Used when ``market_broker`` / ``trader_broker``
+            are both unset.
+        :param market_broker: Market-data source, overriding ``broker`` for that
+            side. Must be given together with ``trader_broker``; passing only one
+            raises ``ValueError``. When both are given, ``broker`` is unused.
+        :param trader_broker: Trading source, the counterpart of
+            ``market_broker``. Use the pair to combine two single-sided brokers
+            (``replay`` is market-data-only; some plugins are trading-only).
         :param initialize: Optional function-style initialize callback.
         :param on_start: Optional function-style on_start callback.
         :param on_stop: Optional function-style on_stop callback.

--- a/tests/test_gateway_mixed_market_trader.py
+++ b/tests/test_gateway_mixed_market_trader.py
@@ -1,13 +1,14 @@
-"""行情源与交易源可分别指定(``market_broker`` + ``broker``).
+"""行情源与交易源分开指定: 要么只给 broker, 要么两侧都写明.
 
-``GatewayBundle`` 早已把 ``market_gateway`` / ``trader_gateway`` 拆成两个独立可
-选字段, 但 ``create_gateway_bundle`` 只接受**一个** broker 名, 于是两者只能来自
-同一个 builder。现实里这个组合是缺的:
+``GatewayBundle`` 的 ``market_gateway`` / ``trader_gateway`` 是两个独立可选字段,
+因此一个 broker 可以只提供其中一侧(``replay`` 只有行情, 某些券商插件只有交易)。
+把两者拼起来的入口是 ``market_broker`` + ``trader_broker``:
 
-- ``broker='qmf'`` 只有交易通道(``market_gateway=None``) → 收不到任何行情;
-- ``broker='replay'`` 只有行情通道(``trader_gateway=None``) → 无法下单。
-
-两者都存在却无法拼在一起。本模块锁定"行情用 A、交易用 B"的混搭契约。
+- 只给 ``broker``: 单 broker 供两侧(原语义, 不变);
+- 同时给 ``market_broker`` 与 ``trader_broker``: 各自供一侧, ``broker`` **不参与**;
+- 只给其中一个: 报错。此时另一侧的来源无从确定, 而让 ``broker`` 去兼任会使它
+  一词双义——读 ``broker='qmf', market_broker='replay'`` 必须先知道 "qmf 只有交易
+  通道" 才能推出 broker 在这里指交易源, 参数名本身没有表达这件事。
 """
 
 from typing import Any, Callable, Dict, List, Sequence, cast
@@ -20,6 +21,10 @@ from akquant.gateway.registry import register_broker, unregister_broker
 
 MARKET_ONLY = "test_market_only"
 TRADER_ONLY = "test_trader_only"
+BOTH_SIDES = "test_both_sides"
+
+# BOTH_SIDES builder 的构建次数, 用于验证同名 broker 只构建一次。
+_build_counts: Dict[str, int] = {}
 
 
 class _MarketOnlyGateway:
@@ -73,7 +78,8 @@ class _TraderOnlyGateway:
 
 @pytest.fixture(autouse=True)
 def _register_test_brokers() -> Any:
-    """注册两个互补的测试 broker, 用后注销以免污染全局 registry."""
+    """注册测试 broker, 用后注销以免污染全局 registry."""
+    _build_counts.clear()
 
     def _build_market_only(
         feed: Any, symbols: Sequence[str], use_aggregator: bool, **kwargs: Any
@@ -83,7 +89,9 @@ def _register_test_brokers() -> Any:
             market_gateway=cast(MarketGateway, _MarketOnlyGateway(symbols)),
             trader_gateway=None,
             trader_capabilities=None,
-            metadata={"broker": MARKET_ONLY},
+            # market_note 代表"行情侧声明的会话级信息", 真实场景是 replay 的
+            # bounded_event_total(runner 据此在事件放完后结束会话)。
+            metadata={"broker": MARKET_ONLY, "market_note": "from-market-side"},
         )
 
     def _build_trader_only(
@@ -97,45 +105,100 @@ def _register_test_brokers() -> Any:
             metadata={"broker": TRADER_ONLY},
         )
 
+    def _build_both_sides(
+        feed: Any, symbols: Sequence[str], use_aggregator: bool, **kwargs: Any
+    ) -> GatewayBundle:
+        _ = (feed, use_aggregator, kwargs)
+        _build_counts[BOTH_SIDES] = _build_counts.get(BOTH_SIDES, 0) + 1
+        return GatewayBundle(
+            market_gateway=cast(MarketGateway, _MarketOnlyGateway(symbols)),
+            trader_gateway=cast(TraderGateway, _TraderOnlyGateway()),
+            trader_capabilities=None,
+            metadata={"broker": BOTH_SIDES},
+        )
+
     register_broker(MARKET_ONLY, _build_market_only)
     register_broker(TRADER_ONLY, _build_trader_only)
+    register_broker(BOTH_SIDES, _build_both_sides)
     yield
     unregister_broker(MARKET_ONLY)
     unregister_broker(TRADER_ONLY)
+    unregister_broker(BOTH_SIDES)
 
 
-def test_market_broker_supplies_market_gateway() -> None:
-    """指定 market_broker 后, 行情网关应来自该 broker.
+def test_split_mode_does_not_build_broker() -> None:
+    """两侧都指定时 ``broker`` 完全不参与构建.
 
-    未实现时 create_gateway_bundle 不认识 market_broker 这个参数。
+    用 ``broker='ctp'`` 作探针: 真去构建它会因缺 ``md_front`` 抛 ValueError。这正是
+    ``run_live`` 的实际处境——``broker`` 默认值是 ``'ctp'``, 用户即使把两侧都写明,
+    未被跳过的 ctp 也会报一句莫名其妙的 "md_front is required"。
     """
     bundle = create_gateway_bundle(
-        broker=TRADER_ONLY,
+        broker="ctp",
         market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
         feed=DataFeed(),
         symbols=["600000"],
     )
 
     assert bundle.market_gateway is not None
+    assert bundle.trader_gateway is not None
 
 
-def test_market_broker_keeps_trader_gateway_from_broker() -> None:
-    """混搭时交易网关必须仍来自 broker, 不能被行情 broker 的 None 覆盖."""
+def test_market_broker_alone_raises_asking_for_trader_broker() -> None:
+    """只给 market_broker 应报错并要求写明 trader_broker.
+
+    旧行为是让 ``broker`` 兼任交易侧, 那使 ``broker`` 一词双义。
+    """
+    with pytest.raises(ValueError, match="trader_broker"):
+        create_gateway_bundle(
+            broker=TRADER_ONLY,
+            market_broker=MARKET_ONLY,
+            feed=DataFeed(),
+            symbols=["600000"],
+        )
+
+
+def test_trader_broker_alone_raises_asking_for_market_broker() -> None:
+    """只给 trader_broker 应报错并要求写明 market_broker(与上一条对称)."""
+    with pytest.raises(ValueError, match="market_broker"):
+        create_gateway_bundle(
+            broker=MARKET_ONLY,
+            trader_broker=TRADER_ONLY,
+            feed=DataFeed(),
+            symbols=["600000"],
+        )
+
+
+def test_split_mode_market_gateway_comes_from_market_broker() -> None:
+    """行情网关应来自 market_broker(而非 trader_broker 的 None)."""
     bundle = create_gateway_bundle(
-        broker=TRADER_ONLY,
         market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
         feed=DataFeed(),
         symbols=["600000"],
     )
 
-    assert bundle.trader_gateway is not None
+    assert isinstance(bundle.market_gateway, _MarketOnlyGateway)
 
 
-def test_market_gateway_receives_requested_symbols() -> None:
+def test_split_mode_trader_gateway_comes_from_trader_broker() -> None:
+    """交易网关应来自 trader_broker(而非 market_broker 的 None)."""
+    bundle = create_gateway_bundle(
+        market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
+        feed=DataFeed(),
+        symbols=["600000"],
+    )
+
+    assert isinstance(bundle.trader_gateway, _TraderOnlyGateway)
+
+
+def test_split_mode_market_gateway_receives_requested_symbols() -> None:
     """行情 broker 应收到本次会话的标的集, 而不是空集."""
     bundle = create_gateway_bundle(
-        broker=TRADER_ONLY,
         market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
         feed=DataFeed(),
         symbols=["600000", "600001"],
     )
@@ -143,33 +206,75 @@ def test_market_gateway_receives_requested_symbols() -> None:
     assert getattr(bundle.market_gateway, "symbols", None) == ["600000", "600001"]
 
 
-def test_metadata_records_both_brokers() -> None:
-    """混搭时应能从 metadata 看出行情与交易各自来自谁(便于日志与排障)."""
+def test_split_mode_metadata_records_both_sides() -> None:
+    """分开指定时应能从 metadata 看出两侧各自来自谁(便于日志与排障)."""
     bundle = create_gateway_bundle(
-        broker=TRADER_ONLY,
         market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
         feed=DataFeed(),
         symbols=["600000"],
     )
 
     assert bundle.metadata is not None
-    assert bundle.metadata.get("broker") == TRADER_ONLY
     assert bundle.metadata.get("market_broker") == MARKET_ONLY
+    assert bundle.metadata.get("trader_broker") == TRADER_ONLY
 
 
-def test_unknown_market_broker_raises_with_supported_list() -> None:
-    """未注册的 market_broker 应报错并列出可选项, 而非静默无行情."""
+def test_split_mode_preserves_market_side_metadata() -> None:
+    """行情侧声明的会话级信息不得因混搭而丢失.
+
+    真实场景: ``replay`` 用 metadata 声明 ``bounded_event_total``, runner 据此在事件
+    放完后结束会话。只保留交易侧 metadata 会丢掉它, 会话便只能等 duration 超时。
+    """
+    bundle = create_gateway_bundle(
+        market_broker=MARKET_ONLY,
+        trader_broker=TRADER_ONLY,
+        feed=DataFeed(),
+        symbols=["600000"],
+    )
+
+    assert bundle.metadata is not None
+    assert bundle.metadata.get("market_note") == "from-market-side"
+
+
+def test_same_broker_on_both_sides_is_built_once() -> None:
+    """两侧同名时只构建一次: builder 可能连柜台/起线程, 建两次有副作用."""
+    bundle = create_gateway_bundle(
+        market_broker=BOTH_SIDES,
+        trader_broker=BOTH_SIDES,
+        feed=DataFeed(),
+        symbols=["600000"],
+    )
+
+    assert bundle.market_gateway is not None
+    assert bundle.trader_gateway is not None
+    assert _build_counts.get(BOTH_SIDES) == 1
+
+
+def test_unknown_market_broker_raises_naming_the_parameter() -> None:
+    """未注册的 market_broker 应报错并点名该参数, 而非静默无行情."""
     with pytest.raises(ValueError, match="market_broker"):
         create_gateway_bundle(
-            broker=TRADER_ONLY,
             market_broker="no_such_broker",
+            trader_broker=TRADER_ONLY,
             feed=DataFeed(),
             symbols=["600000"],
         )
 
 
-def test_without_market_broker_bundle_is_unchanged() -> None:
-    """不传 market_broker 时行为完全不变(单 broker 语义保持)."""
+def test_unknown_trader_broker_raises_naming_the_parameter() -> None:
+    """未注册的 trader_broker 应报错并点名该参数, 而非静默无交易通道."""
+    with pytest.raises(ValueError, match="trader_broker"):
+        create_gateway_bundle(
+            market_broker=MARKET_ONLY,
+            trader_broker="no_such_broker",
+            feed=DataFeed(),
+            symbols=["600000"],
+        )
+
+
+def test_single_broker_mode_is_unchanged() -> None:
+    """只给 broker 时行为完全不变(含 metadata 不多出覆盖键)."""
     bundle = create_gateway_bundle(
         broker=TRADER_ONLY,
         feed=DataFeed(),
@@ -181,106 +286,31 @@ def test_without_market_broker_bundle_is_unchanged() -> None:
     assert bundle.metadata is not None
     assert bundle.metadata.get("broker") == TRADER_ONLY
     assert "market_broker" not in bundle.metadata
+    assert "trader_broker" not in bundle.metadata
 
 
-def test_trader_broker_supplies_trader_gateway() -> None:
-    """指定 trader_broker 后, 交易网关应来自该 broker.
+def test_missing_feed_raises_instead_of_reaching_builder() -> None:
+    """``feed`` 缺失应直接报错, 而非把 None 传进 builder.
 
-    与 market_broker 对称: ``broker`` 是两者的默认源, ``market_broker`` /
-    ``trader_broker`` 各自覆盖一侧。只有 market_broker 而无 trader_broker 时,
-    "行情用 A、交易用 B"只能从行情侧表达, 反方向写不出来。
+    ``feed`` 形式上可选只是为了让 ``broker`` 能有默认值(Python 不允许有默认值的参数
+    排在无默认值参数之前), 实际仍必填。少了这道校验, None 会一路传到 builder, 报出
+    的是各 broker 内部五花八门的 AttributeError 而非一句明确的缺参提示。
     """
-    bundle = create_gateway_bundle(
-        broker=MARKET_ONLY,
-        trader_broker=TRADER_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert bundle.trader_gateway is not None
+    with pytest.raises(ValueError, match="feed"):
+        create_gateway_bundle(broker=TRADER_ONLY, symbols=["600000"])
 
 
-def test_trader_broker_keeps_market_gateway_from_broker() -> None:
-    """指定 trader_broker 时行情网关仍来自 broker."""
-    bundle = create_gateway_bundle(
-        broker=MARKET_ONLY,
-        trader_broker=TRADER_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert bundle.market_gateway is not None
+def test_neither_broker_nor_split_pair_raises() -> None:
+    """既没有 broker 也没有两侧覆盖时应报错(而非返回空 bundle)."""
+    with pytest.raises(ValueError, match="broker"):
+        create_gateway_bundle(feed=DataFeed(), symbols=["600000"])
 
 
-def test_trader_broker_and_market_broker_are_equivalent_spellings() -> None:
-    """两种写法应得到同构的 bundle(对称性的核心断言).
-
-    ``broker=A, trader_broker=B`` 与 ``broker=B, market_broker=A`` 描述的是同一
-    件事: 行情来自 A、交易来自 B。二者不等价就说明这组参数语义错位。
-    """
-    via_trader = create_gateway_bundle(
-        broker=MARKET_ONLY,
-        trader_broker=TRADER_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-    via_market = create_gateway_bundle(
-        broker=TRADER_ONLY,
-        market_broker=MARKET_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert type(via_trader.market_gateway) is type(via_market.market_gateway)
-    assert type(via_trader.trader_gateway) is type(via_market.trader_gateway)
-
-
-def test_metadata_records_trader_broker() -> None:
-    """混搭时应能从 metadata 看出交易源来自谁(与 market_broker 对称)."""
-    bundle = create_gateway_bundle(
-        broker=MARKET_ONLY,
-        trader_broker=TRADER_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert bundle.metadata is not None
-    assert bundle.metadata.get("trader_broker") == TRADER_ONLY
-
-
-def test_unknown_trader_broker_raises_with_supported_list() -> None:
-    """未注册的 trader_broker 应报错并点名该参数, 而非静默无交易通道."""
-    with pytest.raises(ValueError, match="trader_broker"):
+def test_unknown_broker_still_raises_naming_broker() -> None:
+    """单 broker 模式下未注册的名字仍点名 broker 参数."""
+    with pytest.raises(ValueError, match="broker"):
         create_gateway_bundle(
-            broker=MARKET_ONLY,
-            trader_broker="no_such_broker",
+            broker="no_such_broker",
             feed=DataFeed(),
             symbols=["600000"],
         )
-
-
-def test_both_overrides_together_bypass_default_broker() -> None:
-    """两侧都覆盖时, broker 只作默认源不再贡献网关."""
-    bundle = create_gateway_bundle(
-        broker=TRADER_ONLY,
-        market_broker=MARKET_ONLY,
-        trader_broker=TRADER_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert bundle.market_gateway is not None
-    assert bundle.trader_gateway is not None
-
-
-def test_market_broker_equal_to_broker_is_accepted() -> None:
-    """market_broker 与 broker 同名时应等价于单 broker, 不重复构建."""
-    bundle = create_gateway_bundle(
-        broker=MARKET_ONLY,
-        market_broker=MARKET_ONLY,
-        feed=DataFeed(),
-        symbols=["600000"],
-    )
-
-    assert bundle.market_gateway is not None
-    assert bundle.trader_gateway is None

--- a/tests/test_live_mixed_market_broker.py
+++ b/tests/test_live_mixed_market_broker.py
@@ -100,10 +100,12 @@ class _Recorder(Strategy):
         self.bars.append((int(bar.timestamp), str(bar.symbol)))
 
 
-def test_market_broker_delivers_bars_to_trade_only_broker() -> None:
+def test_split_brokers_deliver_bars_to_trade_only_broker() -> None:
     """纯交易 broker 配 replay 行情后, 策略应真正收到 bar.
 
-    未接线时 run_live 不认识 market_broker, 行情网关仍为 None → 收到 0 根。
+    这是本能力的核心用例: 交易侧只有交易通道(``market_gateway=None``), 行情侧
+    借用 replay。未接线时 ``run_live`` 不认识这两个参数, 行情网关仍为 None →
+    收到 0 根 bar。
     """
     strategy = _Recorder()
     stamps = [_ts("2023-01-03 09:30:00"), _ts("2023-01-03 09:31:00")]
@@ -111,31 +113,7 @@ def test_market_broker_delivers_bars_to_trade_only_broker() -> None:
     run_live(
         strategy_cls=strategy,
         instruments=[_instrument(SYMBOL)],
-        broker=TRADER_ONLY,
         market_broker="replay",
-        trading_mode="paper",
-        gateway_options={"bars": [_bar(ts, SYMBOL, 10.0) for ts in stamps]},
-        cash=100_000.0,
-        show_progress=False,
-        duration="60s",
-    )
-
-    assert [ts for ts, _ in strategy.bars] == stamps
-
-
-def test_trader_broker_spelling_delivers_bars_too() -> None:
-    """对称写法 broker='replay' + trader_broker=... 应等效地收到 bar.
-
-    与 ``broker=TRADER_ONLY, market_broker='replay'`` 描述同一件事; 只支持一个
-    方向就说明这组参数语义错位。
-    """
-    strategy = _Recorder()
-    stamps = [_ts("2023-01-03 09:30:00"), _ts("2023-01-03 09:31:00")]
-
-    run_live(
-        strategy_cls=strategy,
-        instruments=[_instrument(SYMBOL)],
-        broker="replay",
         trader_broker=TRADER_ONLY,
         trading_mode="paper",
         gateway_options={"bars": [_bar(ts, SYMBOL, 10.0) for ts in stamps]},
@@ -145,6 +123,25 @@ def test_trader_broker_spelling_delivers_bars_too() -> None:
     )
 
     assert [ts for ts, _ in strategy.bars] == stamps
+
+
+def test_run_live_rejects_one_sided_override() -> None:
+    """只给一侧应报错, 且错误要能穿透 run_live 传到用户面前.
+
+    ``run_live`` 的 ``broker`` 默认值是 ``'ctp'``, 若校验缺失或被吞掉, 用户只写
+    ``market_broker`` 时会收到一句与本次配置无关的 "md_front is required"。
+    """
+    with pytest.raises(ValueError, match="trader_broker"):
+        run_live(
+            strategy_cls=_Recorder(),
+            instruments=[_instrument(SYMBOL)],
+            market_broker="replay",
+            trading_mode="paper",
+            gateway_options={"bars": []},
+            cash=100_000.0,
+            show_progress=False,
+            duration="30s",
+        )
 
 
 def test_mixed_session_ends_on_bounded_event_total() -> None:
@@ -161,8 +158,8 @@ def test_mixed_session_ends_on_bounded_event_total() -> None:
     run_live(
         strategy_cls=strategy,
         instruments=[_instrument(SYMBOL)],
-        broker=TRADER_ONLY,
         market_broker="replay",
+        trader_broker=TRADER_ONLY,
         trading_mode="paper",
         gateway_options={"bars": [_bar(ts, SYMBOL, 10.0) for ts in stamps]},
         cash=100_000.0,


### PR DESCRIPTION
- 重构create_gateway_bundle的参数逻辑，将broker设为可选参数，严格校验market_broker和trader_broker必须同时指定，避免语义歧义
- 新增feed参数的非空校验，避免将None传入builder导致的不明错误
- 修复原逻辑中重复构建broker的问题，优化元数据处理逻辑，避免重复连接柜台
- 更新相关文档、示例代码、测试用例和CHANGELOG.md，修正混合broker的使用语义描述
- 升级包版本至0.3.31