### PR TITLE
docs: 补充指标单位说明并升级版本至0.3.56

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "akquant"
-version = "0.3.55"
+version = "0.3.56"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "akquant"
-version = "0.3.55"
+version = "0.3.56"
 edition = "2024"
 description = "High-performance quantitative trading framework based on Rust and Python"
 license = "MIT"

--- a/docs/en/guide/analysis.md
+++ b/docs/en/guide/analysis.md
@@ -60,6 +60,25 @@ The structured benchmark analysis shares the same alignment and calculation logi
 - `meta`: sample count and date range
 - `reason`: explanation when the benchmark input is invalid or cannot be aligned
 
+#### Summary Field Units
+
+All return-based metrics in `summary` are returned as **Ratio (decimal)**, matching the convention of `annualized_return` and `max_drawdown`. Frontend clients must multiply by 100 when displaying as percentages. Dimensionless ratio metrics should **not** be multiplied.
+
+| Field | Description | Unit/Type | Display Format |
+| :--- | :--- | :--- | :--- |
+| `total_excess` | Total excess return | Ratio (decimal) | `× 100` with `%` |
+| `annual_excess` | Annualized excess return | Ratio (decimal) | `× 100` with `%` |
+| `tracking_error` | Tracking error | Ratio (decimal) | `× 100` with `%` |
+| `alpha` | Alpha (annualized) | Ratio (decimal) | `× 100` with `%` |
+| `information_ratio` | Information ratio | Ratio (dimensionless) | Show as-is, no scaling |
+| `beta` | Beta | Ratio (dimensionless) | Show as-is, no scaling |
+
+Any field may be `None` when the benchmark cannot be aligned or variance is zero; check before rendering.
+
+Returns in `series` (`strategy_return`, `benchmark_return`, `excess_return`, and all `*_cum_return` fields) are also decimals.
+
+The built-in HTML report follows this convention: `total_excess` / `annual_excess` / `tracking_error` / `alpha` are formatted as percentages, while `information_ratio` / `beta` are displayed as 4-decimal floats. Use the information ratio as a sanity check — it always equals `annual_excess / tracking_error`. If your frontend's calculated ratio doesn't match the `information_ratio` field, one of the operands was scaled incorrectly.
+
 To persist the analysis:
 
 ```python
@@ -288,6 +307,79 @@ risk_trend_by_strategy = result.risk_rejections_trend_by_strategy(freq="D")
 # margin-account forced liquidation audit (when enabled)
 liquidation_audit = result.liquidation_audit_df
 ```
