### PR TITLE
chore(release): 发布v0.3.37，修复#361并完善相关功能

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`orders_df` / `executions_df` 现在导出开平语义**。#361 争的就是 `position_effect`，而这两张最常用的表原先都不导出它，使用者只能自行遍历 `Order` / `Trade` 对象才看得到。现在：
+
+    - `executions_df` 新增 `position_effect`、`timestamp_iso`
+    - `orders_df` 新增 `position_effect`、`reduce_only`、`created_at_iso`、`updated_at_iso`
+
+    委托表比成交表更早暴露拆腿结果——`auto` 拆腿在下单时就定了，无需等成交。`reduce_only` 与 `position_effect` 成对：为真时不产生开仓腿，只看 effect 会看不懂为什么少了一条腿。ISO 列是 UTC 归一的稳定字符串，与已本地化的 `timestamp` / `created_at` 并存，便于跨系统对账与导出。
+
+    导出词表与下单**入参同一套**（`auto` / `open` / `close` / `close_today` / `close_yesterday`），可直接用于筛选。这一点是刻意的：若沿用仓库既有的 `format!("{:?}").to_lowercase()` 惯例，`CloseToday` 会导出成 `closetoday`，而 API 接受的是 `close_today`，`df[df.position_effect == "close_today"]` 会**静默匹配不到**。`status` 那类只读列可以这么做，但 `position_effect` 是可回传值，入参与导出必须同词表，故新增 `PositionEffect::as_canonical_str()` 作为唯一词表源。
+
+- `StrategyContext` 新增 `get_closable_position(symbol)` 与 `get_projected_position(symbol)`，分别是「还能平多少」与「仓位将落在哪」两个口径，供开平推断与目标仓位使用（详见 Fixed 中 #361 条目）。同时 `ExecutionBackend` 协议新增这两个方法；协议是公开且 `runtime_checkable` 的，故调用点按名取值、缺失则退回 `get_position()`，第三方自定义后端不会因此崩溃（代价是维持旧行为，需自行实现新方法才能获得修复）。`broker_live` 下这两个方法退回结算仓：柜台挂单快照 `UnifiedOrderSnapshot` 只有 `position_effect` 与 `filled_quantity`，没有 `side` 和 `quantity`，算不出剩余量也判不了方向。
+
 - **实盘 `subscribe()` 现在真正下发到行情网关**。`MarketGateway` 协议一直定义着 `subscribe(symbols)`，各内置网关（`ctp` / `replay` / `miniqmt` / `ptrade`）也都实现了它，但 `LiveRunner` 从不调用——订阅链路只接了一半：`instruments` 进得去，`Strategy.subscribe()` 出不来。此前用户在 `on_start` 里 `subscribe()` 一个标的只会拿到一条 warning。现在 `run_live` 会给主策略与各 slot 策略装上转发器，`subscribe()` 调用即刻把订阅集下发到行情网关。
 
     下发的是 **`instruments` 与全部 slot 的 `_subscriptions` 的并集**：各网关的 `subscribe()` 是整集替换语义（`self.symbols = list(symbols)`），只下发增量会把其余标的静默退订。转发在 `subscribe()` 发生的当刻进行而非装配期——行情网关先于策略 `on_start` 启动，装配时还不知道策略要订什么。
@@ -108,6 +119,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **回测数据列表改为逐元素类型校验（破坏性）**：`run_backtest(data=[...])` 此前只检查首元素类型，`[Bar, "garbage"]` 会漏到 Rust 层抛出难以定位的错误。现在在 Python 层逐元素校验，抛 `TypeError` 并指名位置索引与实际类型；空列表抛 `ValueError`。
 
 ### Fixed
+- 修复同一根 bar 内「先平后开」反手时开平语义标错的问题（#361）。`buy()` / `sell()` 在默认 `position_effect="auto"` 下按**结算持仓**拆开平腿，而结算持仓不含同周期已提交未成交的平仓单——`close_position()` 紧跟 `buy()` 的写法里，第二笔看到的仓位仍是反向的，于是被判成平仓：反手两笔都标 `close`，本该是 `close + open`。做空方向不暴露此问题只是因为 `short()` / `cover()` 把 `position_effect` 硬编码为 `open` / `close`，从不走 auto 推断。
+
+    不止是标签错。落账层（`order_manager`）只看 `side` 无条件加减，所以最终净仓与净值曲线一直是对的（这也是它长期未被发现的原因）；但风控与保证金层按 `position_effect` 投影，那条假 `close` 腿的仓位变化算作 0，**保证金需求为 0**——一笔实质开仓的单子零保证金过闸。同时 `is_reduce_first_order` 会把它排到开仓单之前参与 reduce-first 撮合排序。
+
+    现改为按**可平仓**拆腿：结算持仓扣除在途平仓/减仓单占用（状态取 `New` / `Submitted` / `PartiallyFilled`，按 `quantity - filled_quantity` 折算，并对平仓量封顶）。刻意**不**投影在途开仓单——在途开仓单未必成交，不投影它使拆腿偏向判为开仓，即偏向多预留保证金（安全侧）。此口径与 vn.py `OffsetConverter`、RQAlpha `closable` 一致。`__engine_rule_version__` 相应升至 `1.3.7`。
+
+- 修复 `order_target*` / `close_position()` 在同一根 bar 内重复下单造成超卖的问题（与 #361 同源）。它们同样按结算持仓算差额，先 `close_position()` 再 `order_target_percent()` 会在全平单之外再补一笔同向单——卖出量超过持仓。现改为按**投影持仓**（结算持仓叠加**全部**在途单的预期效果）算差额：目标仓位问的是「仓位最终落在哪」，开仓与平仓在途单都要计入，否则目标不收敛。同一根 bar 内重复调用 `close_position()` 现在是幂等的。
+
+    与 `auto` 拆腿只扣在途平仓单的取舍不同，两者问的问题不同，故分为 `get_closable_position()` 与 `get_projected_position()` 两个口径，共用同一投影核心。
+
+- 修复多策略下同周期跨策略挂单不可见的问题。`ctx.positions` 是账户级全局，但 `active_orders` 在 slot 循环**之前**只快照一次，slot 0 本周期提交的单要到循环体末尾才发给事件管理器，slot 1 因此看不到——两边口径不一致会让开平推断漏掉别的策略的减仓意图。现在 slot 之间累加已提交单（仅多策略时累加，单策略不多付克隆开销）。
+
+- 修复 `examples/textbook/ch07_futures.py` 从不触发反手分支的问题：`warmup_period = 10` 少于 `get_history(count=ma_window + 1)` 要求的 11 根，返回数组首位为 `NaN`，示例又取 `closes[:-1][-10:]` 正好圈入该 `NaN`，均线恒为 `NaN`、比较恒为假、信号永久锁在初值。同时修正期末权益取错 metrics 键的问题：`end_portfolio_value` 从不存在，正确键是 `end_market_value`，原写法有 `if key in index else 0.0` 兜底，故静默打印 `0.00` 而不报错。
+
+- 修复 `executions_df` 的 Python 兜底路径与 Rust 快路径 `side` 列取值不一致的问题：兜底路径用 `str(t.side).lower()` 产出 `orderside.sell`，而快路径产出 `sell`——同一列的值随走哪条路而变。
+
 - 修复 `broker_live` 下 `buy()` / `sell()` 缺省参数不解析的问题：`quantity=None` 原先直接透传到拆腿逻辑并以 `TypeError` 崩掉——等价于 `set_sizer()` 在实盘静默失效；`symbol=None` 原先会把 `None` 送进柜台请求。现按回测同口径解析：`symbol` 取当前 bar/tick，买入量走 `strategy.sizer`，卖出量全平持仓。另外解析后 `quantity <= 0` 时不再向柜台发 0 手单，改为返回空回执（与回测一致）。一处有意偏离：卖出全平在实盘取**可用**持仓而非总持仓，因为 A 股 T+1 下按总量报单会被柜台整单拒绝，取可用量退化为部分卖出。
 - 修复 `broker_live` 下 `get_instrument()` / `get_instruments()` / `get_instrument_field()` 对**任何**标的都抛 `KeyError` 的问题：`run_live` 原先从不调用 `_set_instrument_snapshots`，策略侧快照字典恒为空。现由 `LiveRunner` 从传入的 `Instrument` 列表灌入。受实盘入口形态限制，`Instrument` 仅能回读 9 个字段，`option_type` / `strike_price` / `expiry_date` / `underlying_symbol` / `settlement_*` 在实盘快照中为 `None`（回测不受影响，仍由 `InstrumentConfig` 灌入完整字段）。
 - 修复 `client_order_id` 跨会话撞号的问题：原格式 `{broker}-coid-{序号}` 的序号每次 `run_live` 从 0 起，重启后第一笔单又是 `...-coid-1`，与柜台里同名历史委托冲突——把 `client_order_id` 当幂等键的柜台会直接拒单（实测中间件返回 409 Conflict）。现格式为 `{broker}-{8 位会话标记}-{会话内序号}`，会话标记每次启动重新生成，跨重启与多进程并行均不撞号。

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.36"
+version = "0.3.37"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.36"
+version = "0.3.37"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/strategy.md
+++ b/docs/en/guide/strategy.md
@@ -581,6 +581,13 @@ In AKQuant, order status transitions are as follows:
     ```
 *   **Target Orders**:
     Automatically calculates buy/sell quantities to adjust the position to a target value.
+
+    The delta is computed against the **projected position** — the settled position plus the
+    expected effect of *all* in-flight orders from the same bar. This is what makes repeated
+    calls within one bar converge: after `close_position()` has queued a full exit, a
+    following `order_target_*()` sees a projected position of zero rather than the stale
+    settled one (computing against the settled position would add a second same-direction
+    order on top of the exit, selling more than held).
     ```python
     # Adjust position to 50% of total assets
     self.order_target_percent(target_percent=0.5, symbol="AAPL", price=None)
