### PR TITLE
perf(parquet): 切换 parquet 读取为 eager 模式以减小 wheel 体积并更新版本至 0.3.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.32"
+version = "0.3.33"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.32"
+version = "0.3.33"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"
@@ -16,8 +16,11 @@ crate-type = ["cdylib", "rlib"]
 pyo3 = { version = "0.28.2", features = ["abi3-py310", "chrono"] }
 numpy = "0.28"
 pyo3-stub-gen = "0.6.0"
-serde = { version = "1.0", features = ["derive"] }
-polars = { version = "0.51.0", features = ["lazy", "parquet", "ipc", "csv"] }
+# `rc`: tracker.rs / portfolio.rs 给 `Arc<..>` 字段 derive(Serialize)。
+serde = { version = "1.0", features = ["derive", "rc"] }
+# 别加 `lazy`: 一个 lazy 调用点会把查询计划/表达式引擎链进 wheel (+12MB, 见 0.3.6)。
+# parquet 走 eager ParquetReader; CSV 用独立的 `csv` crate, 不需要 polars 的。
+polars = { version = "0.51.0", features = ["parquet", "ipc"] }
 rayon = "1.11"
 uuid = { version = "1.20.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 # Utilities
@@ -41,10 +44,8 @@ extension-module = ["pyo3/extension-module"]
 test-utils = ["pyo3/auto-initialize"]
 
 [profile.release]
-# Strip debug symbols from the compiled extension. The release build statically
-# links all Rust deps (polars, etc.); without stripping, their debug symbols
-# roughly triple the .pyd size. This is the dominant lever on wheel size.
+# 去掉残留符号表(release 本就 debug=0)。实测 linux -7.8% / macOS -9.2% /
+# Windows ~0(MSVC 调试信息在独立 .pdb 里)。体积的主要杠杆不在这, 在上面 polars 的 features。
 strip = "symbols"
-# Thin LTO trims dead code across crates for a smaller, faster artifact at a
-# modest compile-time cost.
+# 跨 crate 消除死代码。也是"声明但未调用的依赖不进产物"的机制来源。
 lto = "thin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.32"
+version = "0.3.33"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/src/data/parquet_stream.rs
+++ b/src/data/parquet_stream.rs
@@ -1,8 +1,11 @@
 //! 流式 Parquet 数据客户端 (C.2a, out-of-core 基座).
 //!
-//! 有界内存: 每次经 polars `scan_parquet().slice()` 读取一个块 (chunk_size 行),
-//! 转为 `Bar` 缓冲后逐个产出; 内存占用约为 chunk_size 行, 与文件总量无关。
-//! 假定 parquet 已按 `timestamp` 升序 (规范格式)。
+//! 有界内存: 每次经 polars eager `ParquetReader::with_slice` 读取一个块
+//! (chunk_size 行), 转为 `Bar` 缓冲后逐个产出; 内存占用约为 chunk_size 行,
+//! 与文件总量无关。假定 parquet 已按 `timestamp` 升序 (规范格式)。
+//!
+//! 用 eager reader 而非 `LazyFrame::scan_parquet().slice()`: 二者切片语义等价,
+//! 但 lazy 版会把 polars 的查询计划/表达式引擎链进扩展模块 (wheel +12MB)。
 //!
 //! 规范列: `timestamp` (i64 纳秒 UTC) + `open/high/low/close/volume` (f64) +
 //! 可选 `symbol` (str)。价格重构用 `Decimal::from_f64`, 与 `from_arrays` 一致。
@@ -52,9 +55,10 @@ impl ParquetStreamClient {
     }
 
     fn read_chunk(&self) -> PolarsResult<DataFrame> {
-        LazyFrame::scan_parquet(PlPath::new(&self.path), ScanArgsParquet::default())?
-            .slice(self.offset as i64, self.chunk_size as IdxSize)
-            .collect()
+        let file = std::fs::File::open(&self.path)?;
+        ParquetReader::new(file)
+            .with_slice(Some((self.offset, self.chunk_size)))
+            .finish()
     }
 
     /// 读取下一块并填充缓冲区.


### PR DESCRIPTION
- 替换 polars 惰性 parquet 读取为 eager ParquetReader，二者切片语义一致但避免引入 polars 查询计划引擎，减少约 12MB 的 wheel 体积
- 更新 Cargo.toml 与 pyproject.toml 的包版本至 0.3.33
- 调整依赖配置、构建配置注释以及代码文档注释
- 为 serde 添加 rc 特性以支持 Arc 字段的 Serialize 派生