+
+### Attribution & Capacity Field Units
+
+All ratio and percentage fields in these structured outputs follow the same convention as `annualized_return` and `max_drawdown`, returning **Ratio (decimal)**. Frontend clients must multiply by 100 when displaying as percentages.
+
+**`exposure_df` Fields**
+
+| Field | Description | Unit/Type |
+| :--- | :--- | :--- |
+| `date` | Date | Datetime |
+| `equity` | Account equity | Float |
+| `long_exposure` | Long market value | Float |
+| `short_exposure` | Short market value | Float |
+| `net_exposure` | Net exposure | Float |
+| `gross_exposure` | Gross exposure | Float |
+| `net_exposure_pct` | Net exposure ratio | Ratio (decimal) |
+| `gross_exposure_pct` | Gross exposure ratio | Ratio (decimal) |
+| `leverage` | Leverage multiple | Ratio (decimal) |
+
+**`attribution_df` Fields**
+
+| Field | Description | Unit/Type |
+| :--- | :--- | :--- |
+| `group` | Group identifier (symbol / tag) | String |
+| `trade_count` | Number of trades | Int |
+| `total_pnl` | Total P&L | Float |
+| `avg_return_pct` | Average return | Ratio (decimal) |
+| `total_commission` | Total commission | Float |
+| `contribution_pct` | Contribution ratio | Ratio (decimal) |
+| `abs_contribution_pct` | Absolute contribution ratio | Ratio (decimal) |
+
+Note: Despite the `_pct` suffix, all three percentage fields in `attribution_df` return **decimals**, not percentages. Multiply by 100 for display.
+
+**`capacity_df` Fields**
+
+| Field | Description | Unit/Type |
+| :--- | :--- | :--- |
+| `date` | Date | Datetime |
+| `order_count` | Order count | Int |
+| `filled_order_count` | Filled order count | Int |
+| `ordered_quantity` | Total ordered quantity | Float |
+| `filled_quantity` | Total filled quantity | Float |
+| `ordered_value` | Total ordered value | Float |
+| `filled_value` | Total filled value | Float |
+| `fill_rate_qty` | Fill rate (quantity) | Ratio (decimal) |
+| `fill_rate_value` | Fill rate (value) | Ratio (decimal) |
+| `equity` | Account equity | Float |
+| `turnover` | Turnover rate | Ratio (decimal) |
+
+**`orders_by_strategy` Fields**
+
+| Field | Description | Unit/Type |
+| :--- | :--- | :--- |
+| `owner_strategy_id` | Strategy identifier | String |
+| `order_count` | Order count | Int |
+| `filled_order_count` | Filled order count | Int |
+| `ordered_quantity` | Total ordered quantity | Float |
+| `filled_quantity` | Total filled quantity | Float |
+| `ordered_value` | Total ordered value | Float |
+| `filled_value` | Total filled value | Float |
+| `fill_rate_qty` | Fill rate (quantity) | Ratio (decimal) |
+| `fill_rate_value` | Fill rate (value) | Ratio (decimal) |
+
+**`executions_by_strategy` Fields**
+
+| Field | Description | Unit/Type |
+| :--- | :--- | :--- |
+| `owner_strategy_id` | Strategy identifier | String |
+| `execution_count` | Execution count | Int |
+| `total_quantity` | Total executed quantity | Float |
+| `total_notional` | Total executed value | Float |
+| `total_commission` | Total commission | Float |
+| `avg_fill_price` | Average fill price | Float |
 
 When margin mode is enabled and forced liquidation occurs, `result.viz.report(...)` automatically includes:
 

--- a/docs/en/guide/visualization.md
+++ b/docs/en/guide/visualization.md
@@ -46,7 +46,7 @@ The payload includes:
 - `available`: whether benchmark analysis is available
 - `reason`: validation or alignment message when analysis is unavailable
 - `benchmark.label`: display label of the selected benchmark