@@ -603,6 +610,29 @@ In AKQuant, order status transitions are as follows:
     self.cancel_order(order_id) # Cancel specific order
     self.cancel_all_orders()    # Cancel all open orders
     ```
+
+#### Position effect (open vs close)
+
+An order carries `side + position_effect`, not just `side`:
+
+*   `buy()` / `sell()` default to `position_effect="auto"` and split into `close + open`
+    legs before execution, sized against the **closable position** — the settled position
+    minus what in-flight close/reduce orders from the same bar already claim. This is what
+    makes a flip split correctly: after `close_position()` claims the closable quantity, a
+    following `buy()` is classified as `open` rather than a second `close`.
+*   `short()` is `side="Sell", position_effect="open"`; `cover()` is
+    `side="Buy", position_effect="close"`.
+*   Explicit control: `self.submit_order(..., position_effect="open" | "close" |
+    "close_today" | "close_yesterday")`. Under `broker_live + CTP` these map to the
+    counter's offset flags.
+
+In-flight *open* orders are deliberately not projected here: they may never fill, and
+ignoring them biases the split toward `open`, i.e. toward reserving more margin. Note the
+contrast with target orders above, which project *all* in-flight orders — the two answer
+different questions ("how much can still be closed" vs "where will the position end up").
+
+The resulting legs are visible in `orders_df.position_effect` (at submission) and
+`executions_df.position_effect` (after the fill).
 
 ### 5.3 Execution Policy (Fill Mode)
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -1145,8 +1145,18 @@ Backtest result object.
 
 *   `metrics_df`: Performance metrics DataFrame. Core trade-state fields include `closed_trade_count`, `execution_count`, and `open_position_count`.
 *   `trades_df`: Trade history DataFrame.
-*   `orders_df`: Order history DataFrame.
-*   `executions_df`: Execution fills DataFrame (prefers Rust IPC/dict fast export path).
+*   `orders_df`: Order history DataFrame. Includes `position_effect`, `reduce_only`, and `created_at_iso` / `updated_at_iso` (UTC ISO strings).
+*   `executions_df`: Execution fills DataFrame (prefers Rust IPC/dict fast export path). Includes `position_effect` and `timestamp_iso`.
+
+!!! tip "Position effect (`position_effect`)"
+    Values are `auto` / `open` / `close` / `close_today` / `close_yesterday` —
+    the **same vocabulary** accepted by order submission, so it can be filtered
+    directly (e.g. `df[df.position_effect == "close_today"]`).
+
+    With the default `position_effect="auto"`, `buy()` / `sell()` split into
+    close and open legs automatically: a flip emits the `close` leg first, then
+    the `open` leg. These columns are where that split is visible — in the order
+    table at submission time, in the execution table after the fill.
 *   `positions_df`: Daily position details.
 *   `equity_curve`: Equity curve.
 *   `cash_curve`: Cash curve.

--- a/docs/zh/guide/strategy.md
+++ b/docs/zh/guide/strategy.md
@@ -811,6 +811,11 @@ class SMACrossStrategy(Strategy):
     *   `self.order_target(target=100, symbol="AAPL")`: 调整持仓数量至 100 股。
     *   `self.order_target_percent(target_percent=0.5, symbol="AAPL")`: 调整持仓至总资产的 50%。
     *   `self.order_target_value(target_value=10000, symbol="AAPL")`: 调整持仓至 10000 元市值。
+    *   目标仓位系列（含 `close_position()`）按**投影持仓**算差额，即结算持仓叠加同一根
+        bar 内**全部**在途单的预期效果。因为它们问的是"仓位最终落在哪"，若按结算持仓算，
+        同一根 bar 内连续调用会以同一基准重复下单（例如先 `close_position()` 再
+        `order_target_percent()`，会在全平单之外再补一笔同向单，卖超持仓）。
+        与 `buy()` / `sell()` 的 `auto` 拆腿只扣在途平仓单不同——两者问的问题不同。
     *   `self.rebalance_weights(target_weights={"AAPL":0.4,"MSFT":0.3}, liquidate_unmentioned=True, rebalance_tolerance=0.01)`: 按多标的权重统一调仓。
         *   默认权重和不超过 `1.0`，如需超过请设置 `allow_leverage=True`。
         *   该接口仍然更偏向 long-only 组合管理；如需正负目标仓位，请优先使用 `rebalance_positions()`。
@@ -847,7 +852,9 @@ def on_timer(self, payload: str):
 
 AKQuant 当前的订单语义已经不再是单纯的 `side`，而是 `side + position_effect`：
 
-*   `buy()` / `sell()` 默认使用 `position_effect="auto"`，进入执行前会按当前净仓自动拆成 `close + open`。
+*   `buy()` / `sell()` 默认使用 `position_effect="auto"`，进入执行前会按**可平仓**自动拆成 `close + open`。
+    可平仓 = 结算持仓 − 同一根 bar 内已提交未成交的平仓/减仓单占用。所以「先 `close_position()`
+    再 `buy()`」这类反手写法能拆对：第一笔占掉可平量后，第二笔判为 `open`。
 *   `short()` 默认等价于 `side="Sell", position_effect="open"`。
 *   `cover()` 默认等价于 `side="Buy", position_effect="close"`。
 *   高级场景可直接使用：

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -1251,8 +1251,16 @@ class RiskConfig:
 
 *   `metrics_df`: 绩效指标表格 (Sharpe, Drawdown 等)。其中交易相关主字段包括 `closed_trade_count`、`execution_count`、`open_position_count`。
 *   `trades_df`: 所有平仓交易记录表格。
-*   `orders_df`: 所有委托记录表格。
-*   `executions_df`: 所有成交流水表格（优先使用 Rust IPC/dict 快速导出）。
+*   `orders_df`: 所有委托记录表格。含 `position_effect`（开平语义）、`reduce_only`、`created_at_iso` / `updated_at_iso`（UTC ISO 串）。
+*   `executions_df`: 所有成交流水表格（优先使用 Rust IPC/dict 快速导出）。含 `position_effect` 与 `timestamp_iso`。
+
+!!! tip "开平语义（`position_effect`）"
+    取值为 `auto` / `open` / `close` / `close_today` / `close_yesterday`，与下单
+    入参**同一套词表**，可直接用于筛选（如 `df[df.position_effect == "close_today"]`）。
+
+    `buy()` / `sell()` 在默认的 `position_effect="auto"` 下会自动拆开平腿：反手
+    时先出 `close` 腿再出 `open` 腿。这两列就是查看拆腿结果的地方——委托表在
+    下单时即可见，成交表在成交后可见。
 *   `positions_df`: 每日持仓详情。
 *   `equity_curve`: 权益曲线 (List[Tuple[timestamp, value]])。
 *   `cash_curve`: 现金曲线 (List[Tuple[timestamp, value]])。

--- a/docs/zh/textbook/05_strategy.md
+++ b/docs/zh/textbook/05_strategy.md
@@ -227,6 +227,10 @@ result = aq.run_backtest(
 
 一键平仓。无论当前持有多头还是空头，都会发出相反方向的市价单将其平掉。
 
+它按**投影持仓**（结算持仓 + 同一根 bar 内全部在途单的预期效果）算差额，所以在同一根
+bar 内重复调用是幂等的：第一次已排下全平单，第二次算出差额为 0、不再下单。`order_target*`
+系列同理，见 5.3.4 与第 7 章。
+
 ### 5.3.4 `rebalance_positions(target_positions, ...)`
 
 这是面向高级调仓场景的新接口。它按“目标持仓数量”工作，而不是按目标权重工作。
@@ -277,10 +281,23 @@ print(plan["skipped_legs"])
 *   `short()` -> `side=Sell, position_effect=open`
 *   `cover()` -> `side=Buy, position_effect=close`
 
-其中 `auto` 不是简单标签，而是会在执行前按当前净仓自动拆单：
+其中 `auto` 不是简单标签，而是会在执行前按**可平仓**自动拆单：
 
 *   `buy 150` 且当前持仓为 `-100` -> `close 100 + open 50`
 *   `sell 150` 且当前持仓为 `+100` -> `close 100 + open 50`
+
+这里的"可平仓"是**结算持仓减去同一根 bar 内已提交未成交的平仓/减仓单占用**，不是单纯的
+结算持仓。差别只在同一根 bar 里连续下单时才显现，但很关键：
+
+```python
+# 空头反手做多：两次调用在同一根 bar 内
+self.close_position(symbol)   # 提交 close 1 手，此刻结算仓仍是 -1
+self.buy(symbol, 1)           # 可平量已被上一笔占掉 -> 判为 open（而非又一笔 close）
+```
+
+若按结算持仓拆，第二笔会被误判成平仓——两笔都标 `close`，且平仓腿在风控投影里
+仓位变化为 0，等于零保证金过闸。这与 vn.py `OffsetConverter`、RQAlpha `closable`
+的口径一致：只扣在途**平仓**单，不投影在途开仓单（偏向判为开仓，即偏向多预留保证金）。
 
 你也可以直接显式提交：
 

--- a/docs/zh/textbook/07_futures.md
+++ b/docs/zh/textbook/07_futures.md
@@ -32,6 +32,16 @@ python examples/textbook/ch07_futures.py
 1. 脚本能够完成期货回测并输出收益与风险指标。
 2. 结果中可体现保证金与杠杆对权益波动的放大效应。
 3. 调整合约参数或杠杆后，策略波动率变化符合预期。
+4. 日志里能看到至少一次"趋势反转"，且 `MA=` 后是真实数值而非 `nan`。
+   若均线恒为 `nan`，说明 `warmup_period` 小于 `get_history(count=...)` 要求的根数——
+   本例用 `count=ma_window + 1`，所以 `warmup_period` 也必须是 `ma_window + 1`。
+5. 反手时的开平拆腿可在成交流水里核对：
+
+    ```python
+    result.executions_df[["bar_index", "side", "position_effect", "quantity"]]
+    ```
+
+    多头转空头应看到 `sell` + `close` 紧跟 `sell` + `open` 两笔，而不是两笔 `close`。
 
 ## 7.0 AKQuant 中国期货配置速览
 

--- a/examples/textbook/ch07_futures.py
+++ b/examples/textbook/ch07_futures.py
@@ -58,7 +58,9 @@ class FuturesTrendStrategy(Strategy):
         """初始化策略."""
         super().__init__()
         self.ma_window = 10
-        self.warmup_period = 10
+        # 下面用 get_history(count=ma_window + 1) 取 11 根，warmup 必须 >= 11，
+        # 否则首位是 NaN，均线恒为 NaN，信号会永远锁在初值上（示例跑不出反转）。
+        self.warmup_period = self.ma_window + 1
 
         # 记录上一次的信号，避免重复发单
         self.last_signal = 0
@@ -186,10 +188,12 @@ if __name__ == "__main__":
     # 假设最后一天持仓 1 手，价格 3200
     # 保证金 = 3200 * 10 * 1 * 0.1 = 3200 元
     # 杠杆倍数 = 3200 * 10 / 3200 = 10 倍
+    # metrics_df 的期末权益键是 end_market_value（等于 equity_curve 末值）。
+    # 注意不是 end_portfolio_value——那个键不存在，配上 else 兜底会静默打印 0.00。
     metrics = result.metrics_df
-    final_val = (
-        metrics.loc["end_portfolio_value", "value"]
-        if "end_portfolio_value" in metrics.index
+    end_value = (
+        metrics.loc["end_market_value", "value"]
+        if "end_market_value" in metrics.index
         else 0.0
     )
-    print(f"最终权益: {float(str(final_val)):.2f}")
+    print(f"最终权益: {float(str(end_value)):.2f}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.36"
+version = "0.3.37"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}

--- a/python/akquant/__init__.py
+++ b/python/akquant/__init__.py
@@ -8,7 +8,7 @@ try:
 except metadata.PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
-__engine_rule_version__ = "1.3.6"  # Increment on behavior-changing updates
+__engine_rule_version__ = "1.3.7"  # Increment on behavior-changing updates
 
 from . import akquant as _akquant
 from . import log as _log

--- a/python/akquant/akquant.pyi
+++ b/python/akquant/akquant.pyi
@@ -2734,6 +2734,28 @@ class StrategyContext:
         """
         ...
 
+    def get_closable_position(self, symbol: str) -> float:
+        r"""
+        获取可平持仓:结算仓扣除在途**平仓/减仓**单占用后的剩余可平量.
+
+        用于 `buy()` / `sell()` 在 ``position_effect="auto"`` 下拆开平腿。
+
+        :param symbol: 标的代码
+        :return: 可平方向的剩余持仓 (Long为正, Short为负)
+        """
+        ...
+
+    def get_projected_position(self, symbol: str) -> float:
+        r"""
+        获取投影持仓:结算仓叠加**全部**在途单的预期效果.
+
+        用于 ``order_target*`` / ``close_position`` 等目标仓位语义算 delta。
+
+        :param symbol: 标的代码
+        :return: 投影后的持仓数量 (Long为正, Short为负)
+        """
+        ...
+
     def get_available_position(self, symbol: str) -> float:
         r"""
         获取当前可用持仓数量.

--- a/python/akquant/backtest/result.py
+++ b/python/akquant/backtest/result.py
@@ -20,6 +20,27 @@ import pandas as pd
 from ..akquant import BacktestResult as RustBacktestResult
 from ..akquant import ClosedTrade, Order, Trade
 
+_POSITION_EFFECT_TEXT = {
+    "auto": "auto",
+    "open": "open",
+    "close": "close",
+    "closetoday": "close_today",
+    "closeyesterday": "close_yesterday",
+}
+
+
+def _position_effect_text(value: Any) -> Optional[str]:
+    """把 ``PositionEffect`` 枚举归一成规范词表，与 Rust 快路径口径一致.
+
+    必须与 ``PositionEffect::as_canonical_str`` 输出同一套词表（``close_today``
+    而非 ``closetoday``）：``position_effect`` 是可回传值，用户按 API 入参词表
+    筛 DataFrame，两边不一致会静默匹配不到。
+    """
+    if value is None:
+        return None
+    name = str(value).rsplit(".", 1)[-1].lower()
+    return _POSITION_EFFECT_TEXT.get(name, name)
+
 
 class BacktestResult:
     """
@@ -494,6 +515,12 @@ class BacktestResult:
             - status (str): 'filled', 'cancelled', 'rejected', etc.
             - time_in_force (str): 'gtc', 'day', 'ioc', etc.
             - created_at (datetime): Creation time.
+            - position_effect (str): 开平语义，'auto' / 'open' / 'close' /
+              'close_today' / 'close_yesterday'，与下单入参同一词表。
+              ``buy()`` / ``sell()`` 的 auto 拆腿结果在此可见。
+            - reduce_only (bool): 是否只减仓（为真时不产生开仓腿）。
+            - created_at_iso (str): 创建时间的 UTC ISO 8601 串。
+            - updated_at_iso (str): 更新时间的 UTC ISO 8601 串。
         """
         if not hasattr(self._raw, "orders_df"):
             return pd.DataFrame()
@@ -667,7 +694,20 @@ class BacktestResult:
 
     @cached_property
     def executions_df(self) -> pd.DataFrame:
-        """Get execution reports (fills) as a Pandas DataFrame."""
+        """Get execution reports (fills) as a Pandas DataFrame.
+
+        Columns:
+            - id / order_id / symbol: 成交号、来源订单号、标的。
+            - side (str): 'buy' 或 'sell'。
+            - quantity / price / commission (float): 成交量、成交价、手续费。
+            - timestamp (datetime): 成交时间（已按结果时区本地化）。
+            - timestamp_iso (str): 同一时刻的 UTC ISO 8601 串，便于跨系统对账。
+            - bar_index (int): 成交所在 Bar 序号。
+            - owner_strategy_id (str): 归属策略。
+            - position_effect (str): 开平语义，'auto' / 'open' / 'close' /
+              'close_today' / 'close_yesterday'，与下单入参同一词表。反手时
+              ``close`` 腿与 ``open`` 腿在此区分（issue #361）。
+        """
         executions = cast(List[Trade], getattr(self._raw, "executions", []))
         if not executions:
             return pd.DataFrame()
@@ -703,14 +743,22 @@ class BacktestResult:
                         "id": t.id,
                         "order_id": t.order_id,
                         "symbol": t.symbol,
-                        "side": str(t.side).lower(),
+                        # 削掉 `OrderSide.` 前缀：Rust 快路径导出的是 `sell`，
+                        # 此处不削会得到 `orderside.sell`，同一列的值随走哪条
+                        # 路而变。
+                        "side": str(t.side).rsplit(".", 1)[-1].lower(),
                         "quantity": float(t.quantity),
                         "price": float(t.price),
                         "commission": float(t.commission),
                         "timestamp": t.timestamp,
+                        "timestamp_iso": getattr(t, "timestamp_iso", None),
                         "bar_index": t.bar_index,
                         "owner_strategy_id": getattr(
                             t, "owner_strategy_id", fallback_owner_strategy_id
+                        ),
+                        # 开平语义（#361）：auto 拆腿的结果只有这一列看得见
+                        "position_effect": _position_effect_text(
+                            getattr(t, "position_effect", None)
                         ),
                     }
                 )

--- a/python/akquant/execution/base.py
+++ b/python/akquant/execution/base.py
@@ -15,6 +15,22 @@ class ExecutionBackend(Protocol):
     def get_available_position(self, symbol: str | None = None) -> float:
         """获取指定标的可用持仓数量."""
 
+    def get_closable_position(self, symbol: str | None = None) -> float:
+        """获取可平持仓：结算仓扣除在途平仓/减仓单占用后的剩余可平量.
+
+        供 ``buy()`` / ``sell()`` 在 ``position_effect="auto"`` 下拆开平腿使用。
+        结算仓不含同一 on_bar 内已提交未成交的在途单，直接用它拆腿会把"先平后开"
+        的反手第二腿误判成平仓（issue #361）。只投影减仓方向的在途单。
+        """
+
+    def get_projected_position(self, symbol: str | None = None) -> float:
+        """获取投影持仓：结算仓叠加全部在途单的预期效果.
+
+        供 ``order_target*`` / ``close_position`` 算 delta 使用——它们问的是
+        "仓位最终会落在哪"，故开仓与平仓在途单都要计入，否则同一 on_bar 内
+        连续调用会按同一个结算仓重复下单。
+        """
+
     def get_positions(self) -> dict[str, float]:
         """获取所有持仓信息."""
 

--- a/python/akquant/execution/sim.py
+++ b/python/akquant/execution/sim.py
@@ -23,6 +23,14 @@ class SimExecution:
         """获取指定标的可用持仓数量."""
         return api._sim_get_available_position(self._s, symbol)
 
+    def get_closable_position(self, symbol: str | None = None) -> float:
+        """获取可平持仓（结算仓 − 在途平仓/减仓单占用）."""
+        return api._sim_get_closable_position(self._s, symbol)
+
+    def get_projected_position(self, symbol: str | None = None) -> float:
+        """获取投影持仓（结算仓 + 全部在途单效果）."""
+        return api._sim_get_projected_position(self._s, symbol)
+
     def get_positions(self) -> dict[str, float]:
         """获取所有持仓信息."""
         return api._sim_get_positions(self._s)

--- a/python/akquant/gateway/broker_execution.py
+++ b/python/akquant/gateway/broker_execution.py
@@ -59,6 +59,28 @@ class BrokerExecution:
             _resolve_symbol(self._s, symbol), 0.0
         )
 
+    def get_closable_position(self, symbol: str | None = None) -> float:
+        """获取可平持仓; broker_live 下降级为结算仓(理由同 get_projected_position)."""
+        return self.get_position(symbol)
+
+    def get_projected_position(self, symbol: str | None = None) -> float:
+        """获取投影持仓; broker_live 下降级为结算仓.
+
+        回测侧该方法把同周期在途单计入,供 auto 拆腿与目标仓位算 delta(#361)。实盘
+        无法照做: 柜台挂单快照 ``UnifiedOrderSnapshot`` 只有 ``position_effect``
+        与 ``filled_quantity``, **没有** ``side`` 和 ``quantity``——
+        ``map_order_snapshot`` 的这两个字段取自 ``request``, 而 ``get_open_orders``
+        并不传 ``request``, 故算不出 ``remaining`` 也判不了方向。
+
+        因此这里返回结算仓, 与 :meth:`get_position` 同值: 保持协议完整(不抛
+        AttributeError)且不用缺失数据伪造投影。实盘开平通常已由柜台/网关侧
+        转换(参见 vn.py ``OffsetConverter`` 的定位), 代价是实盘"先平后开"的
+        反手第二腿仍可能被标成平仓。要真正修实盘需给
+        ``UnifiedOrderSnapshot`` 补 ``side`` / ``quantity``, 会牵动各 broker 插件
+        的 mapper, 不在本次范围内。
+        """
+        return self.get_position(symbol)
+
     def get_positions(self) -> dict[str, float]:
         """获取所有持仓信息."""
         return dict(self._cache.positions())

--- a/python/akquant/strategy_trading_api.py
+++ b/python/akquant/strategy_trading_api.py
@@ -390,7 +390,12 @@ def _submit_buy_side_orders(
         return []
 
     if position_effect == "auto":
-        current_position = float(strategy.ctx.get_position(symbol))
+        # 用可平持仓而非结算仓：同一 on_bar 内已提交未成交的平仓单必须扣除，
+        # 否则"先平后开"的反手第二腿会被误判成平仓（#361）。这里刻意不投影在途
+        # 开仓单，偏向判为开仓即偏向多预留保证金（与 vn.py / RQAlpha 一致）。
+        current_position = _position_from_execution(
+            strategy, symbol, "get_closable_position"
+        )
         legs = _resolve_auto_position_effect_legs(
             "buy", current_position, float(quantity), reduce_only
         )
@@ -556,7 +561,10 @@ def _submit_sell_side_orders(
         return []
 
     if position_effect == "auto":
-        current_position = float(strategy.ctx.get_position(symbol))
+        # 与 buy 侧对称：可平持仓已扣除在途平仓单，避免反手第二腿误判（#361）。
+        current_position = _position_from_execution(
+            strategy, symbol, "get_closable_position"
+        )
         legs = _resolve_auto_position_effect_legs(
             "sell", current_position, float(quantity), reduce_only
         )
@@ -1046,6 +1054,21 @@ def order_target(
     return _target_to_orders(strategy, symbol, target, price, **kwargs)
 
 
+def _position_from_execution(strategy: Any, symbol: str, method: str) -> float:
+    """按名取执行后端的持仓口径，缺失则退回 ``get_position``.
+
+    ``get_closable_position`` / ``get_projected_position`` 是 #361 新增到
+    :class:`ExecutionBackend` 协议上的方法。协议是公开且 ``runtime_checkable``
+    的，第三方自定义后端不会有这两个方法，故此处降级而非抛错——代价是这类后端
+    维持旧行为（结算仓口径），需自行实现新方法才能获得修复。
+    """
+    execution = strategy.execution
+    getter = getattr(execution, method, None)
+    if callable(getter):
+        return float(getter(symbol))
+    return float(execution.get_position(symbol))
+
+
 def _target_to_orders(
     strategy: Any,
     symbol: Optional[str] = None,
@@ -1058,7 +1081,11 @@ def _target_to_orders(
     if target_qty is None:
         raise ValueError("target requires a target quantity (目标持仓数量)")
     symbol = resolve_symbol(strategy, symbol)
-    current_qty = float(strategy.execution.get_position(symbol))
+    # 目标仓位问的是"仓位最终会落在哪"，故按投影持仓（含全部在途单）算 delta。
+    # 用结算仓会让同一 on_bar 内的连续调用按同一基准重复下单——例如先
+    # close_position 再 order_target_percent，会在全平单之外再补一笔卖单造成
+    # 超卖（与 #361 同源，均是"结算仓不含在途单"）。
+    current_qty = _position_from_execution(strategy, symbol, "get_projected_position")
     delta_qty = target_qty - current_qty
 
     if round_to_lot:
@@ -1595,6 +1622,20 @@ def _sim_get_available_position(strategy: Any, symbol: Optional[str] = None) -> 
     if strategy.ctx is None:
         return 0.0
     return float(strategy.ctx.get_available_position(resolve_symbol(strategy, symbol)))
+
+
+def _sim_get_closable_position(strategy: Any, symbol: Optional[str] = None) -> float:
+    """可平持仓：结算仓 − 在途平仓/减仓单占用（auto 拆腿用，见 #361）."""
+    if strategy.ctx is None:
+        return 0.0
+    return float(strategy.ctx.get_closable_position(resolve_symbol(strategy, symbol)))
+
+
+def _sim_get_projected_position(strategy: Any, symbol: Optional[str] = None) -> float:
+    """投影持仓：结算仓 + 全部在途单效果（目标仓位算 delta 用）."""
+    if strategy.ctx is None:
+        return 0.0
+    return float(strategy.ctx.get_projected_position(resolve_symbol(strategy, symbol)))
 
 
 def _sim_get_positions(strategy: Any) -> Dict[str, float]:

--- a/src/analysis/python.rs
+++ b/src/analysis/python.rs
@@ -275,6 +275,22 @@ impl BacktestResult {
                 .map(|t| t.owner_strategy_id.clone())
                 .collect::<Vec<_>>(),
         );
+        // 开平语义(#361):auto 拆腿的结果只有在这一列才看得见。
+        let s_position_effect = Series::new(
+            "position_effect".into(),
+            executions
+                .iter()
+                .map(|t| t.position_effect.as_canonical_str().to_string())
+                .collect::<Vec<_>>(),
+        );
+        // UTC ISO 串:与已本地化的 `timestamp` 并存,便于跨系统对账/导出。
+        let s_timestamp_iso = Series::new(
+            "timestamp_iso".into(),
+            executions
+                .iter()
+                .map(|t| crate::model::order::format_timestamp_iso(t.timestamp))
+                .collect::<Vec<_>>(),
+        );
 
         let mut df = DataFrame::new_infer_height(vec![
             s_id.into(),
@@ -285,8 +301,10 @@ impl BacktestResult {
             s_price.into(),
             s_commission.into(),
             s_timestamp.into(),
+            s_timestamp_iso.into(),
             s_bar_index.into(),
             s_owner_strategy_id.into(),
+            s_position_effect.into(),
         ])
         .map_err(|e| PyValueError::new_err(e.to_string()))?;
 
@@ -377,8 +395,10 @@ impl BacktestResult {
         let mut prices = Vec::with_capacity(n);
         let mut commissions = Vec::with_capacity(n);
         let mut timestamps = Vec::with_capacity(n);
+        let mut timestamp_isos = Vec::with_capacity(n);
         let mut bar_indexes = Vec::with_capacity(n);
         let mut owner_strategy_ids = Vec::with_capacity(n);
+        let mut position_effects = Vec::with_capacity(n);
 
         for t in &self.executions {
             ids.push(t.id.clone());
@@ -389,8 +409,10 @@ impl BacktestResult {
             prices.push(t.price.to_f64().unwrap_or(0.0));
             commissions.push(t.commission.to_f64().unwrap_or(0.0));
             timestamps.push(t.timestamp);
+            timestamp_isos.push(crate::model::order::format_timestamp_iso(t.timestamp));
             bar_indexes.push(t.bar_index);
             owner_strategy_ids.push(t.owner_strategy_id.clone());
+            position_effects.push(t.position_effect.as_canonical_str().to_string());
         }
 
         let dict = pyo3::types::PyDict::new(py);
@@ -402,8 +424,10 @@ impl BacktestResult {
         dict.set_item("price", prices)?;
         dict.set_item("commission", commissions)?;
         dict.set_item("timestamp", timestamps)?;
+        dict.set_item("timestamp_iso", timestamp_isos)?;
         dict.set_item("bar_index", bar_indexes)?;
         dict.set_item("owner_strategy_id", owner_strategy_ids)?;
+        dict.set_item("position_effect", position_effects)?;
         Ok(dict.into())
     }
 
@@ -659,6 +683,10 @@ impl BacktestResult {
         let mut tags = Vec::with_capacity(n);
         let mut reject_reasons = Vec::with_capacity(n);
         let mut owner_strategy_ids = Vec::with_capacity(n);
+        let mut position_effects = Vec::with_capacity(n);
+        let mut reduce_onlys = Vec::with_capacity(n);
+        let mut created_at_isos = Vec::with_capacity(n);
+        let mut updated_at_isos = Vec::with_capacity(n);
 
         for o in &self.orders {
             ids.push(o.id.clone());
@@ -690,6 +718,11 @@ impl BacktestResult {
             tags.push(o.tag.clone());
             reject_reasons.push(o.reject_reason.clone());
             owner_strategy_ids.push(o.owner_strategy_id.clone());
+            // 开平语义(#361):auto 拆腿在下单时就定了,订单表比成交表更早暴露。
+            position_effects.push(o.position_effect.as_canonical_str().to_string());
+            reduce_onlys.push(o.reduce_only);
+            created_at_isos.push(crate::model::order::format_timestamp_iso(o.created_at));
+            updated_at_isos.push(crate::model::order::format_timestamp_iso(o.updated_at));
         }
 
         let dict = pyo3::types::PyDict::new(py);
@@ -709,6 +742,10 @@ impl BacktestResult {
         dict.set_item("updated_at", updated_dates)?;
         dict.set_item("tag", tags)?;
         dict.set_item("reject_reason", reject_reasons)?;
+        dict.set_item("position_effect", position_effects)?;
+        dict.set_item("reduce_only", reduce_onlys)?;
+        dict.set_item("created_at_iso", created_at_isos)?;
+        dict.set_item("updated_at_iso", updated_at_isos)?;
         dict.set_item("owner_strategy_id", owner_strategy_ids)?;
 
         Ok(dict.into())

--- a/src/context.rs
+++ b/src/context.rs
@@ -444,6 +444,55 @@ impl StrategyContext {
             last_prices: init.last_prices,
         }
     }
+
+    /// 把在途订单投影进持仓,返回预期持仓。
+    ///
+    /// 合并 `active_orders`(往期挂单)与 `orders`(本回调已提交),口径对齐
+    /// `EngineCore::current_frozen_cash`:只认非终态(`New`/`Submitted`/
+    /// `PartiallyFilled`),按 `remaining = quantity - filled_quantity` 折算。
+    ///
+    /// `reducing_only=true` 只投影**减仓**方向的在途单(平仓/`reduce_only`),
+    /// 用于 auto 拆腿判定"还能平多少";`false` 投影全部在途单(按各自
+    /// `position_effect`),用于目标仓位算 delta 判定"仓位将落在哪"。
+    fn project_pending_position(&self, symbol: &str, reducing_only: bool) -> Decimal {
+        let mut projected = self
+            .positions
+            .get(symbol)
+            .copied()
+            .unwrap_or(Decimal::ZERO);
+        for order in self.active_orders.iter().chain(self.orders.iter()) {
+            if order.symbol != symbol {
+                continue;
+            }
+            if !matches!(
+                order.status,
+                crate::model::OrderStatus::New
+                    | crate::model::OrderStatus::Submitted
+                    | crate::model::OrderStatus::PartiallyFilled
+            ) {
+                continue;
+            }
+            let reducing = crate::model::is_position_reducing_order(order);
+            if reducing_only && !reducing {
+                continue;
+            }
+            let remaining = order.quantity - order.filled_quantity;
+            if remaining <= Decimal::ZERO {
+                continue;
+            }
+            // 减仓单统一按 Close 语义投影:`project_position_after` 已对平仓量
+            // 做 `min(remaining, |pos|)` 封顶,等价于 vn.py 的 `min(frozen, pos)`。
+            // 净仓模型下 CloseToday / CloseYesterday 与 Close 同效。
+            let effect = if reducing {
+                crate::model::PositionEffect::Close
+            } else {
+                order.position_effect
+            };
+            projected =
+                crate::model::project_position_after(order.side, effect, projected, remaining);
+        }
+        projected
+    }
 }
 
 #[gen_stub_pymethods]
@@ -1045,6 +1094,43 @@ impl StrategyContext {
         self.positions
             .get(&symbol)
             .unwrap_or(&Decimal::ZERO)
+            .to_f64()
+            .unwrap_or_default()
+    }
+
+    /// 获取可平持仓:结算仓扣除在途**平仓/减仓**单占用后的剩余可平量.
+    ///
+    /// 用于 `buy()` / `sell()` 在 ``position_effect="auto"`` 下拆开平腿。结算仓
+    /// 不含同一 on_bar 内已提交、未成交的在途单,直接用它拆腿会把"先平后开"的
+    /// 反手第二腿误判成平仓(issue #361)。本方法是 :meth:`get_buying_power`
+    /// 的持仓镜像:同样合并 ``active_orders``(往期挂单)+ ``orders``(本回调已提交)。
+    ///
+    /// **只**投影减仓方向的在途单,不投影在途开仓单——与 vn.py
+    /// ``OffsetConverter`` / RQAlpha ``closable`` 一致。在途开仓单未必成交,不投
+    /// 影它可使 auto 拆腿偏向判为开仓,即偏向**多预留**保证金(安全侧)。
+    ///
+    /// :param symbol: 标的代码
+    /// :return: 可平方向的剩余持仓 (Long为正, Short为负)
+    fn get_closable_position(&self, symbol: String) -> f64 {
+        self.project_pending_position(&symbol, true)
+            .to_f64()
+            .unwrap_or_default()
+    }
+
+    /// 获取投影持仓:结算仓叠加**全部**在途单的预期效果.
+    ///
+    /// 用于 ``order_target*`` / ``close_position`` 等目标仓位语义算 delta:它们问
+    /// 的是"仓位最终会落在哪",故开仓与平仓在途单都要计入,否则同一 on_bar 内
+    /// 连续调用会按同一个结算仓重复下单(如先 ``close_position`` 再
+    /// ``order_target_percent`` 会在全平单之外再补一笔卖单,形成超卖)。
+    ///
+    /// 与 :meth:`get_closable_position` 的取舍不同:那里刻意不投影在途开仓单以
+    /// 偏向安全侧;这里必须投影,否则目标仓位不收敛。
+    ///
+    /// :param symbol: 标的代码
+    /// :return: 投影后的持仓数量 (Long为正, Short为负)
+    fn get_projected_position(&self, symbol: String) -> f64 {
+        self.project_pending_position(&symbol, false)
             .to_f64()
             .unwrap_or_default()
     }

--- a/src/model/order.rs
+++ b/src/model/order.rs
@@ -53,7 +53,7 @@ fn validate_order_inputs(
     Ok(())
 }
 
-fn format_timestamp_iso(timestamp: i64) -> String {
+pub(crate) fn format_timestamp_iso(timestamp: i64) -> String {
     let secs = timestamp.div_euclid(1_000_000_000);
     let nanos = timestamp.rem_euclid(1_000_000_000) as u32;
 
@@ -121,6 +121,21 @@ pub fn reduction_priority_rank(side: OrderSide, position_effect: PositionEffect)
 
 pub fn is_reduce_first_order(side: OrderSide, position_effect: PositionEffect) -> bool {
     reduction_priority_rank(side, position_effect) == 0
+}
+
+/// 在途订单是否会减少持仓敞口(用于可平仓投影)。
+///
+/// 与 [`is_reduce_first_order`] 的区别:后者判定撮合排序优先级,把
+/// `(Sell, Auto)` 也算作 reduce;此处只认**显式**平仓语义与 `reduce_only`,
+/// 避免把 `Auto` 单误算成减仓,从而低估可开量。
+pub fn is_position_reducing_order(order: &Order) -> bool {
+    if order.reduce_only {
+        return true;
+    }
+    matches!(
+        order.position_effect,
+        PositionEffect::Close | PositionEffect::CloseToday | PositionEffect::CloseYesterday
+    )
 }
 
 #[gen_stub_pyclass]

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -209,6 +209,25 @@ pub enum PositionEffect {
     CloseYesterday,
 }
 
+impl PositionEffect {
+    /// 导出用的规范词表,与 Python 入参词表一致(``auto`` / ``open`` / ``close``
+    /// / ``close_today`` / ``close_yesterday``)。
+    ///
+    /// 不能用 `format!("{:?}").to_lowercase()`:那会把 `CloseToday` 变成
+    /// `closetoday`,而 API 接受的是 `close_today`,导致 DataFrame 按规范词筛选
+    /// 静默匹配不到。`position_effect` 与只读的 `status` 不同,它是可回传值,
+    /// 入参与导出必须同一套词表。
+    pub fn as_canonical_str(&self) -> &'static str {
+        match self {
+            PositionEffect::Auto => "auto",
+            PositionEffect::Open => "open",
+            PositionEffect::Close => "close",
+            PositionEffect::CloseToday => "close_today",
+            PositionEffect::CloseYesterday => "close_yesterday",
+        }
+    }
+}
+
 #[pymethods]
 impl PositionEffect {
     fn __hash__(&self) -> isize {

--- a/src/pipeline/stages/strategy.rs
+++ b/src/pipeline/stages/strategy.rs
@@ -53,7 +53,12 @@ impl Processor for StrategyProcessor {
             engine.ensure_strategy_slot_exists();
             engine.ensure_strategy_context_capacity();
             let slot_count = engine.strategy_slots.len();
-            let active_orders = Arc::new(engine.state.order_manager.active_orders.clone());
+            // 本周期内已知的挂单:引擎既有 active_orders,加上**前面 slot 刚提交**
+            // 的单。后者要在 slot 之间累加,否则多策略下 slot 1 看不到 slot 0 本
+            // 周期的平仓单——而 ctx.positions 是账户级全局,两边口径必须一致,
+            // 否则 auto 拆腿/目标仓位的投影会漏掉别的策略的减仓意图。
+            let mut cycle_orders = engine.state.order_manager.active_orders.clone();
+            let mut active_orders = Arc::new(cycle_orders.clone());
             let step_trades = engine.state.order_manager.current_step_trades.clone();
             let step_rejected_orders = engine
                 .state
@@ -106,6 +111,20 @@ impl Processor for StrategyProcessor {
                             .event_manager
                             .send(Event::ExecutionReport(cancelled_order, None));
                     }
+                }
+                // 只有多策略才需要在 slot 间累加(单策略下无后续 slot 会读它),
+                // 避免为单策略回测多付一次 Vec 克隆。
+                //
+                // 取本 slot Context 的 `orders` 而非上面的 `new_orders`:回测下
+                // Context 带 `event_tx`,下单直接进事件通道,`orders_arc` 恒空,
+                // `new_orders` 因此取不到东西;而 `StrategyContext::buy/sell` 无论
+                // 走哪条路都会先 push 进 `orders`(每周期由 update_state 清空)。
+                if slot_count > 1 {
+                    if let Some(Some(slot_ctx)) = engine.strategy_contexts.get(slot_index) {
+                        let ctx_ref = slot_ctx.borrow(py);
+                        cycle_orders.extend(ctx_ref.orders.iter().cloned());
+                    }
+                    active_orders = Arc::new(cycle_orders.clone());
                 }
                 for order in new_orders {
                     let _ = engine.event_manager.send(Event::OrderRequest(order));

--- a/tests/test_examples_regression.py
+++ b/tests/test_examples_regression.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import akquant as aq
 import pandas as pd
+import pytest
 
 
 def _load_example_module(module_name: str, relative_path: str) -> ModuleType:
@@ -195,3 +196,35 @@ def test_functional_multi_slot_warm_start_example_main_runs(capsys: Any) -> None
     assert "beta_resume_count=1" in output
     assert "slot_ids=['beta']" in output
     assert "done_functional_multi_slot_warm_start_demo" in output
+
+
+def test_ch07_futures_example_reports_real_equity_and_flips() -> None:
+    """ch07 期货示例须真正产出趋势反转，且期末权益不是兜底的 0.
+
+    两个历史缺陷：``warmup_period`` 比 ``get_history(count=ma_window + 1)`` 少一根，
+    均线恒为 NaN 导致信号永远锁在初值（示例从不走反手分支）；``metrics_df`` 里
+    没有 ``end_portfolio_value`` 键，用错键会静默打印 0.00。
+    """
+    module = _load_example_module(
+        "example_ch07_futures_metrics",
+        "examples/textbook/ch07_futures.py",
+    )
+
+    df = module.generate_futures_data()
+    result = aq.run_backtest(
+        strategy=module.FuturesTrendStrategy,
+        data=df,
+        initial_cash=500_000.0,
+        fill_policy=aq.CurrentClose(),
+    )
+
+    # warmup 足够 -> 均线有真值 -> 至少发生一次开仓
+    assert len(result.orders_df) > 0
+
+    metrics = result.metrics_df
+    assert "end_portfolio_value" not in metrics.index
+    assert "end_market_value" in metrics.index
+
+    end_value = float(str(metrics.loc["end_market_value", "value"]))
+    assert end_value > 0.0
+    assert end_value == pytest.approx(float(result.equity_curve.iloc[-1]))

--- a/tests/test_position_effect_flip.py
+++ b/tests/test_position_effect_flip.py
@@ -1,0 +1,332 @@
+# -*- coding: utf-8 -*-
+"""Regression for issue #361.
+
+同一根 bar 内"先平后开"的反手（``close_position()`` 紧跟 ``buy()`` / ``sell()``）
+必须拆成 Close + Open 两腿。修复前 auto 拆腿读的是**结算仓**，而结算仓不含同
+周期已提交未成交的平仓单，导致第二腿被误判成平仓：反手两笔都标 Close，且该腿
+在风控投影里 delta 为 0，等于零保证金过闸。
+
+同源问题还在 ``_target_to_orders``：它同样按结算仓算 delta，先 ``close_position``
+再 ``order_target_*`` 会在全平单之外再补一笔同向单造成超卖，故一并锁住。
+
+多策略下还有一层：``ctx.positions`` 是账户级全局，故 ``ctx.active_orders`` 也必须
+含**同周期内前面 slot 刚提交**的单，否则 slot 1 看不到 slot 0 的平仓意图，同样会
+把开仓腿误判成平仓。
+"""
+
+import akquant as aq
+import numpy as np
+import pandas as pd
+from akquant import (
+    BacktestConfig,
+    Bar,
+    ChinaFuturesConfig,
+    InstrumentConfig,
+    Strategy,
+    StrategyConfig,
+)
+from akquant.backtest import BacktestResult
+
+SYMBOL = "RB2310"
+PRICES = np.array([3500.0, 3510.0, 3520.0, 3530.0, 3540.0, 3550.0])
+
+
+def _futures_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2023-01-01", periods=len(PRICES), freq="D"),
+            "open": PRICES,
+            "high": PRICES + 5.0,
+            "low": PRICES - 5.0,
+            "close": PRICES,
+            "volume": 1_000.0,
+            "symbol": SYMBOL,
+        }
+    )
+
+
+def _run(strategy: type[Strategy], initial_cash: float = 500_000.0) -> BacktestResult:
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(initial_cash=initial_cash, commission_rate=0.0),
+        instruments_config=[
+            InstrumentConfig(
+                symbol=SYMBOL,
+                asset_type="FUTURES",
+                multiplier=10.0,
+                margin_ratio=0.1,
+            )
+        ],
+        china_futures=ChinaFuturesConfig(enforce_sessions=False),
+    )
+    return aq.run_backtest(
+        strategy=strategy,
+        data=_futures_data(),
+        config=config,
+        fill_policy=aq.CurrentClose(),
+    )
+
+
+def _effects(result: BacktestResult) -> list[str]:
+    """成交流水的 ``side-position_effect`` 序列."""
+    return [
+        f"{str(t.side).rsplit('.', 1)[-1]}-{str(t.position_effect).rsplit('.', 1)[-1]}"
+        for t in result._raw.executions
+    ]
+
+
+class _ShortToLong(Strategy):
+    """bar0 开空 1 手；bar2 ``close_position()`` + ``buy(1)`` 反手做多."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.short(bar.symbol, 1)
+        elif self.bar_index == 2:
+            self.close_position(bar.symbol)
+            self.buy(bar.symbol, 1)
+        self.bar_index += 1
+
+
+class _LongToShort(Strategy):
+    """bar0 开多 1 手；bar2 ``close_position()`` + ``sell(1)`` 反手做空."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.buy(bar.symbol, 1)
+        elif self.bar_index == 2:
+            self.close_position(bar.symbol)
+            self.sell(bar.symbol, 1)
+        self.bar_index += 1
+
+
+def test_short_to_long_flip_splits_close_then_open() -> None:
+    """空头反手做多：应为 Buy-Close + Buy-Open，而非两笔 Buy-Close（#361）."""
+    result = _run(_ShortToLong)
+
+    assert _effects(result) == ["Sell-Open", "Buy-Close", "Buy-Open"]
+
+
+def test_long_to_short_flip_splits_close_then_open() -> None:
+    """多头反手做空：与做多方向对称，应为 Sell-Close + Sell-Open."""
+    result = _run(_LongToShort)
+
+    assert _effects(result) == ["Buy-Open", "Sell-Close", "Sell-Open"]
+
+
+def test_flip_reaches_opposite_position() -> None:
+    """标签修正不得改变最终净仓：-1 手反手后应为 +1 手."""
+    result = _run(_ShortToLong)
+    positions = result.positions_df
+
+    assert float(positions["long_shares"].iloc[-1]) == 1.0
+    assert float(positions["short_shares"].iloc[-1]) == 0.0
+
+
+class _FlipOversized(Strategy):
+    """空 1 手后 ``close_position()`` + ``buy(10)``：开仓腿须整体过保证金闸."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.short(bar.symbol, 1)
+        elif self.bar_index == 2:
+            self.close_position(bar.symbol)
+            self.buy(bar.symbol, 10)
+        self.bar_index += 1
+
+
+def test_flip_open_leg_is_margin_checked() -> None:
+    """反手的开仓腿不得借"平仓"标签零保证金过闸（#361）.
+
+    一手保证金 = 3520 × 10 × 0.1 = 3520；资金 34_000 够 9 手不够 10 手。修复前
+    ``buy(10)`` 会拆出一条假 Close 腿（投影 delta 为 0 → 免保证金）并成交，
+    只有 open-9 腿被拒。修复后整个 10 手作为开仓一体过闸，应被整单拒绝。
+    """
+    result = _run(_FlipOversized, initial_cash=34_000.0)
+    orders = result.orders_df
+
+    buys = orders[orders["side"] == "buy"]
+    # close_position 的平空单 + buy(10) 的开仓单，共两笔买单
+    assert len(buys) == 2
+    closing_buy = buys.iloc[0]
+    opening_buy = buys.iloc[1]
+
+    assert float(closing_buy["quantity"]) == 1.0
+    assert closing_buy["status"] == "filled"
+
+    assert float(opening_buy["quantity"]) == 10.0
+    assert opening_buy["status"] == "rejected"
+    # 未再出现"假平仓腿零保证金成交"：成交总量不含被拒的开仓量
+    assert float(orders[orders["status"] == "filled"]["quantity"].sum()) == 2.0
+
+
+class _CloseThenTarget(Strategy):
+    """bar0 建仓；bar2 ``close_position()`` 后紧跟 ``order_target()`` 同量目标.
+
+    目标仓位按投影持仓算 delta：全平单已把投影仓打到 0，故重建到原目标应下
+    一笔买单，而不是在全平单之外再补一笔卖单（后者会卖超持仓）。
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.buy(bar.symbol, 10)
+        elif self.bar_index == 2:
+            self.close_position(bar.symbol)
+            self.order_target(bar.symbol, 10)
+        self.bar_index += 1
+
+
+def test_close_then_target_does_not_oversell() -> None:
+    """``close_position()`` + ``order_target()`` 不得卖超持仓（与 #361 同源）."""
+    result = _run(_CloseThenTarget)
+    orders = result.orders_df
+
+    sells = orders[orders["side"] == "sell"]
+    # 只应有 close_position 的一笔全平单；不得再多一笔同向卖单
+    assert len(sells) == 1
+    assert float(sells.iloc[0]["quantity"]) == 10.0
+
+    total_sold = float(sells["quantity"].sum())
+    assert total_sold <= 10.0, f"卖出 {total_sold} 超过持仓 10"
+
+
+class _SlotCloser(Strategy):
+    """slot 0：bar0 开空 1 手，bar2 平掉（同周期提交 Buy-Close）."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.short(bar.symbol, 1)
+        elif self.bar_index == 2:
+            self.close_position(bar.symbol)
+        self.bar_index += 1
+
+
+class _SlotBuyer(Strategy):
+    """slot 1：bar2 买 1 手，须看到 slot 0 同周期的平仓单."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+        self.seen_closable: float | None = None
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 2:
+            self.seen_closable = float(self.execution.get_closable_position(bar.symbol))
+            self.buy(bar.symbol, 1)
+        self.bar_index += 1
+
+
+def test_pending_close_is_visible_across_strategy_slots() -> None:
+    """多策略同周期：slot 0 的在途平仓单必须对 slot 1 可见.
+
+    账户仓位是全局的（两个 slot 都看到 -1），故 slot 1 的买单在 slot 0 已提交
+    全平单之后应判 Open。修复前 ``active_orders`` 在 slot 循环前只快照一次，
+    slot 1 看不到 slot 0 本周期的单，会把这笔误判成 Close。
+    """
+    config = BacktestConfig(
+        strategy_config=StrategyConfig(initial_cash=500_000.0, commission_rate=0.0),
+        instruments_config=[
+            InstrumentConfig(
+                symbol=SYMBOL,
+                asset_type="FUTURES",
+                multiplier=10.0,
+                margin_ratio=0.1,
+            )
+        ],
+        china_futures=ChinaFuturesConfig(enforce_sessions=False),
+    )
+    result = aq.run_backtest(
+        strategy=_SlotCloser,
+        data=_futures_data(),
+        config=config,
+        strategies_by_slot={"beta": _SlotBuyer},
+        fill_policy=aq.CurrentClose(),
+    )
+
+    effects = _effects(result)
+    # slot 0 开空 -> slot 0 平空 -> slot 1 开多（而非第二笔 Buy-Close）
+    assert effects == ["Sell-Open", "Buy-Close", "Buy-Open"]
+
+
+def test_dataframes_expose_position_effect_columns() -> None:
+    """``orders_df`` / ``executions_df`` 须暴露开平语义与 ISO 时间列.
+
+    #361 争的就是 ``position_effect``，而这两张最常用的表原先都不导出它，
+    使用者只能自行遍历 ``Trade`` / ``Order`` 对象才看得到。
+    """
+    result = _run(_ShortToLong)
+
+    executions = result.executions_df
+    assert "position_effect" in executions.columns
+    assert "timestamp_iso" in executions.columns
+    assert executions["position_effect"].tolist() == ["open", "close", "open"]
+    # side 不带 `OrderSide.` 前缀（Rust 快路径与 Python 兜底须同口径）
+    assert executions["side"].tolist() == ["sell", "buy", "buy"]
+    assert all(s.endswith("Z") for s in executions["timestamp_iso"])
+
+    orders = result.orders_df
+    for column in (
+        "position_effect",
+        "reduce_only",
+        "created_at_iso",
+        "updated_at_iso",
+    ):
+        assert column in orders.columns
+    assert orders["position_effect"].tolist() == ["open", "close", "open"]
+    assert orders["reduce_only"].tolist() == [False, False, False]
+
+
+class _ExplicitCloseToday(Strategy):
+    """显式下 ``close_today`` 平今单，用于锁住导出词表."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.bar_index = 0
+
+    def on_bar(self, bar: Bar) -> None:
+        if self.bar_index == 0:
+            self.short(bar.symbol, 1)
+        elif self.bar_index == 2:
+            self.submit_order(
+                symbol=bar.symbol,
+                side="Buy",
+                quantity=1,
+                position_effect="close_today",
+            )
+        self.bar_index += 1
+
+
+def test_position_effect_uses_canonical_vocabulary() -> None:
+    """导出词表须与下单入参一致：``close_today``，不是 ``closetoday``.
+
+    多词枚举若按 ``format!("{:?}").to_lowercase()`` 导出会变成 ``closetoday``，
+    而 API 接受的是 ``close_today``，使用者按入参词表筛 DataFrame 会静默匹配
+    不到——与 #361 同类的静默错答。
+    """
+    result = _run(_ExplicitCloseToday)
+
+    executions = result.executions_df
+    assert executions["position_effect"].tolist() == ["open", "close_today"]
+    assert result.orders_df["position_effect"].tolist() == ["open", "close_today"]
+
+    # 按入参词表回筛必须命中
+    matched = executions[executions["position_effect"] == "close_today"]
+    assert len(matched) == 1

--- a/tests/test_strategy_extras.py
+++ b/tests/test_strategy_extras.py
@@ -5297,6 +5297,9 @@ def test_strategy_buy_auto_splits_cover_then_open() -> None:
     strategy = MyStrategy()
     ctx = MagicMock(spec=StrategyContext)
     ctx.get_position.return_value = -2.0
+    # auto 拆腿改读可平持仓（已扣除同 bar 在途平仓单，见 #361）；此处无在途单，
+    # 可平量与结算仓一致。
+    ctx.get_closable_position.return_value = -2.0
     ctx.cash = 100000.0
     ctx.buy.side_effect = ["oid-close", "oid-open"]
     strategy.ctx = ctx
@@ -5396,6 +5399,11 @@ def test_strategy_rebalance_positions_supports_signed_targets() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 100.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 100.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="margin", enable_short_sell=True)
     strategy.ctx = ctx
 
@@ -5536,6 +5544,11 @@ def test_strategy_rebalance_positions_missing_price_mode_fail() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 10.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 10.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="cash", enable_short_sell=False)
     strategy.ctx = ctx
 
@@ -5604,6 +5617,11 @@ def test_strategy_rebalance_positions_missing_price_mode_skip() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 10.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 10.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="cash", enable_short_sell=False)
     strategy.ctx = ctx
 
@@ -5673,6 +5691,11 @@ def test_strategy_rebalance_positions_missing_price_mode_ignore() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 10.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 10.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="cash", enable_short_sell=False)
     strategy.ctx = ctx
 
@@ -5744,6 +5767,11 @@ def test_strategy_rebalance_positions_records_explainable_plan() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 10.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 10.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="cash", enable_short_sell=False)
     strategy.ctx = ctx
 
@@ -5817,6 +5845,11 @@ def test_strategy_rebalance_positions_plan_tracks_skipped_legs() -> None:
     ctx.get_position.side_effect = lambda symbol: {"AAA": 10.0, "BBB": 0.0}.get(
         symbol, 0.0
     )
+    # 目标仓位改读投影持仓（含在途单，见 #361）；此处无在途单，与结算仓一致。
+    ctx.get_projected_position.side_effect = lambda symbol: {
+        "AAA": 10.0,
+        "BBB": 0.0,
+    }.get(symbol, 0.0)
     ctx.risk_config = SimpleNamespace(account_mode="cash", enable_short_sell=False)
     strategy.ctx = ctx
 


### PR DESCRIPTION
- 修复#361核心bug：`buy()`/`sell()`自动开平拆分时未扣除同周期在途平仓单，导致反手订单被误标为平仓腿，修正保证金计算错误
- 修复目标仓位接口重复下单问题：改用投影持仓计算delta，避免同一bar内连续调用导致超卖
- 新增`get_closable_position`和`get_projected_position`两个持仓查询API，适配不同场景的持仓口径
- 完善全量文档、示例与测试用例，修复期货示例的预热周期和指标键错误
- 为成交/委托表格新增`position_effect`、ISO时间戳等列，方便查看开平语义和跨系统对账
- 更新包版本至v0.3.37，引擎规则版本升至1.3.7