-- `summary`: aggregate metrics such as `total_excess`, `annual_excess`, `tracking_error`, `information_ratio`, `beta`, and `alpha`
+- `summary`: aggregate metrics such as `total_excess`, `annual_excess`, `tracking_error`, `information_ratio`, `beta`, and `alpha` (return/error fields are decimals and must be multiplied by 100 for percentage display; ratio fields are dimensionless and should not be scaled — see [Backtest Results & Metrics](./analysis.md#summary-field-units))
 - `series`: aligned daily points with strategy, benchmark, excess, and cumulative series
 - `meta`: sample count, start/end date, and annualization settings
 

--- a/docs/en/reference/api.md
+++ b/docs/en/reference/api.md
@@ -1231,10 +1231,11 @@ benchmark_analysis = result.benchmark_analysis(
 # Common benchmark_analysis fields:
 # - schema_version, available, reason
 # - benchmark.label
-# - summary.total_excess / annual_excess / tracking_error
-# - summary.information_ratio / beta / alpha
-# - series[*].date / strategy_return / benchmark_return / excess_return
-# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return
+# - summary.total_excess / annual_excess / tracking_error (decimals, ×100 for %)
+# - summary.information_ratio / beta (dimensionless, no scaling)
+# - summary.alpha (decimal, ×100 for %)
+# - series[*].date / strategy_return / benchmark_return / excess_return (decimals)
+# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return (decimals)
 
 # Common columns
 # orders_by_strategy:

--- a/docs/zh/guide/analysis.md
+++ b/docs/zh/guide/analysis.md
@@ -222,6 +222,25 @@ print(series[:2])
 - `meta`: 样本数与日期范围
 - `reason`: 输入无效或无重叠区间时的说明
 
+#### summary 字段单位
+
+`summary` 中的收益类指标全部返回 **Ratio (小数)**，与 `annualized_return`、`max_drawdown` 的口径一致；前端展示为百分比时需自行乘 100。比率类指标本身无量纲，**不要**乘 100。
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 | 前端展示 |
+| :--- | :--- | :--- | :--- |
+| `total_excess` | 累计超额收益 | Ratio (小数) | `× 100` 并加 `%` |
+| `annual_excess` | 年化超额收益 | Ratio (小数) | `× 100` 并加 `%` |
+| `tracking_error` | 跟踪误差 | Ratio (小数) | `× 100` 并加 `%` |
+| `alpha` | 阿尔法系数 (已年化) | Ratio (小数) | `× 100` 并加 `%` |
+| `information_ratio` | 信息比率 | Ratio (无量纲) | 直接展示，不乘 100 |
+| `beta` | 贝塔系数 | Ratio (无量纲) | 直接展示，不乘 100 |
+
+任一字段在基准无法对齐或方差为 0 时取值为 `None`，展示前需判空。
+
+`series` 中的 `strategy_return`、`benchmark_return`、`excess_return` 及三条 `*_cum_return` 同样是小数。
+
+内置 HTML 报告即按此口径渲染：`total_excess` / `annual_excess` / `tracking_error` / `alpha` 走百分比格式化，`information_ratio` / `beta` 保留 4 位小数原样输出。可用信息比率做自校验——它恒等于 `annual_excess / tracking_error`，若前端算出的比值与 `information_ratio` 不符，说明某一项乘错了倍数。
+
 如果你需要把这份结果落盘：
 
 ```python
@@ -258,6 +277,79 @@ risk_trend_by_strategy = result.risk_rejections_trend_by_strategy(freq="D")
 # 5) 信用账户强平审计（融资融券回测时）
 liquidation_audit = result.liquidation_audit_df
 ```
+
+#### 组合归因与容量分析字段单位
+
+这些结构化输出的比率/百分比字段与 `annualized_return`、`max_drawdown` 口径一致，均返回 **Ratio (小数)**，前端展示为百分比时需 × 100。
+
+**`exposure_df` 字段**
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 |
+| :--- | :--- | :--- |
+| `date` | 日期 | Datetime |
+| `equity` | 账户权益 | Float |
+| `long_exposure` | 多头市值 | Float |
+| `short_exposure` | 空头市值 | Float |
+| `net_exposure` | 净暴露 | Float |
+| `gross_exposure` | 总暴露 | Float |
+| `net_exposure_pct` | 净暴露比例 | Ratio (小数) |
+| `gross_exposure_pct` | 总暴露比例 | Ratio (小数) |
+| `leverage` | 杠杆倍数 | Ratio (小数) |
+
+**`attribution_df` 字段**
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 |
+| :--- | :--- | :--- |
+| `group` | 分组标识 (symbol / tag) | String |
+| `trade_count` | 交易笔数 | Int |
+| `total_pnl` | 总盈亏 | Float |
+| `avg_return_pct` | 平均收益率 | Ratio (小数) |
+| `total_commission` | 总手续费 | Float |
+| `contribution_pct` | 贡献占比 | Ratio (小数) |
+| `abs_contribution_pct` | 绝对贡献占比 | Ratio (小数) |
+
+注意：`attribution_df` 的三个 `*_pct` 字段虽然命名带 `pct`，但返回的是**小数**而非百分数，展示时需 × 100。
+
+**`capacity_df` 字段**
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 |
+| :--- | :--- | :--- |
+| `date` | 日期 | Datetime |
+| `order_count` | 订单数 | Int |
+| `filled_order_count` | 成交订单数 | Int |
+| `ordered_quantity` | 委托总量 | Float |
+| `filled_quantity` | 成交总量 | Float |
+| `ordered_value` | 委托总额 | Float |
+| `filled_value` | 成交总额 | Float |
+| `fill_rate_qty` | 成交率 (数量) | Ratio (小数) |
+| `fill_rate_value` | 成交率 (金额) | Ratio (小数) |
+| `equity` | 账户权益 | Float |
+| `turnover` | 换手率 | Ratio (小数) |
+
+**`orders_by_strategy` 字段**
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 |
+| :--- | :--- | :--- |
+| `owner_strategy_id` | 策略标识 | String |
+| `order_count` | 订单数 | Int |
+| `filled_order_count` | 成交订单数 | Int |
+| `ordered_quantity` | 委托总量 | Float |
+| `filled_quantity` | 成交总量 | Float |
+| `ordered_value` | 委托总额 | Float |
+| `filled_value` | 成交总额 | Float |
+| `fill_rate_qty` | 成交率 (数量) | Ratio (小数) |
+| `fill_rate_value` | 成交率 (金额) | Ratio (小数) |
+
+**`executions_by_strategy` 字段**
+
+| 字段 (Field) | 含义 (Description) | 单位/类型 |
+| :--- | :--- | :--- |
+| `owner_strategy_id` | 策略标识 | String |
+| `execution_count` | 成交笔数 | Int |
+| `total_quantity` | 成交总量 | Float |
+| `total_notional` | 成交总额 | Float |
+| `total_commission` | 总手续费 | Float |
+| `avg_fill_price` | 平均成交价 | Float |
 
 当启用信用账户并触发强平后，`result.viz.report(...)` 的 HTML 报告会自动包含：
 

--- a/docs/zh/guide/visualization.md
+++ b/docs/zh/guide/visualization.md
@@ -46,7 +46,7 @@ print(payload["series"][0])
 - `available`: 当前 benchmark analysis 是否可用
 - `reason`: 当 benchmark 无法对齐或输入非法时的原因
 - `benchmark.label`: 基准显示名称
-- `summary`: 汇总指标，如 `total_excess`、`annual_excess`、`tracking_error`、`information_ratio`、`beta`、`alpha`
+- `summary`: 汇总指标，如 `total_excess`、`annual_excess`、`tracking_error`、`information_ratio`、`beta`、`alpha`（收益/误差类字段为小数，前端展示百分比需 ×100；比率类字段无量纲不乘，详见 [回测结果与指标详解](./analysis.md#summary-字段单位)）
 - `series`: 对齐后的逐日序列，包含策略收益、基准收益、超额收益及三条累计收益曲线
 - `meta`: 对齐样本数、起止日期、年化因子等元信息
 

--- a/docs/zh/reference/api.md
+++ b/docs/zh/reference/api.md
@@ -1347,10 +1347,11 @@ benchmark_analysis = result.benchmark_analysis(
 # benchmark_analysis 常用字段:
 # - schema_version, available, reason
 # - benchmark.label
-# - summary.total_excess / annual_excess / tracking_error
-# - summary.information_ratio / beta / alpha
-# - series[*].date / strategy_return / benchmark_return / excess_return
-# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return
+# - summary.total_excess / annual_excess / tracking_error (小数，需 ×100 展示为 %)
+# - summary.information_ratio / beta (无量纲，不乘)
+# - summary.alpha (小数，需 ×100 展示为 %)
+# - series[*].date / strategy_return / benchmark_return / excess_return (小数)
+# - series[*].strategy_cum_return / benchmark_cum_return / excess_cum_return (小数)
 
 # 常用字段示例
 # orders_by_strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "akquant"
-version = "0.3.55"
+version = "0.3.56"
 description = "High-performance quantitative trading framework based on Rust and Python"
 readme = "README.md"
 license = {text = "MIT License"}


### PR DESCRIPTION
本次提交更新了所有中英文官方文档，补充了基准分析、组合归因、持仓暴露、容量统计等模块的指标单位规则说明，明确收益类指标返回的是原始小数，前端展示百分比时需乘以100，而无量纲比率类指标无需缩放；同时将包版本从0.3.55更新至0.3.56。